### PR TITLE
Fix support for multi dir workspaces

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@
 *.vsix
 *~
 _esy/
+esy.lock
 dist/
 lib/
 node_modules/

--- a/src/Cmd.ml
+++ b/src/Cmd.ml
@@ -58,7 +58,7 @@ let output ~args ?cwd { cmd; env } =
   ChildProcess.exec shellString (ChildProcess.Options.make ?cwd ~env ())
   |> Promise.map (function
        | Error e -> Error e
-       | Ok (exitCode, stdout, stderr) ->
+       | Ok { ChildProcess.exitCode; stdout; stderr } ->
          if exitCode = 0 then
            Ok stdout
          else

--- a/src/Cmd.ml
+++ b/src/Cmd.ml
@@ -1,7 +1,7 @@
 open Import
 
 type t =
-  { cmd : string
+  { cmd : Path.t
   ; env : string Js.Dict.t
   }
 
@@ -14,31 +14,41 @@ let pathMissingFromEnv = "'PATH' variable not found in the environment"
 let binPath c = c.cmd
 
 let make ?(env = Process.env) ~cmd () =
-  match Js.Dict.get env "PATH" with
-  | None -> Error pathMissingFromEnv |> Promise.resolve
-  | Some path ->
-    let cmds =
-      match Sys.unix with
-      | true -> [| cmd |]
-      | false -> [| cmd ^ ".exe"; cmd ^ ".cmd" |]
-    in
-    cmds
-    |> Array.map (fun cmd ->
-           Js.String.split envSep path
-           |> Js.Array.map (fun p -> Filename.concat p cmd))
-    |> Js.Array.reduce Js.Array.concat [||]
-    |> Js.Array.map (fun p ->
-           p |> Fs.exists |> Promise.map (fun exists -> (p, exists)))
-    |> Promise.all
-    |> Promise.map (fun r ->
-           match
-             r |> Js.Array.filter (fun (_p, exists) -> exists) |> Array.to_list
-           with
-           | [] -> Error {j| Command "$cmd" not found |j}
-           | (cmd, _exists) :: _rest -> Ok { cmd; env })
+  if Path.isAbsolute cmd then
+    Promise.Result.return { env; cmd }
+  else
+    match Js.Dict.get env "PATH" with
+    | None -> Error pathMissingFromEnv |> Promise.resolve
+    | Some path ->
+      let cmds =
+        match Sys.unix with
+        | true -> [| cmd |]
+        | false ->
+          [| Path.withExt cmd ~ext:".exe"; Path.withExt cmd ~ext:".cmd" |]
+      in
+      cmds
+      |> Array.map (fun cmd ->
+             Js.String.split envSep path
+             |> Js.Array.map (fun p -> Path.join (Path.ofString p) cmd))
+      |> Js.Array.reduce Js.Array.concat [||]
+      |> Js.Array.map (fun p ->
+             p |> Path.toString |> Fs.exists
+             |> Promise.map (fun exists -> (p, exists)))
+      |> Promise.all
+      |> Promise.map (fun r ->
+             match
+               r
+               |> Js.Array.filter (fun (_p, exists) -> exists)
+               |> Array.to_list
+             with
+             | [] -> Error {j| Command "$cmd" not found |j}
+             | (cmd, _exists) :: _rest -> Ok { cmd; env })
 
 let output ~args ?cwd { cmd; env } =
-  let shellString = Js.Array.concat args [| cmd |] |> Js.Array.joinWith " " in
+  (* TODO use ChildProcess.spawn to get rid of this pointless concatenation *)
+  let shellString =
+    Js.Array.joinWith " " (Js.Array.concat args [| Path.toString cmd |])
+  in
   Js.Console.info shellString;
   let cwd =
     match cwd with
@@ -53,7 +63,7 @@ let output ~args ?cwd { cmd; env } =
            Ok stdout
          else
            Error
-             {j| Command $cmd failed:
+             {j| Command $shellString failed:
 exitCode: $exitCode
 stderr: $stderr
 |j})

--- a/src/Cmd.ml
+++ b/src/Cmd.ml
@@ -13,36 +13,37 @@ let pathMissingFromEnv = "'PATH' variable not found in the environment"
 
 let binPath c = c.cmd
 
+let candidateFns =
+  if Sys.unix then
+    fun x ->
+  [| x |]
+  else
+    fun x ->
+  [| ".exe"; ".cmd" |] |> Array.map (fun ext -> Path.withExt x ~ext)
+
+let which path fn =
+  let candidates = candidateFns fn in
+  Js.String.split envSep path
+  |> Promise.Array.findMap (fun p ->
+         let p = Path.ofString p in
+         Array.map (Path.join p) candidates
+         |> Promise.Array.findMap (fun p ->
+                let open Promise.O in
+                Fs.exists (Path.toString p) >>| function
+                | true -> Some p
+                | false -> None))
+
 let make ?(env = Process.env) ~cmd () =
   if Path.isAbsolute cmd then
     Promise.Result.return { env; cmd }
   else
     match Js.Dict.get env "PATH" with
     | None -> Error pathMissingFromEnv |> Promise.resolve
-    | Some path ->
-      let cmds =
-        match Sys.unix with
-        | true -> [| cmd |]
-        | false ->
-          [| Path.withExt cmd ~ext:".exe"; Path.withExt cmd ~ext:".cmd" |]
-      in
-      cmds
-      |> Array.map (fun cmd ->
-             Js.String.split envSep path
-             |> Js.Array.map (fun p -> Path.join (Path.ofString p) cmd))
-      |> Js.Array.reduce Js.Array.concat [||]
-      |> Js.Array.map (fun p ->
-             p |> Path.toString |> Fs.exists
-             |> Promise.map (fun exists -> (p, exists)))
-      |> Promise.all
-      |> Promise.map (fun r ->
-             match
-               r
-               |> Js.Array.filter (fun (_p, exists) -> exists)
-               |> Array.to_list
-             with
-             | [] -> Error {j| Command "$cmd" not found |j}
-             | (cmd, _exists) :: _rest -> Ok { cmd; env })
+    | Some path -> (
+      let open Promise.O in
+      which path cmd >>| function
+      | None -> Error {j| Command "$cmd" not found |j}
+      | Some cmd -> Ok { cmd; env } )
 
 let output ~args ?cwd { cmd; env } =
   (* TODO use ChildProcess.spawn to get rid of this pointless concatenation *)

--- a/src/Cmd.mli
+++ b/src/Cmd.mli
@@ -3,7 +3,7 @@
 type t
 
 val make :
-  ?env:string Js.Dict.t -> cmd:string -> unit -> (t, string) result Promise.t
+  ?env:string Js.Dict.t -> cmd:Path.t -> unit -> (t, string) result Promise.t
 
 type stdout = string
 
@@ -15,4 +15,4 @@ val output :
   -> t
   -> (stdout, stderr) result Promise.t
 
-val binPath : t -> string
+val binPath : t -> Path.t

--- a/src/Extension.ml
+++ b/src/Extension.ml
@@ -45,8 +45,6 @@ module Instance = struct
     client.start () [@bs]
 end
 
-let workspaceRoot () = Belt.Option.map (Workspace.rootPath ()) Path.ofString
-
 let selectSandbox (instance : Instance.t) () =
   let setToolchain =
     let open Promise.O in

--- a/src/Extension.ml
+++ b/src/Extension.ml
@@ -18,7 +18,7 @@ module Server = struct
   let make (toolchain : Toolchain.resources) :
       Vscode.LanguageClient.serverOptions =
     let command, args = Toolchain.getLspCommand toolchain in
-    { command; args; options = { env = Process.env } }
+    { command = Path.toString command; args; options = { env = Process.env } }
 end
 
 module Instance = struct

--- a/src/Promise.ml
+++ b/src/Promise.ml
@@ -10,6 +10,23 @@ module O = struct
   let ( >>= ) x f = then_ f x
 end
 
+module Array = struct
+  let findMap (type a b) (f : a -> b option t) (arr : a array) : b option t =
+    let open O in
+    Array.map f arr |> Js.Promise.all
+    |> map (fun arr ->
+           match
+             Js.Array.find
+               (function
+                 | Some _ -> true
+                 | None -> false)
+               arr
+           with
+           | None -> None
+           | Some (Some _ as x) -> x
+           | Some None -> assert false)
+end
+
 module Result = struct
   let bind fn promise =
     let open Js.Promise in

--- a/src/Setup.ml
+++ b/src/Setup.ml
@@ -113,7 +113,7 @@ module Bsb = struct
             resolve (Ok ()) [@bs]))
 
   let unzipArtifacts ~esyRoot ~envWithUnzip =
-    Cmd.make ~cmd:"unzip" ~env:envWithUnzip ()
+    Cmd.make ~cmd:(Path.ofString "unzip") ~env:envWithUnzip ()
     |> Promise.Result.bind (fun unzip ->
            Cmd.output unzip ~args:[| cacheFileName |] ~cwd:esyRoot)
     |> Promise.map (function

--- a/src/Toolchain.ml
+++ b/src/Toolchain.ml
@@ -107,10 +107,7 @@ module PackageManager = struct
     | Global -> "global"
 end
 
-type resources =
-  { kind : PackageManager.t
-  ; projectRoot : Path.t
-  }
+type resources = PackageManager.t
 
 let availablePackageManagers () =
   { PackageManager.Kind.Hmap.opam = Opam.make ()
@@ -194,15 +191,21 @@ let selectPackageManager choices =
   in
   Window.showQuickPickItems choices options
 
-let sandboxCandidates ~projectRoot =
+let sandboxCandidates ~workspaceFolders =
   let open Promise.O in
   let available = availablePackageManagers () in
   let esy =
     available.esy >>= function
     | None -> Promise.return []
     | Some esy ->
-      Esy.discover ~dir:projectRoot
-      >>| List.map (fun manifest -> PackageManager.Esy (esy, manifest))
+      workspaceFolders
+      |> Array.map (fun (folder : Vscode.Folder.t) ->
+             let dir = Path.ofString folder.uri.fsPath in
+             Esy.discover ~dir)
+      |> Promise.all
+      >>| fun esys ->
+      Array.to_list esys |> List.concat
+      |> List.map (fun manifest -> PackageManager.Esy (esy, manifest))
   in
   let opam =
     available.opam >>= function
@@ -214,26 +217,27 @@ let sandboxCandidates ~projectRoot =
   Promise.all2 (esy, opam) >>| fun (esy, opam) ->
   (PackageManager.Global :: esy) @ opam
 
-let setupToolChain { kind; projectRoot } =
+let setupToolChain (kind : PackageManager.t) =
   match kind with
   | Global -> Ok () |> Promise.resolve
   | Opam _ -> Ok () |> Promise.resolve
-  | Esy (esy, manifest) -> Esy.setupToolchain esy ~manifest ~projectRoot
+  | Esy (esy, manifest) -> Esy.setupToolchain esy ~manifest
 
-let makeResources ~projectRoot kind = { projectRoot; kind }
+let makeResources kind = kind
 
-let selectAndSave ~projectRoot =
+let selectAndSave () =
   let open Promise.O in
-  sandboxCandidates ~projectRoot >>= fun candidates ->
+  let workspaceFolders = Vscode.Workspace.workspaceFolders () in
+  sandboxCandidates ~workspaceFolders >>= fun candidates ->
   selectPackageManager candidates >>| function
   | None -> None
   | Some choice ->
     let (_ : unit Promise.t) = toSettings choice in
     Some choice
 
-let getLspCommand t =
+let getLspCommand (t : PackageManager.t) =
   let name = "ocamllsp" in
-  match t.kind with
+  match t with
   | Opam (opam, switch) -> Opam.exec opam ~switch ~args:[| name |]
   | Esy (esy, manifest) -> Esy.exec esy ~manifest ~args:[| name |]
   | Global -> (name, [||])

--- a/src/Toolchain.ml
+++ b/src/Toolchain.ml
@@ -235,12 +235,12 @@ let selectAndSave () =
     let (_ : unit Promise.t) = toSettings choice in
     Some choice
 
-let getLspCommand (t : PackageManager.t) =
+let getLspCommand (t : PackageManager.t) : Path.t * string array =
   let name = "ocamllsp" in
   match t with
   | Opam (opam, switch) -> Opam.exec opam ~switch ~args:[| name |]
   | Esy (esy, manifest) -> Esy.exec esy ~manifest ~args:[| name |]
-  | Global -> (name, [||])
+  | Global -> (Path.ofString name, [||])
 
 let runSetup resources =
   let open Promise.Result.O in

--- a/src/Toolchain.mli
+++ b/src/Toolchain.mli
@@ -29,14 +29,14 @@ type resources
 
 val ofSettings : unit -> PackageManager.t option Promise.t
 
-val makeResources : projectRoot:Path.t -> PackageManager.t -> resources
+val makeResources : PackageManager.t -> resources
 
 (** [selectAndSave] requires the process environment the plugin is being run in
    (ie VSCode's process environment) and the project root and produces a promise
    of resources available that can later be passed on to runSetup that can be
    called to install the toolchain. *)
 
-val selectAndSave : projectRoot:Path.t -> PackageManager.t option Promise.t
+val selectAndSave : unit -> PackageManager.t option Promise.t
 
 val runSetup : resources -> (unit, string) result Promise.t
 (** [runSetup] is a effectful function that triggers setup instructions

--- a/src/Toolchain.mli
+++ b/src/Toolchain.mli
@@ -68,6 +68,6 @@ val runSetup : resources -> (unit, string) result Promise.t
 
 (* Helper utils *)
 
-val getLspCommand : resources -> string * string array
+val getLspCommand : resources -> Path.t * string array
 (** Extract lsp command and arguments (Eg. "opam" and [| "exec";
    "ocamllsp" |] *)

--- a/src/__tests__/Bindings_tests.ml
+++ b/src/__tests__/Bindings_tests.ml
@@ -7,6 +7,6 @@ let () =
       testPromise "toBe" (fun () ->
           ChildProcess.exec "echo hey" (ChildProcess.Options.make ())
           |> Promise.map (function
-               | Ok (_exitCode, stdout, _) ->
+               | Ok { ChildProcess.exitCode = _; stdout; stderr = _ } ->
                  expect stdout |> toContainString "hey"
                | Error _ -> fail "exec should have succeeded")))

--- a/src/bindings/Node.ml
+++ b/src/bindings/Node.ml
@@ -185,6 +185,12 @@ module ChildProcess = struct
     -> t = "exec"
     [@@bs.val] [@@bs.module "child_process"]
 
+  type return =
+    { exitCode : int
+    ; stdout : string
+    ; stderr : string
+    }
+
   let exec cmd options =
     let open Promise in
     make (fun ~resolve ~reject:_ ->
@@ -192,7 +198,7 @@ module ChildProcess = struct
         cp :=
           exec cmd options (fun err stdout stderr ->
               if Js.Nullable.isNullable err then (
-                resolve (Ok (!cp##exitCode, stdout, stderr)) [@bs]
+                resolve (Ok { exitCode = !cp##exitCode; stdout; stderr }) [@bs]
               ) else (
                 resolve (Error {j| Exec failed during $cmd |j}) [@bs]
               ));

--- a/src/bindings/Node.ml
+++ b/src/bindings/Node.ml
@@ -208,6 +208,8 @@ module Path = struct
   external extname : string -> string = "extname" [@@bs.module "path"]
 
   external dirname : string -> string = "dirname" [@@bs.module "path"]
+
+  external isAbsolute : string -> bool = "isAbsolute" [@@bs.module "path"]
 end
 
 module Response = struct

--- a/src/bindings/Vscode.ml
+++ b/src/bindings/Vscode.ml
@@ -8,7 +8,11 @@ module TextDocument = struct
 end
 
 module Folder = struct
-  type t = { uri : TextDocument.uri }
+  type t =
+    { uri : TextDocument.uri
+    ; index : int
+    ; name : string
+    }
 end
 
 module WorkspaceConfiguration = struct
@@ -36,8 +40,16 @@ module Workspace = struct
     ; removed : Folder.t array
     }
 
-  external rootPath : string = "rootPath"
+  external _rootPath : string Js.Nullable.t = "rootPath"
     [@@bs.module "vscode"] [@@bs.scope "workspace"]
+
+  let rootPath () = Js.Nullable.toOption _rootPath
+
+  external _workspaceFolders : Folder.t array Js.Nullable.t = "workspaceFolders"
+    [@@bs.module "vscode"] [@@bs.scope "workspace"]
+
+  let workspaceFolders () =
+    Js.Nullable.toOption _workspaceFolders |. Belt.Option.getWithDefault [||]
 
   external onDidOpenTextDocument : (TextDocument.event -> unit) -> unit
     = "onDidOpenTextDocument"
@@ -116,7 +128,7 @@ module Window = struct
   external _showInformationMessage' :
     string -> MessageItem.t array -> MessageItem.t Js.Nullable.t Promise.t
     = "showInformationMessage"
-    [@@bs.module "vscode"] [@@bs.scope "window"]
+    [@@bs.module "vscode"] [@@bs.scope "window"] [@@bs.variadic]
 
   let showInformationMessage' msg choices =
     let choices =

--- a/src/bindings/Vscode.ml
+++ b/src/bindings/Vscode.ml
@@ -40,10 +40,10 @@ module Workspace = struct
     ; removed : Folder.t array
     }
 
-  external _rootPath : string Js.Nullable.t = "rootPath"
+  external _name : string Js.Nullable.t = "name"
     [@@bs.module "vscode"] [@@bs.scope "workspace"]
 
-  let rootPath () = Js.Nullable.toOption _rootPath
+  let name () = Js.Nullable.toOption _name
 
   external _workspaceFolders : Folder.t array Js.Nullable.t = "workspaceFolders"
     [@@bs.module "vscode"] [@@bs.scope "workspace"]

--- a/src/bindings/Vscode.mli
+++ b/src/bindings/Vscode.mli
@@ -140,7 +140,7 @@ module Workspace : sig
     ; removed : Folder.t array
     }
 
-  val rootPath : unit -> string option
+  val name : unit -> string option
 
   val workspaceFolders : unit -> Folder.t array
 

--- a/src/bindings/Vscode.mli
+++ b/src/bindings/Vscode.mli
@@ -127,7 +127,11 @@ module Window : sig
 end
 
 module Folder : sig
-  type t = { uri : TextDocument.uri }
+  type t =
+    { uri : TextDocument.uri
+    ; index : int
+    ; name : string
+    }
 end
 
 module Workspace : sig
@@ -136,7 +140,9 @@ module Workspace : sig
     ; removed : Folder.t array
     }
 
-  val rootPath : string
+  val rootPath : unit -> string option
+
+  val workspaceFolders : unit -> Folder.t array
 
   val onDidOpenTextDocument : (TextDocument.event -> unit) -> unit
 

--- a/src/esy.ml
+++ b/src/esy.ml
@@ -2,7 +2,7 @@ open Import
 
 type t = Cmd.t
 
-let binary = "esy"
+let binary = Path.ofString "esy"
 
 let make () =
   Cmd.make ~cmd:binary ()

--- a/src/esy.ml
+++ b/src/esy.ml
@@ -109,9 +109,9 @@ module State = struct
     | PendingBsb
 end
 
-let state t ~manifest ~projectRoot =
+let state t ~manifest =
   let rootStr = Path.toString manifest in
-  Cmd.output t ~args:[| "status"; "-P"; rootStr |] ~cwd:projectRoot
+  Cmd.output t ~args:[| "status"; "-P"; rootStr |]
   |> Promise.map (function
        | Error _ -> Ok false
        | Ok esyOutput -> (
@@ -124,7 +124,8 @@ let state t ~manifest ~projectRoot =
   |> Promise.Result.map (fun isProjectReadyForDev ->
          if isProjectReadyForDev then
            State.Ready
-         else if Path.compare manifest projectRoot = 0 then
+         else if true then
+           (* TODO this was a check based on projectRoot. This is wrong. *)
            PendingEsy
          else
            PendingBsb)
@@ -171,9 +172,9 @@ let setupEsy t ~manifest =
              progress.report [%bs.obj { increment = int_of_float 100. }] [@bs];
              Ok ()))
 
-let setupToolchain t ~manifest ~projectRoot =
+let setupToolchain t ~manifest =
   let open Promise.Result.O in
-  state t ~manifest ~projectRoot >>= function
+  state t ~manifest >>= function
   | State.Ready -> Promise.Result.return ()
   | PendingEsy -> promptSetup (fun () -> setupEsy t ~manifest)
   | PendingBsb -> setupBsb t ~envWithUnzip:Process.env ~manifest

--- a/src/esy.mli
+++ b/src/esy.mli
@@ -8,6 +8,6 @@ val discover : dir:Path.t -> Path.t list Promise.t
 
 val env : t -> manifest:Path.t -> string Js.Dict.t Or_error.t Promise.t
 
-val exec : t -> manifest:Path.t -> args:string array -> string * string array
+val exec : t -> manifest:Path.t -> args:string array -> Path.t * string array
 
 val setupToolchain : t -> manifest:Path.t -> unit Or_error.t Promise.t

--- a/src/esy.mli
+++ b/src/esy.mli
@@ -10,5 +10,4 @@ val env : t -> manifest:Path.t -> string Js.Dict.t Or_error.t Promise.t
 
 val exec : t -> manifest:Path.t -> args:string array -> string * string array
 
-val setupToolchain :
-  t -> manifest:Path.t -> projectRoot:Path.t -> unit Or_error.t Promise.t
+val setupToolchain : t -> manifest:Path.t -> unit Or_error.t Promise.t

--- a/src/opam.ml
+++ b/src/opam.ml
@@ -16,7 +16,7 @@ module Switch = struct
     | Local p -> Path.toString p
 end
 
-let binary = "opam"
+let binary = Path.ofString "opam"
 
 type t = Cmd.t
 
@@ -57,7 +57,8 @@ let parseEnvOutput (opamEnvOutput : string) =
 let switchList t =
   Cmd.output t ~args:[| "switch"; "list"; "-s" |]
   |> Promise.map (function
-       | Error _ ->
+       | Error e ->
+         Js.Console.log {j|"Unable to read switches: $e"|j};
          message `Warn "Unable to read the list of switches.";
          []
        | Ok out -> parseSwitchList out)

--- a/src/opam.mli
+++ b/src/opam.mli
@@ -18,6 +18,6 @@ val switchList : t -> Switch.t list Promise.t
 
 val env : t -> switch:Switch.t -> string Js.Dict.t Or_error.t Promise.t
 
-val exec : t -> switch:Switch.t -> args:string array -> string * string array
+val exec : t -> switch:Switch.t -> args:string array -> Path.t * string array
 
 val exists : t -> switch:Switch.t -> bool Promise.t

--- a/src/path.ml
+++ b/src/path.ml
@@ -3,22 +3,26 @@ let sep =
   | true -> "/"
   | false -> "\\\\"
 
-type t = string list
+type t = string
 
-let ofString s = Array.to_list (Js.String.split sep s)
+let ofString s = s
+
+let isAbsolute t = Node.Path.isAbsolute t
 
 let v = ofString
 
-let toString s = Js.Array.joinWith sep (Array.of_list s)
+let toString s = s
 
-let compare x y = String.compare (toString x) (toString y)
+let compare = String.compare
 
-let extname t = Node.Path.extname (toString t)
+let extname t = Node.Path.extname t
 
-let ( / ) p x = p @ [ x ]
+let ( / ) = Filename.concat
 
 let relative = ( / )
 
-let relative_all p xs = p @ xs
+let relative_all p xs = List.fold_left Filename.concat p xs
 
-let join x y = x @ y
+let join x y = Filename.concat x y
+
+let withExt x ~ext = x ^ ext

--- a/src/path.mli
+++ b/src/path.mli
@@ -4,6 +4,8 @@ type t
 
 val ofString : string -> t
 
+val isAbsolute : t -> bool
+
 val v : string -> t
 
 val compare : t -> t -> int
@@ -19,3 +21,5 @@ val relative : t -> string -> t
 val relative_all : t -> string list -> t
 
 val join : t -> t -> t
+
+val withExt : t -> ext:string -> t

--- a/src/settings.ml
+++ b/src/settings.ml
@@ -24,9 +24,11 @@ let get t =
       None )
 
 let set t v =
-  let scope = WorkspaceConfiguration.configurationTargetToJs t.scope in
-  (* TODO this will raise if a workspace isn't open *)
-  WorkspaceConfiguration.update section t.key (t.toJson v) scope
+  match Vscode.Workspace.name () with
+  | None -> Promise.return ()
+  | Some _ ->
+    let scope = WorkspaceConfiguration.configurationTargetToJs t.scope in
+    WorkspaceConfiguration.update section t.key (t.toJson v) scope
 
 let string =
   let toJson = Js.Json.string in

--- a/src/settings.ml
+++ b/src/settings.ml
@@ -25,6 +25,7 @@ let get t =
 
 let set t v =
   let scope = WorkspaceConfiguration.configurationTargetToJs t.scope in
+  (* TODO this will raise if a workspace isn't open *)
   WorkspaceConfiguration.update section t.key (t.toJson v) scope
 
 let string =


### PR DESCRIPTION
This removes all the reliance on a "projectRoot". This does not make
sense for workspaces with multiple directories.

For now, this creates an awkward situation for esy projects as it means
that only a single LSP server is used for all projects in the workspace.