### PR TITLE
readme: avoid confusion between ocaml-lsp and ocaml-lsp-server

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,4 +40,4 @@ the settings under `File > Preferences > Settings`.
 
 ## Requirements
 
-- [ocaml-lsp-server](https://github.com/ocaml/ocaml-lsp)
+- [ocaml-lsp](https://github.com/ocaml/ocaml-lsp)


### PR DESCRIPTION
At first glance, I thought those two were different things while actually they redirect to the same project.

I guess that using the same name for both might avoid some confusion.