### PR TITLE
Fix tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # VSCode OCaml Platform
 
-[![Main workflow](https://img.shields.io/github/workflow/status/ocamllabs/vscode-ocaml-platform/Main%20workflow)](https://github.com/ocamllabs/vscode-ocaml-platform/actions?query=workflow%3A%22Main+workflow%22)
+[![Main workflow](https://img.shields.io/github/workflow/status/ocamllabs/vscode-ocaml-platform/Main%20workflow?branch=master)](https://github.com/ocamllabs/vscode-ocaml-platform/actions?query=workflow%3A%22Main+workflow%22+branch%3Amaster)
 
 Visual Studio Code extension for OCaml and relevant tools.
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # VSCode OCaml Platform
 
-[![Main workflow](https://github.com/ocamllabs/vscode-ocaml-platform/workflows/Main%20workflow/badge.svg?branch=master)](https://github.com/ocamllabs/vscode-ocaml-platform/actions)
+[![Main workflow](https://img.shields.io/github/workflow/status/ocamllabs/vscode-ocaml-platform/Main%20workflow)](https://github.com/ocamllabs/vscode-ocaml-platform/actions?query=workflow%3A%22Main+workflow%22)
 
 Visual Studio Code extension for OCaml and relevant tools.
 

--- a/src/CheckBucklescriptCompat.ml
+++ b/src/CheckBucklescriptCompat.ml
@@ -1,4 +1,6 @@
-open Import
+let mergeDicts dict1 dict2 =
+  Js.Dict.fromArray
+    (Js.Array.concat (Js.Dict.entries dict1) (Js.Dict.entries dict2))
 
 let processDeps dependencies =
   match Js.Dict.get dependencies "bs-platform" with

--- a/src/import.ml
+++ b/src/import.ml
@@ -23,10 +23,6 @@ let propertyExists json property =
 let getSubDict dict key =
   ((dict |. Js.Dict.get) key |. Belt.Option.flatMap) Js.Json.decodeObject
 
-let mergeDicts dict1 dict2 =
-  Js.Dict.fromArray
-    (Js.Array.concat (Js.Dict.entries dict1) (Js.Dict.entries dict2))
-
 let hiddenEsyDir root = Path.(root / ".vscode" / "esy")
 
 module Result = struct


### PR DESCRIPTION
`CheckBucklescriptCompat` was bringing `Import` module which imported `vscode`, which made jest failed for some reason.

Just inlining `mergeDicts` in `CheckBucklescriptCompat` (it's not used anywhere else) fixes the problem.

Also removed svg usage in readme, which apparently made a subsequent "Package extension" step [fail](url). 

Successful run: https://github.com/jchavarri/vscode-ocaml-platform/actions/runs/99952913.