### PR TITLE
Improve OCaml syntax highlighting in strings and doc comments

### DIFF
--- a/syntaxes/ocaml.json
+++ b/syntaxes/ocaml.json
@@ -49,6 +49,7 @@
               "comment": "embedded ocaml source",
               "begin": "\\[",
               "end": "\\]",
+              "contentName": "source.embedded.ocaml",
               "patterns": [{ "include": "source.ocaml" }]
             },
             { "include": "#comments" }

--- a/syntaxes/ocaml.json
+++ b/syntaxes/ocaml.json
@@ -114,11 +114,6 @@
               "match": "%[-0+ #]*([0-9]+|\\*)?(.([0-9]+|\\*))?[lLn]?[diunlLNxXosScCfFeEgGhHBbat!%@,]"
             },
             {
-              "comment": "unknown printf format string",
-              "name": "invalid.illegal.unknown-escape.ocaml",
-              "match": "%[^\"]"
-            },
-            {
               "comment": "unknown escape sequence",
               "name": "invalid.illegal.unknown-escape.ocaml",
               "match": "\\\\."
@@ -189,8 +184,19 @@
           "match": "~[a-z_][A-Za-z0-9_']*"
         },
         {
+          "comment": "for loop",
+          "match": "\\b(for)\\s([a-z_][A-Za-z0-9_']*)",
+          "captures": {
+            "1": { "name": "keyword.ocaml" },
+            "2": {
+              "name": "entity.name.function.binding.ocaml",
+              "patterns": [{ "include": "source.ocaml" }]
+            }
+          }
+        },
+        {
           "comment": "let expression",
-          "match": "\\b(let|external|for)\\s+(rec\\s+)?([a-z_][A-Za-z0-9_']*)",
+          "match": "\\b(let)\\s+(rec\\s+)?([a-z_][A-Za-z0-9_']*)",
           "captures": {
             "1": { "name": "keyword.ocaml" },
             "2": { "name": "keyword.ocaml" },
@@ -233,6 +239,33 @@
             "1": { "name": "keyword.ocaml" },
             "2": { "name": "keyword.ocaml" },
             "3": {
+              "name": "entity.name.function.binding.ocaml",
+              "patterns": [{ "include": "source.ocaml" }]
+            }
+          }
+        },
+        {
+          "comment": "external declaration assigned to string",
+          "contentName": "string.quoted.double.ocaml",
+          "begin": "\\b(external)\\s+([a-z_][A-Za-z0-9_']*)?(.*=)\\s*(\")",
+          "beginCaptures": {
+            "1": { "name": "keyword.ocaml" },
+            "2": {
+              "name": "entity.name.function.binding.ocaml",
+              "patterns": [{ "include": "source.ocaml" }]
+            },
+            "3": { "patterns": [{ "include": "source.ocaml" }] },
+            "4": { "name": "string.quoted.double.ocaml" }
+          },
+          "end": "\"",
+          "endCaptures": [{ "name": "string.quoted.double.ocaml" }]
+        },
+        {
+          "comment": "external declaration",
+          "match": "\\b(external)\\s+([a-z_][A-Za-z0-9_']*)",
+          "captures": {
+            "1": { "name": "keyword.ocaml" },
+            "2": {
               "name": "entity.name.function.binding.ocaml",
               "patterns": [{ "include": "source.ocaml" }]
             }

--- a/syntaxes/ocaml.json
+++ b/syntaxes/ocaml.json
@@ -36,7 +36,7 @@
       "patterns": [
         {
           "comment": "ocamldoc comment",
-          "name": "comment.doc.ocaml emphasis",
+          "name": "comment.doc.ocaml",
           "begin": "\\(\\*\\*",
           "end": "\\*\\)",
           "patterns": [
@@ -44,6 +44,12 @@
               "comment": "ocamldoc documentation tag",
               "name": "keyword.doc-tag.ocaml",
               "match": "\\@[a-z]+"
+            },
+            {
+              "comment": "embedded ocaml source",
+              "begin": "\\[",
+              "end": "\\]",
+              "patterns": [{ "include": "source.ocaml" }]
             },
             { "include": "#comments" }
           ]


### PR DESCRIPTION
 - Printf placeholders (those that begin with `%`) are no longer highlighted in `external` declarations
 - Invalid printf placeholders are no longer highlighted because `%` can appear in other contexts where it is not an error
- OCaml sources are highlighted inside ocamldoc comments
- ocamldoc comments no longer have the `emphasis` tag because ocamldoc comments can have text formatting for italics

Comparison:
| Old | New |
| - | - |
| ![printf_old](https://user-images.githubusercontent.com/25037249/78469076-6a7ce080-76d2-11ea-85f3-aeaa1af4f5e8.png) | ![printf_new](https://user-images.githubusercontent.com/25037249/78469077-6cdf3a80-76d2-11ea-8895-c54b105e6329.png) | 
| ![doc_old](https://user-images.githubusercontent.com/25037249/78469081-82546480-76d2-11ea-802e-7f6a8a12014c.png) | ![doc_new](https://user-images.githubusercontent.com/25037249/78469082-84b6be80-76d2-11ea-96db-38664e131c34.png) | 

Still need to find a way to easily distinguish ocamldoc comments from normal comments at a glance...






