### PR TITLE
Discover esy in parent folders

### DIFF
--- a/src/Promise.ml
+++ b/src/Promise.ml
@@ -25,6 +25,11 @@ module Array = struct
            | None -> None
            | Some (Some _ as x) -> x
            | Some None -> assert false)
+
+  let filterMap (type a b) (f : a -> b option t) (a : a array) : b array t =
+    let open O in
+    Array.map f a |> Js.Promise.all >>| fun a ->
+    Belt.Array.keepMap a (fun x -> x)
 end
 
 module Result = struct

--- a/src/esy.ml
+++ b/src/esy.ml
@@ -41,13 +41,11 @@ module Discover = struct
              | None -> None
              | Some json ->
                if
-                 propertyExists json "dependencies"
-                 || propertyExists json "devDependencies"
+                 ( propertyExists json "dependencies"
+                 || propertyExists json "devDependencies" )
+                 && propertyExists json "esy"
                then
-                 if propertyExists json "esy" then
-                   Some projectRoot
-                 else
-                   Some (hiddenEsyDir projectRoot)
+                 Some projectRoot
                else
                  None)
     | file -> (

--- a/src/esy.ml
+++ b/src/esy.ml
@@ -100,7 +100,8 @@ module Discover = struct
 
   let run ~dir : Path.t list Promise.t =
     dir |> getUpstreamDirs |> Array.of_list |> Array.map parseDir |> Promise.all
-    |> Promise.map (fun res -> res |> Array.to_list |> Array.concat |> foldResults)
+    |> Promise.map (fun res ->
+           res |> Array.to_list |> Array.concat |> foldResults)
 end
 
 let discover = Discover.run

--- a/src/path.ml
+++ b/src/path.ml
@@ -26,3 +26,8 @@ let relative_all p xs = List.fold_left Filename.concat p xs
 let join x y = Filename.concat x y
 
 let withExt x ~ext = x ^ ext
+
+let split x =
+  x |> Js.String.split sep |> Array.to_list |> List.filter (fun p -> p != "")
+
+let concat x = sep ^ (x |> Array.of_list |> Js.Array.joinWith sep)

--- a/src/path.ml
+++ b/src/path.ml
@@ -27,7 +27,9 @@ let join x y = Filename.concat x y
 
 let withExt x ~ext = x ^ ext
 
-let split x =
-  x |> Js.String.split sep |> Array.to_list |> List.filter (fun p -> p != "")
-
-let concat x = sep ^ (x |> Array.of_list |> Js.Array.joinWith sep)
+let parent x =
+  match x |> Js.String.split sep with
+  | [||]
+  | [| "" |] ->
+    None
+  | x -> Some (x |> Js.Array.slice ~start:0 ~end_:~-1 |> Js.Array.joinWith sep)

--- a/src/path.mli
+++ b/src/path.mli
@@ -24,6 +24,4 @@ val join : t -> t -> t
 
 val withExt : t -> ext:string -> t
 
-val split : t -> string list
-
-val concat : string list -> t
+val parent : t -> t option

--- a/src/path.mli
+++ b/src/path.mli
@@ -23,3 +23,7 @@ val relative_all : t -> string list -> t
 val join : t -> t -> t
 
 val withExt : t -> ext:string -> t
+
+val split : t -> string list
+
+val concat : string list -> t


### PR DESCRIPTION
Right now we only looking for esy in projectRoot, but sometimes esy can be configured in some other parent folder.

This is a dirty implementation of looking in parent directories. Is there a better way to do it? cc @rgrinberg @prometheansacrifice 