### PR TITLE
Add dependabot config

### DIFF
--- a/.dependabot/config.yml
+++ b/.dependabot/config.yml
@@ -1,0 +1,5 @@
+version: 1
+update_configs:
+  - package_manager: "javascript"
+    directory: "/"
+    update_schedule: "live"


### PR DESCRIPTION
Automate dependency updates using [Dependabot](https://dependabot.com), recently acquired by GitHub. This frees us from the hassle and speeds up our response to the frequent security issues of the npm package.