### PR TITLE
dune-workspace syntax highlighting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 - Fix bugs in ocaml and ocamllex syntax highlighting
 - Add OCamlFormat syntax highlighting
 - Add dune-project syntax highlighting
+- Add dune-workspace syntax highlighting
 
 ## 0.4.0
 

--- a/package.json
+++ b/package.json
@@ -95,6 +95,19 @@
         "configuration": "./languages/dune.json"
       },
       {
+        "id": "ocaml.dune-workspace",
+        "aliases": [
+          "dune workspace"
+        ],
+        "filenames": [
+          "dune-workspace"
+        ],
+        "filenamePatterns": [
+          "dune-workspace.*"
+        ],
+        "configuration": "./languages/dune.json"
+      },
+      {
         "id": "ocaml.merlin",
         "aliases": [
           "Merlin",
@@ -189,13 +202,18 @@
     "grammars": [
       {
         "language": "ocaml.dune",
-        "scopeName": "source.dune",
+        "scopeName": "source.ocaml.dune",
         "path": "./syntaxes/dune.json"
       },
       {
         "language": "ocaml.dune-project",
-        "scopeName": "source.dune-project",
+        "scopeName": "source.ocaml.dune-project",
         "path": "./syntaxes/dune-project.json"
+      },
+      {
+        "language": "ocaml.dune-workspace",
+        "scopeName": "source.ocaml.dune-workspace",
+        "path": "./syntaxes/dune-workspace.json"
       },
       {
         "language": "ocaml.merlin",

--- a/syntaxes/dune-project.json
+++ b/syntaxes/dune-project.json
@@ -1,6 +1,6 @@
 {
   "name": "ocaml.dune-project",
-  "scopeName": "source.dune-project",
+  "scopeName": "source.ocaml.dune-project",
   "fileTypes": ["dune-project"],
   "patterns": [{ "include": "#stanzas" }, { "include": "#general" }],
   "repository": {
@@ -24,7 +24,8 @@
           "beginCaptures": {
             "1": { "name": "keyword.language.dune-project" }
           },
-          "contentName": "variable.other.declaration.dune-project"
+          "contentName": "variable.other.declaration.dune-project",
+          "patterns": [{ "include": "#general" }]
         },
 
         {
@@ -34,7 +35,8 @@
           "beginCaptures": {
             "1": { "name": "keyword.language.dune-project" }
           },
-          "contentName": "constant.language.dune-project"
+          "contentName": "constant.language.dune-project",
+          "patterns": [{ "include": "#general" }]
         },
 
         {
@@ -80,7 +82,8 @@
               "beginCaptures": {
                 "1": { "name": "keyword.language.dune-project" }
               },
-              "contentName": "variable.other.declaration.dune-project"
+              "contentName": "variable.other.declaration.dune-project",
+              "patterns": [{ "include": "#general" }]
             },
 
             {
@@ -156,7 +159,8 @@
               "beginCaptures": {
                 "1": { "name": "keyword.language.dune-project" }
               },
-              "contentName": "variable.other.declaration.dune-project"
+              "contentName": "variable.other.declaration.dune-project",
+              "patterns": [{ "include": "#general" }]
             },
 
             {
@@ -202,7 +206,8 @@
               "beginCaptures": {
                 "1": { "name": "keyword.language.dune-project" }
               },
-              "contentName": "variable.other.declaration.dune-project"
+              "contentName": "variable.other.declaration.dune-project",
+              "patterns": [{ "include": "#general" }]
             },
 
             {
@@ -222,7 +227,7 @@
 
         {
           "comment": "using",
-          "begin": "\\(\\s*(using) (menhir)?\\b",
+          "begin": "\\(\\s*(using)(\\s+menhir)?\\b",
           "end": "\\)",
           "beginCaptures": {
             "1": { "name": "keyword.language.dune-project" },
@@ -244,7 +249,8 @@
           "beginCaptures": {
             "1": { "name": "keyword.language.dune-project" }
           },
-          "contentName": "constant.language.dune-project"
+          "contentName": "constant.language.dune-project",
+          "patterns": [{ "include": "#general" }]
         },
 
         {
@@ -346,6 +352,14 @@
           "match": "\\b(true|false)\\b"
         },
         {
+          "comment": "variable",
+          "begin": "%\\{",
+          "end": "\\}",
+          "beginCaptures": [{ "name": "keyword.operator.dune" }],
+          "endCaptures": [{ "name": "keyword.operator.dune" }],
+          "patterns": [{ "include": "#variables" }]
+        },
+        {
           "comment": "boolean/predicate language",
           "begin": "\\(\\s*(=|<>|>=|<=|<|>)",
           "end": "\\)",
@@ -360,12 +374,13 @@
           "patterns": [{ "include": "#general" }]
         },
         {
-          "comment": "variable",
-          "begin": "%\\{",
-          "end": "\\}",
-          "beginCaptures": [{ "name": "keyword.operator.dune" }],
-          "endCaptures": [{ "name": "keyword.operator.dune" }],
-          "patterns": [{ "include": "#variables" }]
+          "comment": "ordered set language",
+          "begin": "\\(",
+          "end": "\\)",
+          "patterns": [
+            { "name": "keyword.operator.dune", "match": "/" },
+            { "include": "#general" }
+          ]
         }
       ]
     },

--- a/syntaxes/dune-workspace.json
+++ b/syntaxes/dune-workspace.json
@@ -1,0 +1,350 @@
+{
+  "name": "ocaml.dune-workspace",
+  "scopeName": "source.ocaml.dune-workspace",
+  "fileTypes": ["dune-workspace"],
+  "patterns": [{ "include": "#stanzas" }, { "include": "#general" }],
+  "repository": {
+    "stanzas": {
+      "patterns": [
+        {
+          "comment": "lang",
+          "begin": "\\(\\s*(lang)\\s+(dune)\\b",
+          "end": "\\)",
+          "beginCaptures": {
+            "1": { "name": "keyword.language.dune-workspace" },
+            "2": { "name": "keyword.language.dune-workspace" }
+          },
+          "patterns": [{ "include": "#general" }]
+        },
+
+        {
+          "comment": "profile",
+          "begin": "\\(\\s*(profile)\\b",
+          "end": "\\)",
+          "beginCaptures": {
+            "1": { "name": "keyword.language.dune-workspace" }
+          },
+          "contentName": "variable.other.declaration.dune-project",
+          "patterns": [{ "include": "#general" }]
+        },
+
+        {
+          "comment": "env",
+          "begin": "\\(\\s*(env)\\b",
+          "end": "\\)",
+          "beginCaptures": {
+            "1": { "name": "keyword.language.dune-workspace" }
+          },
+          "patterns": [{ "include": "#general" }]
+        },
+
+        {
+          "comment": "context",
+          "begin": "\\(\\s*(context)\\b",
+          "end": "\\)",
+          "beginCaptures": {
+            "1": { "name": "keyword.language.dune-workspace" }
+          },
+          "patterns": [
+            {
+              "comment": "default",
+              "name": "keyword.language.dune-workspace",
+              "match": "\\b(default)\\b"
+            },
+            {
+              "comment": "opam/default",
+              "begin": "\\(\\s*(opam|default)\\b",
+              "end": "\\)",
+              "beginCaptures": {
+                "1": { "name": "keyword.language.dune-workspace" }
+              },
+              "patterns": [
+                {
+                  "comment": "opam switch",
+                  "begin": "\\(\\s*(switch)\\b",
+                  "end": "\\)",
+                  "beginCaptures": {
+                    "1": { "name": "keyword.language.dune-workspace" }
+                  },
+                  "patterns": [{ "include": "#general" }]
+                },
+
+                {
+                  "comment": "name",
+                  "begin": "\\(\\s*(name)\\b",
+                  "end": "\\)",
+                  "beginCaptures": {
+                    "1": { "name": "keyword.language.dune-workspace" }
+                  },
+                  "patterns": [{ "include": "#general" }]
+                },
+
+                {
+                  "comment": "root",
+                  "begin": "\\(\\s*(root)\\b",
+                  "end": "\\)",
+                  "beginCaptures": {
+                    "1": { "name": "keyword.language.dune-workspace" }
+                  },
+                  "patterns": [{ "include": "#general" }]
+                },
+
+                {
+                  "comment": "merlin",
+                  "begin": "\\(\\s*(merlin)\\b",
+                  "end": "\\)",
+                  "beginCaptures": {
+                    "1": { "name": "keyword.language.dune-workspace" }
+                  },
+                  "patterns": [{ "include": "#general" }]
+                },
+
+                {
+                  "comment": "profile",
+                  "begin": "\\(\\s*(profile)\\b",
+                  "end": "\\)",
+                  "beginCaptures": {
+                    "1": { "name": "keyword.language.dune-workspace" }
+                  },
+                  "patterns": [{ "include": "#general" }]
+                },
+
+                {
+                  "comment": "env",
+                  "begin": "\\(\\s*(env)\\b",
+                  "end": "\\)",
+                  "beginCaptures": {
+                    "1": { "name": "keyword.language.dune-workspace" }
+                  },
+                  "patterns": [{ "include": "#general" }]
+                },
+
+                {
+                  "comment": "toolchain",
+                  "begin": "\\(\\s*(toolchain)\\b",
+                  "end": "\\)",
+                  "beginCaptures": {
+                    "1": { "name": "keyword.language.dune-workspace" }
+                  },
+                  "patterns": [{ "include": "#general" }]
+                },
+
+                {
+                  "comment": "host",
+                  "begin": "\\(\\s*(host)\\b",
+                  "end": "\\)",
+                  "beginCaptures": {
+                    "1": { "name": "keyword.language.dune-workspace" }
+                  },
+                  "patterns": [{ "include": "#general" }]
+                },
+
+                {
+                  "comment": "paths",
+                  "begin": "\\(\\s*(paths)\\b",
+                  "end": "\\)",
+                  "beginCaptures": {
+                    "1": { "name": "keyword.language.dune-workspace" }
+                  },
+                  "patterns": [{ "include": "#general" }]
+                },
+
+                {
+                  "comment": "fdo",
+                  "begin": "\\(\\s*(fdo)\\b",
+                  "end": "\\)",
+                  "beginCaptures": {
+                    "1": { "name": "keyword.language.dune-workspace" }
+                  },
+                  "patterns": [{ "include": "#general" }]
+                },
+
+                {
+                  "comment": "disable_dynamically_linked_foreign_archives",
+                  "begin": "\\(\\s*(disable_dynamically_linked_foreign_archives)\\b",
+                  "end": "\\)",
+                  "beginCaptures": {
+                    "1": { "name": "keyword.language.dune-workspace" }
+                  },
+                  "patterns": [{ "include": "#general" }]
+                },
+
+                {
+                  "comment": "targets",
+                  "begin": "\\(\\s*(targets)\\b",
+                  "end": "\\)",
+                  "beginCaptures": {
+                    "1": { "name": "keyword.language.dune-workspace" }
+                  },
+                  "patterns": [{ "include": "#general" }]
+                },
+
+                { "include": "#general" }
+              ]
+            },
+            { "include": "#general" }
+          ]
+        }
+      ]
+    },
+
+    "general": {
+      "patterns": [
+        {
+          "name": "comment.line.dune",
+          "begin": ";",
+          "end": "$"
+        },
+        {
+          "name": "string.quoted.line.dune",
+          "begin": "\"\\\\\\|",
+          "end": "$",
+          "patterns": [{ "include": "#escape-characters" }]
+        },
+        {
+          "name": "string.quoted.line.dune",
+          "begin": "\"\\\\>",
+          "end": "$"
+        },
+        {
+          "name": "string.quoted.double.dune",
+          "begin": "\"",
+          "end": "\"",
+          "patterns": [{ "include": "#escape-characters" }]
+        },
+        {
+          "comment": "symbol",
+          "name": "constant.symbol.dune",
+          "match": "(:[a-zA-Z_-]+)\\b"
+        },
+        {
+          "comment": "number or version",
+          "name": "constant.numeric.dune",
+          "match": "\\b([0-9](\\.[0-9]+)+)\\b"
+        },
+        {
+          "comment": "true or false",
+          "name": "constant.language.dune",
+          "match": "\\b(true|false)\\b"
+        },
+        {
+          "comment": "variable",
+          "begin": "%\\{",
+          "end": "\\}",
+          "beginCaptures": [{ "name": "keyword.operator.dune" }],
+          "endCaptures": [{ "name": "keyword.operator.dune" }],
+          "patterns": [{ "include": "#variables" }]
+        },
+        {
+          "comment": "boolean/predicate language",
+          "begin": "\\(\\s*(=|<>|>=|<=|<|>)",
+          "end": "\\)",
+          "beginCaptures": { "1": { "name": "keyword.operator.dune" } },
+          "patterns": [{ "include": "#general" }]
+        },
+        {
+          "comment": "boolean/predicate language",
+          "begin": "\\(\\s*(and|or|not)\\b",
+          "end": "\\)",
+          "beginCaptures": { "1": { "name": "keyword.operator.dune" } },
+          "patterns": [{ "include": "#general" }]
+        },
+        {
+          "comment": "ordered set language",
+          "begin": "\\(",
+          "end": "\\)",
+          "patterns": [
+            { "name": "keyword.operator.dune", "match": "/" },
+            { "include": "#general" }
+          ]
+        }
+      ]
+    },
+
+    "escape-characters": {
+      "patterns": [
+        {
+          "comment": "escaped newline",
+          "name": "constant.character.escape.dune",
+          "match": "\\\\$"
+        },
+        {
+          "comment": "escaped character",
+          "name": "constant.character.escape.dune",
+          "match": "\\\\(n|r|b|t|\\\\|\")"
+        },
+        {
+          "comment": "character from decimal ASCII code",
+          "name": "constant.character.escape.dune",
+          "match": "\\\\[0-9]{3}"
+        },
+        {
+          "comment": "character from hexadecimal ASCII code",
+          "name": "constant.character.escape.dune",
+          "match": "\\\\x[0-9A-Fa-f]{2}"
+        },
+        {
+          "comment": "escaped variable",
+          "begin": "(\\%\\{)",
+          "end": "(\\})",
+          "beginCaptures": [{ "name": "constant.character.escape.dune" }],
+          "endCaptures": [{ "name": "constant.character.escape.dune" }],
+          "patterns": [{ "include": "#variables" }]
+        }
+      ]
+    },
+
+    "variables": {
+      "patterns": [
+        {
+          "name": "keyword.operator.variable.dune",
+          "match": ":"
+        },
+        {
+          "name": "constant.language.variable.dune",
+          "match": "\\b(project_root|workspace_root)\\b"
+        },
+        {
+          "name": "constant.language.variable.dune",
+          "match": "\\b(CC|CXX)\\b"
+        },
+        {
+          "name": "constant.language.variable.dune",
+          "match": "\\b(ocaml_bin|ocaml|ocamlc|ocamlopt|ocaml_version|ocaml_where|ocaml-config)\\b"
+        },
+        {
+          "name": "constant.language.variable.dune",
+          "match": "\\b(profile|null|context_name|ignoring_promoted_rule)\\b"
+        },
+        {
+          "name": "constant.language.variable.dune",
+          "match": "\\b(ext_obj|ext_asm|ext_lib|ext_dll|ext_exe|ext_plugin)\\b"
+        },
+        {
+          "name": "constant.language.variable.dune",
+          "match": "\\b(arch_sixtyfour|architecture|os_type|model|system)\\b"
+        },
+        {
+          "name": "constant.language.variable.dune",
+          "match": "\\b(cmo|cmi|cma|cmx|cmxa)\\b"
+        },
+        {
+          "name": "constant.language.variable.action.dune",
+          "match": "\\^"
+        },
+        {
+          "name": "constant.language.variable.action.dune",
+          "match": "\\b(targets|target|deps|dep|exe|bin|version)\\b"
+        },
+        {
+          "name": "constant.language.variable.action.dune",
+          "match": "\\b(lib-available|lib-private|libexec-private|libexec|lib)\\b"
+        },
+        {
+          "name": "constant.language.variable.action.dune",
+          "match": "\\b(read-lines|read-strings|read)\\b"
+        }
+      ]
+    }
+  }
+}

--- a/syntaxes/dune.json
+++ b/syntaxes/dune.json
@@ -1,6 +1,6 @@
 {
   "name": "ocaml.dune",
-  "scopeName": "source.dune",
+  "scopeName": "source.ocaml.dune",
   "fileTypes": ["dune", "jbuild"],
   "patterns": [
     {


### PR DESCRIPTION
Adds syntax highlighting for dune-workspace files:

![dune-workspace](https://user-images.githubusercontent.com/25037249/80289953-f9d84b00-86f6-11ea-93f3-0c26816b5875.png)

I will rewrite the syntax highlighting for `dune` files after this.