### PR TITLE
Fix LSP command check

### DIFF
--- a/src/Toolchain.ml
+++ b/src/Toolchain.ml
@@ -243,7 +243,7 @@ let getLspCommand (t : PackageManager.t) : Path.t * string array =
   | Global -> (Path.ofString name, [||])
 
 let addLspCheckArg args =
-  Array.append args [| "--help" |]
+  Array.append args [| "--help=plain" |]
 
 let runSetup resources =
   let open Promise.Result.O in

--- a/src/Toolchain.ml
+++ b/src/Toolchain.ml
@@ -242,12 +242,15 @@ let getLspCommand (t : PackageManager.t) : Path.t * string array =
   | Esy (esy, manifest) -> Esy.exec esy ~manifest ~args:[| name |]
   | Global -> (Path.ofString name, [||])
 
+let addLspCheckArg args =
+  Array.append args [| "--help" |]
+
 let runSetup resources =
   let open Promise.Result.O in
   setupToolChain resources
   >>= (fun () ->
         let cmd, args = getLspCommand resources in
-        Cmd.make ~cmd () >>= fun cmd -> Cmd.output cmd ~args)
+        Cmd.make ~cmd () >>= fun cmd -> Cmd.output cmd ~args:(addLspCheckArg args))
   |> Promise.map (function
        | Ok _ -> Ok ()
        | Error msg -> Error {j| Toolchain initialisation failed: $msg |j})


### PR DESCRIPTION
Following up on conversation in Slack. Existing command check was blocking initialization of extension. 

Instead of using external command I decided to just use `--help` argument as it will be hard to check something like `/usr/local/bin/opam exec --switch=[switch-path] -- ocamllsp` otherwise.