### PR TITLE
Add enough to satisfy `vcse package`

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,65 +1,19 @@
 # ocaml-platform README
 
-This is the README for your extension "ocaml-platform". After writing up a brief description, we recommend including the following sections.
+The OCaml platform extension
 
 ## Features
 
-Describe specific features of your extension including screenshots of your extension in action. Image paths are relative to this README file.
-
-For example if there is an image subfolder under your extension project workspace:
-
-\!\[feature X\]\(images/feature-x.png\)
-
-> Tip: Many popular extensions utilize animations. This is an excellent way to show off your extension! We recommend short, focused animations that are easy to follow.
-
 ## Requirements
 
-If you have any requirements or dependencies, add a section describing those and how to install and configure them.
+OCaml
 
 ## Extension Settings
 
-Include if your extension adds any VS Code settings through the `contributes.configuration` extension point.
-
-For example:
-
-This extension contributes the following settings:
-
-* `myExtension.enable`: enable/disable this extension
-* `myExtension.thing`: set to `blah` to do something
-
 ## Known Issues
 
-Calling out known issues can help limit users opening duplicate issues against your extension.
 
 ## Release Notes
 
-Users appreciate release notes as you update your extension.
+### Unreleased
 
-### 1.0.0
-
-Initial release of ...
-
-### 1.0.1
-
-Fixed issue #.
-
-### 1.1.0
-
-Added features X, Y, and Z.
-
------------------------------------------------------------------------------------------------------------
-
-## Working with Markdown
-
-**Note:** You can author your README using Visual Studio Code.  Here are some useful editor keyboard shortcuts:
-
-* Split the editor (`Cmd+\` on macOS or `Ctrl+\` on Windows and Linux)
-* Toggle preview (`Shift+CMD+V` on macOS or `Shift+Ctrl+V` on Windows and Linux)
-* Press `Ctrl+Space` (Windows, Linux) or `Cmd+Space` (macOS) to see a list of Markdown snippets
-
-### For more information
-
-* [Visual Studio Code's Markdown Support](http://code.visualstudio.com/docs/languages/markdown)
-* [Markdown Syntax Reference](https://help.github.com/articles/markdown-basics/)
-
-**Enjoy!**

--- a/package.json
+++ b/package.json
@@ -14,7 +14,9 @@
     "categories": [
         "Programming Languages"
     ],
-    "activationEvents": ["onLanguage:ocaml"],
+    "activationEvents": [
+        "onLanguage:ocaml"
+    ],
     "main": "./out/client/extension",
     "contributes": {
         "configuration": {
@@ -133,5 +135,6 @@
     },
     "dependencies": {
         "vscode-languageclient": "^5.2.1"
-    }
+    },
+    "publisher": "ocamllabs"
 }


### PR DESCRIPTION
It needs a 'publisher' set in package.json and a non-default README

Signed-off-by: Jon Ludlam <jon@recoil.org>