### PR TITLE
Tweak OCaml Syntax Highlighting - external declaration and bindings

### DIFF
--- a/syntaxes/ocaml.json
+++ b/syntaxes/ocaml.json
@@ -208,11 +208,12 @@
         },
         {
           "comment": "let expression",
-          "match": "\\b(let)\\s+(rec\\s+)?([a-z_][A-Za-z0-9_']*)",
+          "match": "\\b(let)\\s+(rec\\s+)?(lazy\\s+)?([a-z_][A-Za-z0-9_']*)\\s*(?==|:)",
           "captures": {
             "1": { "name": "keyword.ocaml" },
             "2": { "name": "keyword.ocaml" },
-            "3": { "name": "entity.name.function.binding.ocaml" }
+            "3": { "name": "keyword.ocaml" },
+            "4": { "name": "entity.name.function.binding.ocaml" }
           }
         },
         {
@@ -227,7 +228,7 @@
         },
         {
           "comment": "and declaration for let bindings, type declarations, class bindings, or class type definitions",
-          "match": "\\b(and)\\s+(virtual\\s+)?(_\\s+|'[A-Za-z][A-Za-z0-9_']*\\s+|\\(.*\\)\\s+)?([a-z_][A-Za-z0-9_']*)",
+          "match": "\\b(and)\\s+((?:virtual|lazy)\\s+)?(_\\s+|'[A-Za-z][A-Za-z0-9_']*\\s+|\\(.*\\)\\s+)?([a-z_][A-Za-z0-9_']*)\\s*(?==|:|$)",
           "captures": {
             "1": { "name": "keyword.ocaml" },
             "2": { "name": "keyword.ocaml" },
@@ -237,7 +238,7 @@
         },
         {
           "comment": "using binding operators",
-          "match": "\\b(let|and)([$&*+\\-/=>@^|<][!?$&*+\\-/=>@^|%:]*)\\s*([a-z_][A-Za-z0-9_']*)",
+          "match": "\\b(let|and)([$&*+\\-/=>@^|<][!?$&*+\\-/=>@^|%:]*)\\s*(lazy\\s+)?([a-z_][A-Za-z0-9_']*)\\s*(?==|:)",
           "captures": {
             "1": { "name": "keyword.ocaml" },
             "2": { "name": "keyword.ocaml" },
@@ -245,12 +246,11 @@
           }
         },
         {
-          "comment": "external declaration assigned to string",
-          "begin": "\\b(external)\\s+([a-z_][A-Za-z0-9_']*)?(.*=)",
+          "comment": "external declaration",
+          "begin": "\\b(external)\\s+([a-z_][A-Za-z0-9_']*)?",
           "beginCaptures": {
             "1": { "name": "keyword.ocaml" },
-            "2": { "name": "entity.name.function.binding.ocaml" },
-            "3": { "patterns": [{ "include": "source.ocaml" }] }
+            "2": { "name": "entity.name.function.binding.ocaml" }
           },
           "end": "$",
           "patterns": [
@@ -259,16 +259,9 @@
               "name": "string.quoted.double.ocaml",
               "begin": "\"",
               "end": "\""
-            }
+            },
+            { "include": "source.ocaml" }
           ]
-        },
-        {
-          "comment": "external declaration",
-          "match": "\\b(external)\\s+([a-z_][A-Za-z0-9_']*)",
-          "captures": {
-            "1": { "name": "keyword.ocaml" },
-            "2": { "name": "entity.name.function.binding.ocaml" }
-          }
         },
         {
           "comment": "first class module packing",


### PR DESCRIPTION
- Attributes should be highlighted in external declarations
- Bindings are only highlighted when a single variable is introduced

| Old | New |
| - | - |
| ![old](https://user-images.githubusercontent.com/25037249/81039843-e481c000-8e5e-11ea-8311-8448ec63530c.png) | ![new](https://user-images.githubusercontent.com/25037249/81039846-e6e41a00-8e5e-11ea-942d-dbbc92b08b12.png) |


In the future, the grammar may be modified to highlight bindings inside any pattern.
