### PR TITLE
Tweak OCaml syntax highlighting and snippets

### DIFF
--- a/snippets/ocaml.json
+++ b/snippets/ocaml.json
@@ -1,7 +1,7 @@
 {
   "lambda": {
     "prefix": "fun",
-    "body": ["(${1:pattern}) -> ${2:${1:pattern}}"]
+    "body": ["fun (${1:pattern}) -> ${2:${1:pattern}}"]
   },
   "let .. in": {
     "prefix": "let",

--- a/syntaxes/ocaml.json
+++ b/syntaxes/ocaml.json
@@ -103,7 +103,7 @@
             {
               "comment": "unicode character escape sequence",
               "name": "constant.character.escape.ocaml",
-              "match": "\\\\u\\{[0-9A-Fa-f]+\\}"
+              "match": "\\\\u\\{[0-9A-Fa-f]{1,6}\\}"
             },
             {
               "comment": "printf format string",
@@ -349,11 +349,6 @@
           "match": "\\b(and|as|assert|begin|class|constraint|do|done|downto|else|end|exception|external|for|fun|function|functor|if|in|include|inherit|initializer|lazy|let|match|method|module|mutable|new|nonrec|object|of|open|private|rec|sig|struct|then|to|try|type|val|virtual|when|while|with)\\b"
         },
         {
-          "comment": "wildcard underscore",
-          "name": "keyword.other.ocaml",
-          "match": "\\b_\\b"
-        },
-        {
           "comment": "brackets for array literals",
           "name": "source.ocaml",
           "match": "\\[\\||\\|\\]"
@@ -414,9 +409,21 @@
     "literals": {
       "patterns": [
         {
+          "comment": "wildcard underscore",
+          "name": "constant.language.ocaml",
+          "match": "\\b_\\b"
+        },
+
+        {
           "comment": "unit literal",
           "name": "constant.language.ocaml strong",
           "match": "\\(\\)"
+        },
+
+        {
+          "comment": "empty list",
+          "name": "constant.language.ocaml strong",
+          "match": "\\[\\]"
         },
 
         {


### PR DESCRIPTION
I looked over the OCaml grammar and snippets, improving a few things:
- the lambda snippet includes the `fun` keyword
- unicode escape sequence has between 1 and 6 digits
- an underscore is considered a constant pattern instead of a keyword
- the empty list constructor is highlighted