### PR TITLE
Rewrite OCamllex grammar

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Change Log
 
+## Unrealeased
+
+- Improve ocamllex syntax highlighting
+
 ## 0.4.0
 
 - Add syntax highlighting and basic language support for ocamlyacc/menhir

--- a/languages/ocamllex.json
+++ b/languages/ocamllex.json
@@ -1,6 +1,6 @@
 {
   "comments": {
-    "blockComment": ["/*", "*/"]
+    "blockComment": ["(*", "*)"]
   },
   "brackets": [
     ["{", "}"],

--- a/syntaxes/menhir.json
+++ b/syntaxes/menhir.json
@@ -3,12 +3,12 @@
   "scopeName": "source.ocaml.menhir",
   "fileTypes": ["mly"],
   "patterns": [
-    { "include": "#comment" },
+    { "include": "#comments" },
     {
       "comment": "sequence of declarations",
       "begin": "(?=%[^%])",
       "end": "(?=%%)",
-      "patterns": [{ "include": "#comment" }, { "include": "#declaration" }]
+      "patterns": [{ "include": "#comments" }, { "include": "#declarations" }]
     },
     {
       "comment": "sequence of rules",
@@ -16,12 +16,12 @@
       "beginCaptures": [{ "name": "keyword.other.menhir" }],
       "end": "%%",
       "endCaptures": [{ "name": "keyword.other.menhir" }],
-      "patterns": [{ "include": "#comment" }, { "include": "#rule" }]
+      "patterns": [{ "include": "#comments" }, { "include": "#rules" }]
     },
     { "include": "source.ocaml" }
   ],
   "repository": {
-    "declaration": {
+    "declarations": {
       "patterns": [
         {
           "comment": "ocaml header",
@@ -44,10 +44,11 @@
           "endCaptures": [{ "name": "keyword.other.menhir" }],
           "patterns": [{ "include": "source.ocaml" }]
         },
-        { "include": "#strings" }
+        { "include": "source.ocaml#strings" }
       ]
     },
-    "rule": {
+
+    "rules": {
       "patterns": [
         {
           "comment": "rule name with optional parameter list",
@@ -79,11 +80,11 @@
           "beginCaptures": [{ "name": "keyword.other.menhir" }],
           "end": "(?={)",
           "patterns": [
-            { "include": "#comment" },
-            { "include": "#variable" },
-            { "include": "#reference" },
-            { "include": "#operator" },
-            { "include": "#strings" }
+            { "include": "#comments" },
+            { "include": "#variables" },
+            { "include": "#references" },
+            { "include": "#operators" },
+            { "include": "source.ocaml#strings" }
           ]
         },
         {
@@ -96,7 +97,8 @@
         }
       ]
     },
-    "comment": {
+
+    "comments": {
       "patterns": [
         {
           "comment": "c-style block comment",
@@ -118,13 +120,15 @@
         }
       ]
     },
-    "variable": {
+
+    "variables": {
       "comment": "labeled semantic value identifier",
       "match": "([a-z][a-zA-Z0-9_]*)\\s*=",
       "captures": { "1": { "name": "variable.parameter.value.menhir" } },
-      "patterns": [{ "include": "#reference" }]
+      "patterns": [{ "include": "#references" }]
     },
-    "reference": {
+
+    "references": {
       "patterns": [
         {
           "comment": "builtin standard library functions",
@@ -143,57 +147,11 @@
         }
       ]
     },
-    "operator": {
+
+    "operators": {
       "comment": "rule modifier (?, +, *, or |)",
       "match": "[?+*|]",
       "name": "keyword.operator.menhir"
-    },
-    "strings": {
-      "patterns": [
-        {
-          "comment": "strings used as aliases for tokens",
-          "name": "string.quoted.double.ocaml",
-          "begin": "\"",
-          "end": "\"",
-          "patterns": [
-            {
-              "comment": "escaped backslash",
-              "name": "constant.character.escape.ocaml",
-              "match": "\\\\\\\\"
-            },
-            {
-              "comment": "escaped quote or whitespace",
-              "name": "constant.character.escape.ocaml",
-              "match": "\\\\[\"'ntbr ]"
-            },
-            {
-              "comment": "character from decimal ASCII code",
-              "name": "constant.character.escape.ocaml",
-              "match": "\\\\[0-9]{3}"
-            },
-            {
-              "comment": "character from hexadecimal ASCII code",
-              "name": "constant.character.escape.ocaml",
-              "match": "\\\\x[0-9A-Fa-f]{2}"
-            },
-            {
-              "comment": "character from octal ASCII code",
-              "name": "constant.character.escape.ocaml",
-              "match": "\\\\o[0-3][0-7]{2}"
-            },
-            {
-              "comment": "unicode character escape sequence",
-              "name": "constant.character.escape.ocaml",
-              "match": "\\\\u\\{[0-9A-Fa-f]+\\}"
-            },
-            {
-              "comment": "unknown escape sequence",
-              "name": "invalid.illegal.unknown-escape.ocaml",
-              "match": "\\\\."
-            }
-          ]
-        }
-      ]
     }
   }
 }

--- a/syntaxes/ocaml.json
+++ b/syntaxes/ocaml.json
@@ -129,42 +129,42 @@
       "patterns": [
         {
           "comment": "character literal",
-          "name": "string.quoted.single.ocaml",
+          "name": "constant.character.ocaml",
           "match": "'.'"
         },
         {
           "comment": "character literal from escaped backslash",
-          "name": "string.quoted.single.ocaml",
+          "name": "constant.character.ocaml",
           "match": "'(\\\\\\\\)'",
           "captures": { "1": { "name": "constant.character.escape.ocaml" } }
         },
         {
           "comment": "character literal from escaped quote or whitespace",
-          "name": "string.quoted.single.ocaml",
+          "name": "constant.character.ocaml",
           "match": "'(\\\\[\"'ntbr ])'",
           "captures": { "1": { "name": "constant.character.escape.ocaml" } }
         },
         {
           "comment": "character literal from decimal ASCII code",
-          "name": "string.quoted.single.ocaml",
+          "name": "constant.character.ocaml",
           "match": "'(\\\\[0-9]{3})'",
           "captures": { "1": { "name": "constant.character.escape.ocaml" } }
         },
         {
           "comment": "character literal from hexadecimal ASCII code",
-          "name": "string.quoted.single.ocaml",
+          "name": "constant.character.ocaml",
           "match": "'(\\\\x[0-9A-Fa-f]{2})'",
           "captures": { "1": { "name": "constant.character.escape.ocaml" } }
         },
         {
           "comment": "character literal from octal ASCII code",
-          "name": "string.quoted.single.ocaml",
+          "name": "constant.character.ocaml",
           "match": "'(\\\\o[0-3][0-7]{2})'",
           "captures": { "1": { "name": "constant.character.escape.ocaml" } }
         },
         {
           "comment": "character literal from unknown escape sequence",
-          "name": "string.quoted.single.ocaml",
+          "name": "constant.character.ocaml",
           "match": "'(\\\\.)'",
           "captures": {
             "1": { "name": "invalid.illegal.unknown-escape.ocaml" }

--- a/syntaxes/ocamllex.json
+++ b/syntaxes/ocamllex.json
@@ -7,294 +7,100 @@
   "keyEquivalent": "^~O",
   "patterns": [
     {
-      "begin": "(rule|and)\\s+([a-z][a-zA-Z0-9_]*)\\s+(=)\\s+(parse)(?=\\s*$)|((?<!\\|)(\\|)(?!\\|))",
-      "beginCaptures": {
-        "1": {
-          "name": "keyword.other.ocamllex"
-        },
-        "2": {
-          "name": "entity.name.function.entrypoint.ocamllex"
-        },
-        "3": {
-          "name": "keyword.operator.ocamllex"
-        },
-        "4": {
-          "name": "keyword.other.ocamllex"
-        },
-        "5": {
-          "name": "punctuation.separator.match-pattern.ocamllex"
-        }
-      },
-      "end": "(?:^\\s*((and)\\b|(?=\\|)|$))",
-      "endCaptures": {
-        "3": {
-          "name": "keyword.other.entry-definition.ocamllex"
-        }
-      },
-      "name": "meta.pattern-match.ocaml",
-      "patterns": [
-        {
-          "include": "#actions"
-        },
-        {
-          "include": "#match-patterns"
-        }
-      ]
+      "include": "source.ocaml#comments"
     },
     {
-      "begin": "\\(",
-      "end": "\\)",
-      "name": "meta.paren-group.ocamllex",
-      "patterns": [
-        {
-          "include": "$self"
-        }
-      ]
+      "include": "source.ocaml#strings"
     },
     {
-      "begin": "\\b(let)\\s+([a-z][a-zA-Z0-9'_]*)\\s+=",
-      "beginCaptures": {
-        "1": {
-          "name": "keyword.other.pattern-definition.ocamllex"
-        },
-        "2": {
-          "name": "entity.name.type.pattern.stupid-goddamn-hack.ocamllex"
-        }
-      },
-      "end": "^(?:\\s*let)|(?:\\s*(rule|$))",
-      "name": "meta.pattern-definition.ocaml",
-      "patterns": [
-        {
-          "include": "#match-patterns"
-        }
-      ]
+      "include": "source.ocaml#characters"
+    },
+
+    {
+      "include": "#rules"
     },
     {
-      "begin": "^\\s*({)",
-      "beginCaptures": {
-        "1": {
-          "name": "punctuation.section.embedded.ocaml.begin.ocamllex"
-        }
-      },
-      "end": "^\\s*(})",
-      "endCaptures": {
-        "1": {
-          "name": "punctuation.section.embedded.ocaml.end.ocamllex"
-        }
-      },
-      "name": "meta.embedded.ocaml",
-      "patterns": [
-        {
-          "include": "source.ocaml"
-        }
-      ]
+      "include": "#keywords"
     },
     {
-      "include": "#comments"
+      "include": "#actions"
     },
     {
-      "include": "#strings"
+      "include": "#regex"
     },
+
     {
       "match": "(’|‘|“|”)",
       "name": "invalid.illegal.unrecognized-character.ocamllex"
-    },
-    {
-      "match": "=",
-      "name": "keyword.operator.symbol.ocamllex"
     }
   ],
   "repository": {
+    "rules": {
+      "match": "\\b(rule|and)\\s+([a-z][a-zA-Z0-9_]*)\\b",
+      "captures": {
+        "1": {
+          "name": "keyword.other.ocamllex"
+        },
+        "2": {
+          "name": "entity.name.function.rule.ocamllex"
+        }
+      }
+    },
+
+    "keywords": {
+      "patterns": [
+        {
+          "comment": "ocamllex reserved keywords",
+          "name": "keyword.other.ocamllex",
+          "match": "\\b(let|as|rule|and|parse|shortest|refill)\\b"
+        },
+        {
+          "comment": "assignment operator",
+          "match": "=",
+          "name": "keyword.operator.symbol.ocamllex"
+        }
+      ]
+    },
+
     "actions": {
       "patterns": [
         {
-          "begin": "[^\\']({)",
-          "beginCaptures": {
-            "1": {
-              "name": "punctuation.definition.action.begin.ocamllex"
-            }
-          },
-          "end": "(})",
-          "endCaptures": {
-            "1": {
-              "name": "punctuation.definition.action.end.ocamllex"
-            }
-          },
-          "name": "meta.action.ocamllex",
-          "patterns": [
-            {
-              "include": "source.ocaml"
-            }
-          ]
+          "comment": "embedded ocaml source",
+          "begin": "{",
+          "beginCaptures": [{ "name": "keyword.other.ocamllex" }],
+          "end": "}",
+          "endCaptures": [{ "name": "keyword.other.ocamllex" }],
+          "patterns": [{ "include": "source.ocaml" }]
         }
       ]
     },
-    "chars": {
+
+    "regex": {
       "patterns": [
         {
-          "captures": {
-            "1": {
-              "name": "punctuation.definition.char.begin.ocamllex"
-            },
-            "4": {
-              "name": "punctuation.definition.char.end.ocamllex"
-            }
-          },
-          "match": "(')([^\\\\]|\\\\(x[a-fA-F0-9][a-fA-F0-9]|[0-2]\\d\\d|[bnrt'\"\\\\]))(')",
-          "name": "constant.character.ocamllex"
-        }
-      ]
-    },
-    "comments": {
-      "patterns": [
-        {
-          "begin": "(?=[^\\\\])(\")",
-          "end": "\"",
-          "name": "comment.block.string.quoted.double.ocaml",
-          "patterns": [
-            {
-              "match": "\\\\(x[a-fA-F0-9][a-fA-F0-9]|[0-2]\\d\\d|[bnrt'\"\\\\])",
-              "name": "comment.block.string.constant.character.escape.ocaml"
-            }
-          ]
+          "comment": "regex character set",
+          "name": "punctuation.character-set.ocamllex",
+          "match": "\\[|\\]"
         },
         {
-          "begin": "\\(\\*",
-          "beginCaptures": {
-            "0": {
-              "name": "punctuation.definition.comment.begin.ocaml"
-            }
-          },
-          "end": "\\*\\)",
-          "endCaptures": {
-            "0": {
-              "name": "punctuation.definition.comment.end.ocaml"
-            }
-          },
-          "name": "comment.block.ocaml",
-          "patterns": [
-            {
-              "include": "#comments"
-            }
-          ]
-        }
-      ]
-    },
-    "match-patterns": {
-      "patterns": [
-        {
-          "begin": "(\\()",
-          "beginCaptures": {
-            "1": {
-              "name": "punctuation.definition.sub-pattern.begin.ocamllex"
-            }
-          },
-          "end": "(\\))",
-          "endCaptures": {
-            "1": {
-              "name": "punctuation.definition.sub-pattern.end.ocamllex"
-            }
-          },
-          "name": "meta.pattern.sub-pattern.ocamllex",
-          "patterns": [
-            {
-              "include": "#match-patterns"
-            }
-          ]
+          "comment": "regex group",
+          "name": "punctuation.group.ocamllex",
+          "match": "\\(|\\)"
         },
         {
-          "begin": "(\\[)(\\^?)",
-          "beginCaptures": {
-            "1": {
-              "name": "punctuation.definition.character-class.begin.ocamllex"
-            },
-            "2": {
-              "name": "punctuation.definition.character-class.negation.ocamllex"
-            }
-          },
-          "end": "(])(?!\\')",
-          "endCaptures": {
-            "1": {
-              "name": "punctuation.definition.character-class.end.ocamllex"
-            }
-          },
-          "name": "meta.pattern.character-class.ocamllex",
-          "patterns": [
-            {
-              "include": "#chars"
-            },
-            {
-              "match": "-",
-              "name": "punctuation.separator.character-class.range.ocamllex"
-            }
-          ]
+          "comment": "regex operators",
+          "name": "keyword.operator.ocamllex",
+          "match": "\\^|#|\\*|\\+|\\?|\\|"
         },
         {
-          "include": "#chars"
+          "comment": "end-of-file token",
+          "name": "constant.language.eof.ocamllex",
+          "match": "\\beof\\b"
         },
         {
-          "include": "#strings"
-        },
-        {
-          "match": "[a-z][a-zA-Z0-9'_]",
-          "name": "entity.name.type.pattern.reference.stupid-goddamn-hack.ocamllex"
-        },
-        {
-          "match": "\\*|\\+|\\?",
-          "name": "keyword.operator.pattern.modifier.ocamllex"
-        },
-        {
-          "match": "\\bas\\b",
-          "name": "keyword.other.pattern.ocamllex"
-        },
-        {
-          "match": "\\|",
-          "name": "keyword.operator.pattern.alternation.ocamllex"
-        },
-        {
-          "match": "_",
-          "name": "constant.language.universal-match.ocamllex"
-        },
-        {
-          "match": "eof",
-          "name": "constant.language.eof.ocamllex"
-        }
-      ]
-    },
-    "strings": {
-      "patterns": [
-        {
-          "begin": "(?=[^\\\\])(\")",
-          "beginCaptures": {
-            "1": {
-              "name": "punctuation.definition.string.begin.ocaml"
-            }
-          },
-          "end": "(\")",
-          "endCaptures": {
-            "1": {
-              "name": "punctuation.definition.string.end.ocaml"
-            }
-          },
-          "name": "string.quoted.double.ocamllex",
-          "patterns": [
-            {
-              "match": "\\\\$[ \\t]*",
-              "name": "punctuation.separator.string.ignore-eol.ocaml"
-            },
-            {
-              "match": "\\\\(?!(x[a-fA-F0-9][a-fA-F0-9]|[0-2]\\d\\d|[bnrt'\"\\\\]|[\\|\\(\\)1-9$^.*+?\\[\\]]|$[ \\t]*))(?:.)",
-              "name": "invalid.illegal.character.string.escape"
-            },
-            {
-              "match": "\\\\(x[a-fA-F0-9][a-fA-F0-9]|[0-2]\\d\\d|[bnrt'\"\\\\])",
-              "name": "constant.character.string.escape.ocaml"
-            },
-            {
-              "match": "\\\\[\\|\\(\\)1-9$^.*+?\\[\\]]",
-              "name": "constant.character.regexp.escape.ocaml"
-            }
-          ]
+          "comment": "reference to regex pattern",
+          "name": "entity.name.type.reference.ocamllex",
+          "match": "[a-z][a-zA-Z0-9'_]*"
         }
       ]
     }

--- a/syntaxes/ocamllex.json
+++ b/syntaxes/ocamllex.json
@@ -90,7 +90,7 @@
         {
           "comment": "regex operators",
           "name": "keyword.operator.ocamllex",
-          "match": "\\^|#|\\*|\\+|\\?|\\|"
+          "match": "\\^|#|\\*|\\+|\\?|\\||-"
         },
         {
           "comment": "end-of-file token",


### PR DESCRIPTION
This PR fixes some bugs with the ocamllex configuration and grammar. Also, since the OCaml grammar already defines patterns for strings and characters, I made it so the ocamllex and menhir grammars just reference the existing patterns (`source.ocaml#strings` & `source.ocaml#characters`).

- Adds keyword highlighting for `shortest`, `refill`, `as`
- OCaml block comments are used instead of C-style block comments
- Comments are correctly highlighted (dimmed for my theme)
- Curly brackets in string literals don't escape the string and break highlighting
- In the OCaml grammar, character literals are now `constant.character` instead of `string.quoted`

Comparison:
| Old | New |
| - | - |
| ![old](https://user-images.githubusercontent.com/25037249/78325498-978f8e80-752c-11ea-9090-3deb1bed7a89.png) | ![new](https://user-images.githubusercontent.com/25037249/78325732-5a77cc00-752d-11ea-8d46-2ed3c85fb469.png) |

