### PR TITLE
fix ocaml character highlighting

### DIFF
--- a/syntaxes/ocaml.json
+++ b/syntaxes/ocaml.json
@@ -142,42 +142,42 @@
       "patterns": [
         {
           "comment": "character literal",
-          "name": "constant.character.ocaml",
+          "name": "string.quoted.other.ocaml constant.character.ocaml",
           "match": "'.'"
         },
         {
           "comment": "character literal from escaped backslash",
-          "name": "constant.character.ocaml",
+          "name": "string.quoted.other.ocaml constant.character.ocaml",
           "match": "'(\\\\\\\\)'",
           "captures": { "1": { "name": "constant.character.escape.ocaml" } }
         },
         {
           "comment": "character literal from escaped quote or whitespace",
-          "name": "constant.character.ocaml",
+          "name": "string.quoted.other.ocaml constant.character.ocaml",
           "match": "'(\\\\[\"'ntbr ])'",
           "captures": { "1": { "name": "constant.character.escape.ocaml" } }
         },
         {
           "comment": "character literal from decimal ASCII code",
-          "name": "constant.character.ocaml",
+          "name": "string.quoted.other.ocaml constant.character.ocaml",
           "match": "'(\\\\[0-9]{3})'",
           "captures": { "1": { "name": "constant.character.escape.ocaml" } }
         },
         {
           "comment": "character literal from hexadecimal ASCII code",
-          "name": "constant.character.ocaml",
+          "name": "string.quoted.other.ocaml constant.character.ocaml",
           "match": "'(\\\\x[0-9A-Fa-f]{2})'",
           "captures": { "1": { "name": "constant.character.escape.ocaml" } }
         },
         {
           "comment": "character literal from octal ASCII code",
-          "name": "constant.character.ocaml",
+          "name": "string.quoted.other.ocaml constant.character.ocaml",
           "match": "'(\\\\o[0-3][0-7]{2})'",
           "captures": { "1": { "name": "constant.character.escape.ocaml" } }
         },
         {
           "comment": "character literal from unknown escape sequence",
-          "name": "constant.character.ocaml",
+          "name": "string.quoted.other.ocaml constant.character.ocaml",
           "match": "'(\\\\.)'",
           "captures": {
             "1": { "name": "invalid.illegal.unknown-escape.ocaml" }


### PR DESCRIPTION
Currently if users have an extension that highlights parentheses like [Bracket Pair Colorizer](https://marketplace.visualstudio.com/items?itemName=CoenraadS.bracket-pair-colorizer-2), parentheses are incorrectly highlighted inside character literals.

This adds the `string.quoted.other.ocaml` tag to character literals so symbols are not highlighted inside them.

| Old | New |
| - | - |
|![old](https://user-images.githubusercontent.com/25037249/80895645-e9e2dd00-8c9b-11ea-8f81-7ef41feb4c82.png)|![new](https://user-images.githubusercontent.com/25037249/80895648-ec453700-8c9b-11ea-9bac-8675f50ed50b.png)|

