### PR TITLE
Add mli to Node bindings

### DIFF
--- a/src/bindings/Node.ml
+++ b/src/bindings/Node.ml
@@ -47,24 +47,11 @@ module Buffer = struct
   let ofString = from
 end
 
-module type STREAM = sig
+module Stream = struct
   type t
-
-  val on : t -> string -> (Buffer.t -> unit) -> unit
-end
-
-module StreamFunctor (S : sig
-  type t
-end) =
-struct
-  type t = S.t
 
   external on : t -> string -> (Buffer.t -> unit) -> unit = "on" [@@bs.send]
 end
-
-module Stream = StreamFunctor (struct
-  type t
-end)
 
 module Fs = struct
   module E = struct
@@ -167,7 +154,6 @@ module Fs = struct
     else
       mkdir' path |> then_ (fun () -> resolve (Ok ()))
 end
-
 module ChildProcess = struct
   type t = < exitCode : int > Js.t
 

--- a/src/bindings/Node.mli
+++ b/src/bindings/Node.mli
@@ -1,0 +1,109 @@
+module Process : sig
+  type t
+
+  val platform : string
+
+  val env : string Js.Dict.t
+end
+
+module JsError : sig
+  type t
+
+  val ofPromiseError : _ -> t
+end
+
+module ChildProcess : sig
+  module Options : sig
+    type t
+
+    val make : ?cwd:string -> ?env:string Js.Dict.t -> unit -> t
+  end
+
+  type t
+
+  val exec :
+    string -> Options.t -> (int * string * string, string) result Promise.t
+end
+
+module Path : sig
+  val extname : string -> string
+
+  val join : string array -> string
+end
+
+module Stream : sig
+  type t
+end
+
+module Fs : sig
+  module Stat : sig
+    type t
+
+    val isDirectory : t -> bool
+  end
+
+  val exists : string -> bool Promise.t
+
+  val stat : string -> (Stat.t, string) result Promise.t
+
+  val readFile : string -> string Promise.t
+
+  val writeFile : string -> string -> unit Promise.t
+
+  val readDir : string -> (string array, string) result Promise.t
+
+  val createWriteStream : string -> Stream.t
+
+  module E : sig
+    type t = PathNotFound
+  end
+
+  val mkdir : ?p:bool -> string -> (unit, E.t) result Promise.t
+end
+
+module Buffer : sig
+  type t
+end
+
+module Request : sig
+  val request : string -> Stream.t
+end
+
+module RequestProgress : sig
+  type t
+
+  val requestProgress : Stream.t -> t
+
+  type state =
+    < percent : float
+    ; speed : int
+    ; size : < total : int ; transferred : int > Js.t
+    ; time : < elapsed : float ; remaining : float > Js.t >
+    Js.t
+
+  val pipe : t -> Stream.t -> unit
+
+  val onError : t -> (JsError.t -> unit) -> unit
+
+  val onData : t -> (Buffer.t -> unit) -> unit
+
+  val onEnd : t -> (unit -> unit) -> unit
+
+  val onProgress : t -> (state -> unit) -> unit
+end
+
+module Response : sig end
+
+module Https : sig
+  module E : sig
+    type t = Failure of string
+  end
+
+  val getCompleteResponse : string -> (string, E.t) result Promise.t
+end
+
+module Os : sig
+  val tmpdir : unit -> string
+end
+
+val thisProjectsEsyJson : string


### PR DESCRIPTION
Simplify the stream bindings as well by removing an extra functor