### PR TITLE
Add initial snippet support to OCaml

### DIFF
--- a/package.json
+++ b/package.json
@@ -122,6 +122,10 @@
         "scopeName": "source.dune",
         "path": "./syntax/Dune.tmLanguage"
       }
+    ],
+    "snippets": [
+      "language": "ocaml",
+      "path": "./snippets/ocaml.json"
     ]
   },
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -124,8 +124,10 @@
       }
     ],
     "snippets": [
-      "language": "ocaml",
-      "path": "./snippets/ocaml.json"
+      {
+        "language": "ocaml",
+        "path": "./snippets/ocaml.json"
+      }
     ]
   },
   "scripts": {

--- a/snippets/ocaml.json
+++ b/snippets/ocaml.json
@@ -1,0 +1,58 @@
+{
+  "lambda": {
+    "prefix": "fun",
+    "body": ["(${1:pattern}) => ${2:${1:pattern}}"]
+  },
+  "lambda (switch)": {
+    "prefix": "fun",
+    "body": ["fun", "\t| ${1:pattern} => ${2:${1:pattern}}", "\t;"]
+  },
+  "let .. in": {
+    "prefix": "let",
+    "body": ["let ${1:pattern} = ${2:()} in$0"]
+  },
+  "function": {
+    "prefix": "func",
+    "body": ["function\n| $0"]
+  },
+  "variant pattern": {
+    "prefix": "|",
+    "body" ["| ${1:_} -> $0"]
+  },
+  "let": {
+    "prefix": "let",
+    "body": ["let ${1:pattern} = {", "\t$0", "};"]
+  },
+  "val": {
+    "prefix": "val",
+    "body": ["val ${1:name} : $0"]
+  },
+  "sig": {
+    "prefix": "sig",
+    "body": ["sig ${0} end"]
+  },
+  "module": {
+    "prefix": "module",
+    "body": ["module ${1:M} struct = ${2:{}}\nend$0"]
+  },
+  "module (block)": {
+    "prefix": "module",
+    "body": ["module ${1:M} = {", "\t$0", "};"]
+  },
+  "module function": {
+    "prefix": "module",
+    "body": ["module ${1:M} = (${2:X}: $3{:{}}) => ${4:${2:X}};$0"]
+  },
+  "match": {
+    "prefix": "match",
+    "body": ["match ${1:scrutinee} with", "| ${2:pattern} => ${3:${2:pattern}}", ""]
+  },
+  "type (alias or abstract)": {
+    "prefix": "type",
+    "body": ["type ${1:name} ${2:${3:'${4:arg} }= ${5:'${4:arg}}}$0"]
+  },
+  "type": {
+    "prefix": "type",
+    "body": ["type ${1:name} ${2:'${3:arg} }=", "\t| ${4:Con${2: '${3:arg}}}", "\t"]
+  }
+}

--- a/snippets/ocaml.json
+++ b/snippets/ocaml.json
@@ -1,11 +1,7 @@
 {
   "lambda": {
     "prefix": "fun",
-    "body": ["(${1:pattern}) => ${2:${1:pattern}}"]
-  },
-  "lambda (switch)": {
-    "prefix": "fun",
-    "body": ["fun", "\t| ${1:pattern} => ${2:${1:pattern}}", "\t;"]
+    "body": ["(${1:pattern}) -> ${2:${1:pattern}}"]
   },
   "let .. in": {
     "prefix": "let",
@@ -19,9 +15,9 @@
     "prefix": "|",
     "body": ["| ${1:_} -> $0"]
   },
-  "let": {
+  "let (toplevel)": {
     "prefix": "let",
-    "body": ["let ${1:pattern} = {", "\t$0", "};"]
+    "body": ["let ${1:pattern} = $0"]
   },
   "val": {
     "prefix": "val",
@@ -29,38 +25,29 @@
   },
   "sig": {
     "prefix": "sig",
-    "body": ["sig ${0} end"]
+    "body": ["sig\n${1}\nend$0"]
   },
   "module": {
     "prefix": "module",
-    "body": ["module ${1:M} struct = ${2:{}}\nend$0"]
+    "body": ["module ${1:M} struct = ${2}\nend$0"]
   },
-  "module (block)": {
+  "module signature": {
     "prefix": "module",
-    "body": ["module ${1:M} = {", "\t$0", "};"]
+    "body": ["module ${1:M} : sig\n${2}\nend$0"]
   },
-  "module function": {
+  "module type": {
     "prefix": "module",
-    "body": ["module ${1:M} = (${2:X}: $3{:{}}) => ${4:${2:X}};$0"]
+    "body": ["module type ${1:M} = sig", "${2}", "end\n$0"]
   },
   "match": {
     "prefix": "match",
     "body": [
       "match ${1:scrutinee} with",
-      "| ${2:pattern} => ${3:${2:pattern}}",
-      ""
+      "| ${2:pattern} -> ${3:${2:pattern}}"
     ]
   },
-  "type (alias or abstract)": {
+  "type declaration": {
     "prefix": "type",
-    "body": ["type ${1:name} ${2:${3:'${4:arg} }= ${5:'${4:arg}}}$0"]
-  },
-  "type": {
-    "prefix": "type",
-    "body": [
-      "type ${1:name} ${2:'${3:arg} }=",
-      "\t| ${4:Con${2: '${3:arg}}}",
-      "\t"
-    ]
+    "body": ["type ${1:name} = $0"]
   }
 }

--- a/snippets/ocaml.json
+++ b/snippets/ocaml.json
@@ -17,7 +17,7 @@
   },
   "variant pattern": {
     "prefix": "|",
-    "body" ["| ${1:_} -> $0"]
+    "body": ["| ${1:_} -> $0"]
   },
   "let": {
     "prefix": "let",
@@ -45,7 +45,11 @@
   },
   "match": {
     "prefix": "match",
-    "body": ["match ${1:scrutinee} with", "| ${2:pattern} => ${3:${2:pattern}}", ""]
+    "body": [
+      "match ${1:scrutinee} with",
+      "| ${2:pattern} => ${3:${2:pattern}}",
+      ""
+    ]
   },
   "type (alias or abstract)": {
     "prefix": "type",
@@ -53,6 +57,10 @@
   },
   "type": {
     "prefix": "type",
-    "body": ["type ${1:name} ${2:'${3:arg} }=", "\t| ${4:Con${2: '${3:arg}}}", "\t"]
+    "body": [
+      "type ${1:name} ${2:'${3:arg} }=",
+      "\t| ${4:Con${2: '${3:arg}}}",
+      "\t"
+    ]
   }
 }


### PR DESCRIPTION
@imbsky feel free to push here

### ocaml

- [ ] class
- [ ] class type
- [ ] module struct
- [ ] module type
- [x] `| $1 -> $0`
- [ ] `fun $1 -> $0`
- [ ] `let $1 = $0`
- [ ] `let $1 = $2 in$0`
- [ ] `let rec $1 = $2 in$0`
- [ ] `let* $1 = $0 in`
- [ ] module signature
- [ ] `val $1 : $0`
- [ ] `struct $1 end`
- [ ] `sig $1 end`
- [ ] `match $1 with | $2 -> $0`
- [ ] `module $1 : sig $0 end$0`
- [ ] `object`
- [ ] `method $1 = $0`
- [ ] `exception of $1`

### dune

- [ ] executable
- [ ] executables
- [ ] library
- [ ] ocamllex
- [ ] test
- [ ] tests
- [ ] rule
- [ ] alias
- [ ] env
- [ ] toplevel
- [ ] include_subdirs
- [ ] documentation
- [ ] install
- [ ] ocamlyacc
- [ ] foreign_library