### PR TITLE
Add OCamlFormat syntax highlighting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 - Improve ocamllex syntax highlighting
 - Improve opam syntax highlighting
 - Fix bugs in ocaml and ocamllex syntax highlighting
+- Add OCamlFormat syntax highlighting
 
 ## 0.4.0
 

--- a/languages/ocamlformat.json
+++ b/languages/ocamlformat.json
@@ -1,0 +1,5 @@
+{
+  "comments": {
+    "lineComment": "#"
+  }
+}

--- a/package.json
+++ b/package.json
@@ -147,6 +147,17 @@
         ]
       },
       {
+        "id": "ocaml.ocamlformat",
+        "aliases": [
+          "OCamlFormat",
+          "ocamlformat"
+        ],
+        "extensions": [
+          ".ocamlformat"
+        ],
+        "configuration": "./languages/ocamlformat.json"
+      },
+      {
         "id": "ocaml.ocamllex",
         "aliases": [
           "OCamllex",
@@ -213,6 +224,11 @@
         "language": "ocaml.ocamlbuild",
         "scopeName": "source.ocaml.ocamlbuild",
         "path": "./syntaxes/ocamlbuild.json"
+      },
+      {
+        "language": "ocaml.ocamlformat",
+        "scopeName": "source.ocaml.ocamlformat",
+        "path": "./syntaxes/ocamlformat.json"
       },
       {
         "language": "ocaml.ocamllex",

--- a/package.json
+++ b/package.json
@@ -83,16 +83,6 @@
         "configuration": "./languages/dune.json"
       },
       {
-        "id": "ocaml.menhir",
-        "aliases": [
-          "Menhir",
-          "menhir"
-        ],
-        "extensions": [
-          ".mly"
-        ]
-      },
-      {
         "id": "ocaml.merlin",
         "aliases": [
           "Merlin",

--- a/syntaxes/ocamlformat.json
+++ b/syntaxes/ocamlformat.json
@@ -1,0 +1,179 @@
+{
+  "name": "OCamlFormat",
+  "scopeName": "source.ocaml.ocamlformat",
+  "fileTypes": [".ocamlformat"],
+  "patterns": [
+    {
+      "include": "#comments"
+    },
+    {
+      "include": "#options"
+    },
+    {
+      "include": "#values"
+    },
+    {
+      "comment": "equals sign",
+      "name": "keyword.operator.ocamlformat",
+      "match": "="
+    }
+  ],
+  "repository": {
+    "comments": {
+      "comment": "line comment",
+      "name": "comment.line.ocamlformat",
+      "begin": "#",
+      "end": "$"
+    },
+    "options": {
+      "patterns": [
+        {
+          "name": "keyword.other.ocamlformat",
+          "match": "\\b(align-cases|align-constructors-decl|align-variants-decl|assignment-operator)\\b"
+        },
+        {
+          "name": "keyword.other.ocamlformat",
+          "match": "\\b(break-before-in|break-cases|break-collection|break-fun-decl|break-fun-sig|break-infix|break-infix-before-func|break-separators|break-sequences|break-string-literals|break-struct)\\b"
+        },
+        {
+          "name": "keyword.other.ocamlformat",
+          "match": "\\b(cases-exp-indent|cases-matching-exp-indent)\\b"
+        },
+        {
+          "name": "keyword.other.ocamlformat",
+          "match": "\\b(disable|disambiguate-non-breaking-match|doc-comments-padding|doc-comments|doc-comments-tag-only|doc-comments-val|dock-collection-brackets)\\b"
+        },
+        {
+          "name": "keyword.other.ocamlformat",
+          "match": "\\b(escape-chars|escape-strings|exp-grouping|extension-indent|extension-sugar)\\b"
+        },
+        {
+          "name": "keyword.other.ocamlformat",
+          "match": "\\b(field-space|function-indent-nested|function-indent)\\b"
+        },
+        {
+          "name": "keyword.other.ocamlformat",
+          "match": "\\b(if-then-else|indent-after-in|indicate-multiline-delimiters|indicate-nested-or-patterns|infix-precedence)\\b"
+        },
+        {
+          "name": "keyword.other.ocamlformat",
+          "match": "\\b(leading-nested-match-parens|let-and|let-binding-indent|let-binding-spacing|let-module|let-open)\\b"
+        },
+        {
+          "name": "keyword.other.ocamlformat",
+          "match": "\\b(m|margin|match-indent-nested|match-indent|max-indent|module-item-spacing)\\b"
+        },
+        {
+          "name": "keyword.other.ocamlformat",
+          "match": "\\b(no-align-cases|no-align-constructors-decl|no-align-variants-decl|no-break-infix-before-func|no-break-sequences|no-disable|no-disambiguate-non-breaking-match|no-dock-collection-brackets|no-leading-nested-match-parens|no-ocp-indent-compat|no-parens-ite|no-parse-docstrings|no-space-around-arrays|no-space-around-lists|no-space-around-records|no-space-around-variants|no-wrap-comments|no-wrap-fun-args)\\b"
+        },
+        {
+          "name": "keyword.other.ocamlformat",
+          "match": "\\b(ocp-indent-compat)\\b"
+        },
+        {
+          "name": "keyword.other.ocamlformat",
+          "match": "\\b(parens-ite|parens-tuple|parens-tuple-patterns|parse-docstrings)\\b"
+        },
+        {
+          "name": "keyword.other.ocamlformat",
+          "match": "\\b(sequence-blank-line|sequence-style|single-case|space-around-arrays|space-around-lists|space-around-records|space-around-variants|stritem-extension-indent)\\b"
+        },
+        {
+          "name": "keyword.other.ocamlformat",
+          "match": "\\b(type-decl-indent|type-decl)\\b"
+        },
+        {
+          "name": "keyword.other.ocamlformat",
+          "match": "\\b(version)\\b"
+        },
+        {
+          "name": "keyword.other.ocamlformat",
+          "match": "\\b(wrap-comments|wrap-fun-args)\\b"
+        }
+      ]
+    },
+    "values": {
+      "patterns": [
+        {
+          "comment": "boolean literal",
+          "name": "constant.language.ocamlformat",
+          "match": "\\b(true|false)\\b"
+        },
+        {
+          "comment": "numeric literal",
+          "name": "constant.numeric.decimal.ocamlformat",
+          "match": "\\b([0-9]+(\\.[0-9]*)*)\\b"
+        },
+        {
+          "name": "constant.language.ocamlformat",
+          "match": "\\b(after|align|all|always|auto)\\b"
+        },
+        {
+          "name": "constant.language.ocamlformat",
+          "match": "\\b(before|begin-line)\\b"
+        },
+        {
+          "name": "constant.language.ocamlformat",
+          "match": "\\b(closing-on-separate-line|compact)\\b"
+        },
+        {
+          "name": "constant.language.ocamlformat",
+          "match": "\\b(decimal|default|double-semicolon)\\b"
+        },
+        {
+          "name": "constant.language.ocamlformat",
+          "match": "\\b(end-line)\\b"
+        },
+        {
+          "name": "constant.language.ocamlformat",
+          "match": "\\b(fit-or-vertical|fit|force)\\b"
+        },
+        {
+          "name": "constant.language.ocamlformat",
+          "match": "\\b(hexadecimal)\\b"
+        },
+        {
+          "name": "constant.language.ocamlformat",
+          "match": "\\b(indent)\\b"
+        },
+        {
+          "name": "constant.language.ocamlformat",
+          "match": "\\b(k-r|keyword-first)\\b"
+        },
+        {
+          "name": "constant.language.ocamlformat",
+          "match": "\\b(long|loose)\\b"
+        },
+        {
+          "name": "constant.language.ocamlformat",
+          "match": "\\b(multi-line-only)\\b"
+        },
+        {
+          "name": "constant.language.ocamlformat",
+          "match": "\\b(natural|nested|never|no|normal)\\b"
+        },
+        {
+          "name": "constant.language.ocamlformat",
+          "match": "\\b(parens|preserve-one|preserve)\\b"
+        },
+        {
+          "name": "constant.language.ocamlformat",
+          "match": "\\b(separator|short|smart|space|sparse)\\b"
+        },
+        {
+          "name": "constant.language.ocamlformat",
+          "match": "\\b(terminator|tight-decl|tight|toplevel)\\b"
+        },
+        {
+          "name": "constant.language.ocamlformat",
+          "match": "\\b(unsafe-no)\\b"
+        },
+        {
+          "name": "constant.language.ocamlformat",
+          "match": "\\b(wrap)\\b"
+        }
+      ]
+    }
+  }
+}


### PR DESCRIPTION
Addresses #121 

Example:
![ocamlformat](https://user-images.githubusercontent.com/25037249/78858267-c13f2e80-79e0-11ea-8749-7cc02fef7e2a.png)
