### PR TITLE
keyword highlighting for github slash

### DIFF
--- a/syntaxes/dune-project.json
+++ b/syntaxes/dune-project.json
@@ -280,7 +280,7 @@
               },
               "patterns": [
                 {
-                  "name": "keyword.operator.dune-project",
+                  "name": "keyword.language.dune-project",
                   "match": "/"
                 },
                 { "include": "#general" }


### PR DESCRIPTION
Highlights the slash for `github` sources inside `dune-project` files as a keyword instead of an operator.
![image](https://user-images.githubusercontent.com/25037249/80896050-0e8c8400-8c9f-11ea-9c7b-7c1eaf0791a5.png)


Pictured is the old version. With this change, the slash will be the same color as the `github`.