### PR TITLE
Improve OCaml Syntax Highlighting

### DIFF
--- a/syntaxes/ocaml.json
+++ b/syntaxes/ocaml.json
@@ -211,7 +211,7 @@
         },
         {
           "comment": "let expression",
-          "match": "\\b(let)\\s+(rec\\s+)?(lazy\\s+)?([a-z_][A-Za-z0-9_']*)\\s*(?!\\s*,)",
+          "match": "\\b(let)\\s+(rec\\s+)?(lazy\\s+)?([a-z_][A-Za-z0-9_']*)\\b(?!\\s*,)",
           "captures": {
             "1": { "name": "keyword.ocaml" },
             "2": { "name": "keyword.ocaml" },
@@ -231,7 +231,7 @@
         },
         {
           "comment": "and declaration for let bindings, type declarations, class bindings, or class type definitions",
-          "match": "\\b(and)\\s+((?:virtual|lazy)\\s+)?(_\\s+|'[A-Za-z][A-Za-z0-9_']*\\s+|\\(.*\\)\\s+)?([a-z_][A-Za-z0-9_']*)\\s*(?!\\s*,)",
+          "match": "\\b(and)\\s+((?:virtual|lazy)\\s+)?(_\\s+|'[A-Za-z][A-Za-z0-9_']*\\s+|\\(.*\\)\\s+)?([a-z_][A-Za-z0-9_']*)\\b(?!\\s*,)",
           "captures": {
             "1": { "name": "keyword.ocaml" },
             "2": { "name": "keyword.ocaml" },
@@ -241,7 +241,7 @@
         },
         {
           "comment": "using binding operators",
-          "match": "\\b(let|and)([$&*+\\-/=>@^|<][!?$&*+\\-/=>@^|%:]*)\\s*(lazy\\s+)?([a-z_][A-Za-z0-9_']*)\\s*(?!\\s*,)",
+          "match": "\\b(let|and)([$&*+\\-/=>@^|<][!?$&*+\\-/=>@^|%:]*)\\s*(lazy\\s+)?([a-z_][A-Za-z0-9_']*)\\b(?!\\s*,)",
           "captures": {
             "1": { "name": "keyword.ocaml" },
             "2": { "name": "keyword.ocaml" },

--- a/syntaxes/ocaml.json
+++ b/syntaxes/ocaml.json
@@ -210,6 +210,14 @@
           }
         },
         {
+          "comment": "local open/exception/module",
+          "match": "\\b(let)\\s+(open|exception|module)\\b",
+          "captures": {
+            "1": { "name": "keyword.ocaml" },
+            "2": { "name": "keyword.ocaml" }
+          }
+        },
+        {
           "comment": "let expression",
           "match": "\\b(let)\\s+(rec\\s+)?(lazy\\s+)?([a-z_][A-Za-z0-9_']*)\\b(?!\\s*,)",
           "captures": {

--- a/syntaxes/ocaml.json
+++ b/syntaxes/ocaml.json
@@ -78,8 +78,11 @@
         {
           "comment": "quoted string literal",
           "name": "string.quoted.braced.ocaml",
-          "begin": "\\{[a-z_]*\\|",
+          "begin": "\\{(%%?[A-Za-z_][A-Za-z0-9_']*(\\.[A-Za-z_][A-Za-z0-9_']*)*\\s*)?[a-z_]*\\|",
           "end": "\\|[a-z_]*\\}",
+          "beginCaptures": {
+            "1": { "patterns": [{ "include": "source.ocaml" }] }
+          },
           "patterns": [{ "include": "#strings" }]
         },
         {

--- a/syntaxes/ocaml.json
+++ b/syntaxes/ocaml.json
@@ -211,7 +211,7 @@
         },
         {
           "comment": "let expression",
-          "match": "\\b(let)\\s+(rec\\s+)?(lazy\\s+)?([a-z_][A-Za-z0-9_']*)\\s*(?==|:)",
+          "match": "\\b(let)\\s+(rec\\s+)?(lazy\\s+)?([a-z_][A-Za-z0-9_']*)\\s*(?!\\s*,)",
           "captures": {
             "1": { "name": "keyword.ocaml" },
             "2": { "name": "keyword.ocaml" },
@@ -231,7 +231,7 @@
         },
         {
           "comment": "and declaration for let bindings, type declarations, class bindings, or class type definitions",
-          "match": "\\b(and)\\s+((?:virtual|lazy)\\s+)?(_\\s+|'[A-Za-z][A-Za-z0-9_']*\\s+|\\(.*\\)\\s+)?([a-z_][A-Za-z0-9_']*)\\s*(?==|:|$)",
+          "match": "\\b(and)\\s+((?:virtual|lazy)\\s+)?(_\\s+|'[A-Za-z][A-Za-z0-9_']*\\s+|\\(.*\\)\\s+)?([a-z_][A-Za-z0-9_']*)\\s*(?!\\s*,)",
           "captures": {
             "1": { "name": "keyword.ocaml" },
             "2": { "name": "keyword.ocaml" },
@@ -241,7 +241,7 @@
         },
         {
           "comment": "using binding operators",
-          "match": "\\b(let|and)([$&*+\\-/=>@^|<][!?$&*+\\-/=>@^|%:]*)\\s*(lazy\\s+)?([a-z_][A-Za-z0-9_']*)\\s*(?==|:)",
+          "match": "\\b(let|and)([$&*+\\-/=>@^|<][!?$&*+\\-/=>@^|%:]*)\\s*(lazy\\s+)?([a-z_][A-Za-z0-9_']*)\\s*(?!\\s*,)",
           "captures": {
             "1": { "name": "keyword.ocaml" },
             "2": { "name": "keyword.ocaml" },


### PR DESCRIPTION


Closes #180 
OCaml Syntax Highlighting for Quoted Extensions: 
| Old | New |
| - | - |
| ![old](https://user-images.githubusercontent.com/25037249/81211608-79340d00-8f88-11ea-85ca-8b09eeb4091f.png) | ![new](https://user-images.githubusercontent.com/25037249/81211614-7b966700-8f88-11ea-999b-a5fc3ac8b11a.png) | 

Also fixes a fatal flaw in #175 that prevented function declarations from being highlighted:

| Old | New |
| - | - |
| ![old](https://user-images.githubusercontent.com/25037249/81213036-a2ee3380-8f8a-11ea-9cd2-16c7257aebb7.png) | ![new](https://user-images.githubusercontent.com/25037249/81213046-a681ba80-8f8a-11ea-9b8a-99a801a0cc0c.png) | 

