### PR TITLE
Do not show error on fallback

### DIFF
--- a/src/Extension.ml
+++ b/src/Extension.ml
@@ -61,7 +61,8 @@ let selectSandbox (instance : Instance.t) () =
 let suggestToSetupToolchain instance =
   let open Promise.O in
   Vscode.Window.showInformationMessage'
-    "Extension is unable to find ocamllsp automatically. Please select package manager you used to install ocamllsp for this project."
+    "Extension is unable to find ocamllsp automatically. Please select package \
+     manager you used to install ocamllsp for this project."
     [ ("Select package manager", ()) ]
   >>| function
   | None -> ()

--- a/src/Extension.ml
+++ b/src/Extension.ml
@@ -61,8 +61,8 @@ let selectSandbox (instance : Instance.t) () =
 let suggestToSetupToolchain instance =
   let open Promise.O in
   Vscode.Window.showInformationMessage'
-    "There is no toolchain attached to this project."
-    [ ("select toolchain", ()) ]
+    "Extension is unable to find ocamllsp automatically. Please select package manager you used to install ocamllsp for this project."
+    [ ("Select package manager", ()) ]
   >>| function
   | None -> ()
   | Some () -> selectSandbox instance ()


### PR DESCRIPTION
We discussed merging error and suggestion messages but I think that error still useful sometimes.  Here's my proposal:
— At the start, check if there is active configuration
— If there is, try to run `ocamllsp` with it, if it fails, show the error
— If there is not, show the suggestion and fall back to Global
— If there is global `ocamllsp`, run it
— If there is no global `ocamllsp`, do nothing, wait until configured.
— After user configures extension, we are back at square one.

Here are all of the possible cases:

**User has no active configuration, has no global `ocamllsp`**
User gets "Select toolchain" message.

**User has no active configuration, has global `ocamllsp`**
User gets "Select toolchain" message.
Extension starts working using global `ocamllsp` 

**User has active configuration, `ocamllsp` is not available in selected toolchain**
User gets error message

**User has active configuration, `ocamllsp` is available**
Extension starts working without any messages.

What do you think?