### PR TITLE
Improve ocaml and ocamllex/ocamlyacc syntax

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - Improve ocamllex syntax highlighting
 - Improve opam syntax highlighting
+- Fix bugs in ocaml and ocamllex syntax highlighting
 
 ## 0.4.0
 

--- a/syntaxes/ocaml.json
+++ b/syntaxes/ocaml.json
@@ -19,6 +19,9 @@
       "include": "#keywords"
     },
     {
+      "include": "#groupings"
+    },
+    {
       "include": "#operators"
     },
     {
@@ -347,16 +350,62 @@
           "comment": "reserved ocaml keyword",
           "name": "keyword.ocaml",
           "match": "\\b(and|as|assert|begin|class|constraint|do|done|downto|else|end|exception|external|for|fun|function|functor|if|in|include|inherit|initializer|lazy|let|match|method|module|mutable|new|nonrec|object|of|open|private|rec|sig|struct|then|to|try|type|val|virtual|when|while|with)\\b"
-        },
+        }
+      ]
+    },
+
+    "groupings": {
+      "patterns": [
         {
-          "comment": "brackets for array literals",
-          "name": "source.ocaml",
-          "match": "\\[\\||\\|\\]"
+          "comment": "unit literal",
+          "name": "constant.language.ocaml strong",
+          "match": "\\(\\)"
         },
+
+        {
+          "comment": "empty list",
+          "name": "constant.language.ocaml strong",
+          "match": "\\[\\]"
+        },
+
+        {
+          "comment": "empty array",
+          "name": "constant.language.ocaml strong",
+          "match": "\\[\\|\\|\\]"
+        },
+
+        {
+          "comment": "array literal",
+          "begin": "\\[\\|",
+          "beginCaptures": [{ "name": "keyword.other.ocaml" }],
+          "end": "\\|\\]",
+          "endCaptures": [{ "name": "keyword.other.ocaml" }],
+          "patterns": [{ "include": "$self" }]
+        },
+
+        {
+          "comment": "list literal",
+          "begin": "\\[",
+          "beginCaptures": [{ "name": "keyword.other.ocaml" }],
+          "end": "\\]",
+          "endCaptures": [{ "name": "keyword.other.ocaml" }],
+          "patterns": [{ "include": "$self" }]
+        },
+
         {
           "comment": "object duplication",
-          "name": "source.ocaml",
-          "match": "\\{<|>\\}"
+          "begin": "{<",
+          "beginCaptures": [{ "name": "keyword.other.ocaml" }],
+          "end": ">}",
+          "endCaptures": [{ "name": "keyword.other.ocaml" }],
+          "patterns": [{ "include": "$self" }]
+        },
+
+        {
+          "comment": "record literal",
+          "begin": "{",
+          "end": "}",
+          "patterns": [{ "include": "$self" }]
         }
       ]
     },
@@ -402,6 +451,16 @@
           "comment": "type annotation",
           "name": "keyword.other.ocaml",
           "match": ":"
+        },
+        {
+          "comment": "field accessor",
+          "name": "keyword.other.ocaml",
+          "match": "\\."
+        },
+        {
+          "comment": "semicolon or comma separator",
+          "name": "keyword.other.ocaml",
+          "match": "[,;]"
         }
       ]
     },
@@ -412,18 +471,6 @@
           "comment": "wildcard underscore",
           "name": "constant.language.ocaml",
           "match": "\\b_\\b"
-        },
-
-        {
-          "comment": "unit literal",
-          "name": "constant.language.ocaml strong",
-          "match": "\\(\\)"
-        },
-
-        {
-          "comment": "empty list",
-          "name": "constant.language.ocaml strong",
-          "match": "\\[\\]"
         },
 
         {

--- a/syntaxes/ocamllex.json
+++ b/syntaxes/ocamllex.json
@@ -36,7 +36,7 @@
   ],
   "repository": {
     "rules": {
-      "match": "\\b(rule|and)\\s+([a-z][a-zA-Z0-9_]*)\\b",
+      "match": "\\b(rule|and)\\s+([a-z][a-zA-Z0-9_']*('|\\b))",
       "captures": {
         "1": {
           "name": "keyword.other.ocamllex"
@@ -100,7 +100,7 @@
         {
           "comment": "reference to regex pattern",
           "name": "entity.name.type.reference.ocamllex",
-          "match": "[a-z][a-zA-Z0-9'_]*"
+          "match": "\\b[a-zA-Z][a-zA-Z0-9'_]*('|\\b)"
         }
       ]
     }


### PR DESCRIPTION
Fix bugs that arose from interactions between the OCaml and ocamllex/ocamlyacc syntaxes:

| Old | New |
| - | - |
| ![mly_old](https://user-images.githubusercontent.com/25037249/78420419-d17f9400-7603-11ea-9f79-c1a73e971101.png) | ![mly_new](https://user-images.githubusercontent.com/25037249/78420421-d5131b00-7603-11ea-8e6a-a917f49eadef.png) |
| ![mll_old](https://user-images.githubusercontent.com/25037249/78420413-c4fb3b80-7603-11ea-9784-54c5bc83bfe7.png) | ![mll_new](https://user-images.githubusercontent.com/25037249/78420415-ca588600-7603-11ea-8889-0fa3504ce70e.png) | 

Add highlighting for aggregate literals and `.`/`,`/`;` symbols in OCaml sources:

| Old | New |
| - | - |
| ![ml_old](https://user-images.githubusercontent.com/25037249/78420434-068be680-7604-11ea-8b5e-1eb116d90008.png) | ![ml_new](https://user-images.githubusercontent.com/25037249/78420444-160b2f80-7604-11ea-929f-99ce07aff22e.png) |
