### PR TITLE
[CI] Cache esy, opam and yarn folders

### DIFF
--- a/.github/workflows/print_esy_cache.js
+++ b/.github/workflows/print_esy_cache.js
@@ -1,0 +1,13 @@
+const fs = require("fs");
+const os = require("os");
+const path = require("path");
+
+const ESY_FOLDER = process.env.ESY__PREFIX
+  ? process.env.ESY__PREFIX
+  : path.join(os.homedir(), ".esy");
+const esy3 = fs
+  .readdirSync(ESY_FOLDER)
+  .filter(name => name.length > 0 && name[0] === "3")
+  .sort()
+  .pop();
+console.log(`::set-output name=esy_cache::${path.join(ESY_FOLDER, esy3, "i")}`);

--- a/.github/workflows/print_esy_cache.js
+++ b/.github/workflows/print_esy_cache.js
@@ -5,9 +5,11 @@ const path = require("path");
 const ESY_FOLDER = process.env.ESY__PREFIX
   ? process.env.ESY__PREFIX
   : path.join(os.homedir(), ".esy");
+
 const esy3 = fs
   .readdirSync(ESY_FOLDER)
   .filter((name) => name.length > 0 && name[0] === "3")
   .sort()
   .pop();
-console.log(`::set-output name=esy_cache::${path.join(ESY_FOLDER, esy3, "i")}`);
+
+console.log(`::set-output name=dir::${path.join(ESY_FOLDER, esy3, "i")}`);

--- a/.github/workflows/print_esy_cache.js
+++ b/.github/workflows/print_esy_cache.js
@@ -7,7 +7,7 @@ const ESY_FOLDER = process.env.ESY__PREFIX
   : path.join(os.homedir(), ".esy");
 const esy3 = fs
   .readdirSync(ESY_FOLDER)
-  .filter(name => name.length > 0 && name[0] === "3")
+  .filter((name) => name.length > 0 && name[0] === "3")
   .sort()
   .pop();
 console.log(`::set-output name=esy_cache::${path.join(ESY_FOLDER, esy3, "i")}`);

--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -29,6 +29,11 @@ jobs:
         with:
           node-version: ${{ matrix.node-version }}
 
+      - name: Use OCaml ${{ matrix.ocaml-version }}
+        uses: avsm/setup-ocaml@v1
+        with:
+          ocaml-version: ${{ matrix.ocaml-version }}
+
       - name: Get yarn cache directory path
         id: yarn-cache-dir-path
         run: echo "::set-output name=dir::$(yarn cache dir)"
@@ -42,20 +47,19 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-yarn-
 
+      - name: Get opam root directory path
+        id: opam-root-dir-path
+        run: echo "::set-output name=dir::$(opam config var root)"
+
       - name: Try to restore .opam folder
         id: cache-opam
         uses: actions/cache@v1
         with:
-          path: ~/.opam
+          path: ${{ steps.opam-root-dir-path.outputs.dir }}
           # opam cache is coupled to esy lock files, both caches will be wiped whenever esy deps change
           key:
             ${{ runner.os }}-opam-${{ matrix.ocaml-version }}-${{
             hashFiles('**/index.json') }}
-
-      - name: Use OCaml ${{ matrix.ocaml-version }}
-        uses: avsm/setup-ocaml@v1
-        with:
-          ocaml-version: ${{ matrix.ocaml-version }}
 
       - name: Install latest esy
         run: npm install --global esy

--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -24,18 +24,10 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v2
 
-      - name: Use OCaml ${{ matrix.ocaml-version }}
-        uses: avsm/setup-ocaml@v1
-        with:
-          ocaml-version: ${{ matrix.ocaml-version }}
-
       - name: Use Node.js ${{ matrix.node-version }}
         uses: actions/setup-node@v1
         with:
           node-version: ${{ matrix.node-version }}
-
-      - name: Install latest esy
-        run: npm install --global esy
 
       - name: Get yarn cache directory path
         id: yarn-cache-dir-path
@@ -57,6 +49,14 @@ jobs:
           path: ~/.opam
           # opam cache is coupled to esy lock files, so both caches will be wiped whenever esy deps change
           key: ${{ runner.os }}-opam-${{ matrix.ocaml-version }}-${{ hashFiles('**/index.json') }}
+
+      - name: Use OCaml ${{ matrix.ocaml-version }}
+        uses: avsm/setup-ocaml@v1
+        with:
+          ocaml-version: ${{ matrix.ocaml-version }}
+
+      - name: Install latest esy
+        run: npm install --global esy
 
       - name: Try to restore esy install cache
         uses: actions/cache@v1

--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -24,53 +24,47 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v2
 
-      - name: Use Node.js ${{ matrix.node-version }}
-        uses: actions/setup-node@v1
-        with:
-          node-version: ${{ matrix.node-version }}
-
       - name: Use OCaml ${{ matrix.ocaml-version }}
         uses: avsm/setup-ocaml@v1
         with:
           ocaml-version: ${{ matrix.ocaml-version }}
 
-      - name: Get yarn cache directory path
-        id: yarn-cache-dir-path
-        run: echo "::set-output name=dir::$(yarn cache dir)"
-
-      - name: Try to restore yarn cache
-        uses: actions/cache@v1
-        id: yarn-cache # use this to check for `cache-hit` (`steps.yarn-cache.outputs.cache-hit != 'true'`)
+      - name: Use Node.js ${{ matrix.node-version }}
+        uses: actions/setup-node@v1
         with:
-          path: ${{ steps.yarn-cache-dir-path.outputs.dir }}
-          key: ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}
-          restore-keys: |
-            ${{ runner.os }}-yarn-
+          node-version: ${{ matrix.node-version }}
+
+      - name: Use latest esy
+        run: npm install --global esy
 
       - name: Get opam root directory path
         id: opam-root-dir-path
         run: echo "::set-output name=dir::$(opam config var root)"
 
-      - name: Try to restore .opam folder
+      # This step is required because esy's home directory doesn't exist at this point
+      - name: Install esy packages
+        run: esy install
+
+      - name: Get esy cache directory path
+        id: esy-cache-dir-path
+        run: node .github/workflows/print_esy_cache.js
+
+      - name: Restore opam cache
         id: cache-opam
         uses: actions/cache@v1
         with:
           path: ${{ steps.opam-root-dir-path.outputs.dir }}
           # opam cache is coupled to esy lock files, so both caches will be wiped whenever esy deps change
-          key:
-            opam-${{ matrix.os }}-${{ matrix.ocaml-version }}-${{
-            hashFiles('**/index.json') }}
+          key: opam-${{ matrix.os }}-${{ matrix.ocaml-version }}-${{ hashFiles('esy.lock/index.json') }}
           restore-keys: |
             opam-${{ matrix.os }}-${{ matrix.ocaml-version }}-
 
-      - name: Install latest esy
-        run: npm install --global esy
-
-      - name: Try to restore esy install cache
+      - name: Restore esy cache
         uses: actions/cache@v1
         with:
-          path: ~/.esy/source
-          key: source-${{ hashFiles('**/index.json') }}
+          path: ${{ steps.esy-cache-dir-path.outputs.dir }}
+          key: esy-${{ matrix.os }}-${{ hashFiles('esy.lock/index.json') }}
+          restore-keys: esy-${{ matrix.os }}-
 
       - name: Install opam packages
         if: steps.cache-opam.outputs.cache-hit != 'true'
@@ -78,25 +72,10 @@ jobs:
           opam pin ocaml-lsp-server https://github.com/ocaml/ocaml-lsp.git --no-action
           opam install ocaml-lsp-server ocamlformat reason --yes
 
-      - name: Install esy packages
-        run: esy install
-
-      - name: Print esy cache
-        id: print_esy_cache
-        run: node .github/workflows/print_esy_cache.js
-
-      - name: Try to restore esy build cache
-        id: deps-cache-macos
-        uses: actions/cache@v1
-        with:
-          path: ${{ steps.print_esy_cache.outputs.esy_cache }}
-          key: build-${{ matrix.os }}-${{ hashFiles('**/index.json') }}
-          restore-keys: build-${{ matrix.os }}-
-
-      - name: Build
+      - name: Build esy packages
+        # Cleanup build cache in case dependencies have changed
         run: |
           esy build
-          # Cleanup build cache in case dependencies have changed
           esy cleanup .
 
       - name: Install npm packages

--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -47,7 +47,7 @@ jobs:
         uses: actions/cache@v1
         with:
           path: ~/.opam
-          # opam cache is coupled to esy lock files, so both caches will be wiped whenever esy deps change
+          # opam cache is coupled to esy lock files, both caches will be wiped whenever esy deps change
           key:
             ${{ runner.os }}-opam-${{ matrix.ocaml-version }}-${{
             hashFiles('**/index.json') }}

--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -48,7 +48,9 @@ jobs:
         with:
           path: ~/.opam
           # opam cache is coupled to esy lock files, so both caches will be wiped whenever esy deps change
-          key: ${{ runner.os }}-opam-${{ matrix.ocaml-version }}-${{ hashFiles('**/index.json') }}
+          key:
+            ${{ runner.os }}-opam-${{ matrix.ocaml-version }}-${{
+            hashFiles('**/index.json') }}
 
       - name: Use OCaml ${{ matrix.ocaml-version }}
         uses: avsm/setup-ocaml@v1

--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -58,8 +58,10 @@ jobs:
           path: ${{ steps.opam-root-dir-path.outputs.dir }}
           # opam cache is coupled to esy lock files, both caches will be wiped whenever esy deps change
           key:
-            ${{ runner.os }}-opam-${{ matrix.ocaml-version }}-${{
+            opam-${{ matrix.os }}-${{ matrix.ocaml-version }}-${{
             hashFiles('**/index.json') }}
+          restore-keys: |
+            opam-${{ matrix.os }}-${{ matrix.ocaml-version }}-
 
       - name: Install latest esy
         run: npm install --global esy
@@ -83,7 +85,7 @@ jobs:
         id: print_esy_cache
         run: node .github/workflows/print_esy_cache.js
 
-      - name: Try to restore build cache
+      - name: Try to restore esy build cache
         id: deps-cache-macos
         uses: actions/cache@v1
         with:

--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -37,13 +37,59 @@ jobs:
       - name: Install latest esy
         run: npm install --global esy
 
+      - name: Get yarn cache directory path
+        id: yarn-cache-dir-path
+        run: echo "::set-output name=dir::$(yarn cache dir)"
+
+      - name: Try to restore yarn cache
+        uses: actions/cache@v1
+        id: yarn-cache # use this to check for `cache-hit` (`steps.yarn-cache.outputs.cache-hit != 'true'`)
+        with:
+          path: ${{ steps.yarn-cache-dir-path.outputs.dir }}
+          key: ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-yarn-
+
+      - name: Try to restore .opam folder
+        id: cache-opam
+        uses: actions/cache@v1
+        with:
+          path: ~/.opam
+          # opam cache is coupled to esy lock files, so both caches will be wiped whenever esy deps change
+          key: ${{ runner.os }}-opam-${{ matrix.ocaml-version }}-${{ hashFiles('**/index.json') }}
+
+      - name: Try to restore esy install cache
+        uses: actions/cache@v1
+        with:
+          path: ~/.esy/source
+          key: source-${{ hashFiles('**/index.json') }}
+
       - name: Install opam packages
+        if: steps.cache-opam.outputs.cache-hit != 'true'
         run: |
           opam pin ocaml-lsp-server https://github.com/ocaml/ocaml-lsp.git --no-action
           opam install ocaml-lsp-server ocamlformat reason --yes
 
       - name: Install esy packages
-        run: esy
+        run: esy install
+
+      - name: Print esy cache
+        id: print_esy_cache
+        run: node .github/workflows/print_esy_cache.js
+
+      - name: Try to restore build cache
+        id: deps-cache-macos
+        uses: actions/cache@v1
+        with:
+          path: ${{ steps.print_esy_cache.outputs.esy_cache }}
+          key: build-${{ matrix.os }}-${{ hashFiles('**/index.json') }}
+          restore-keys: build-${{ matrix.os }}-
+
+      - name: Build
+        run: |
+          esy build
+          # Cleanup build cache in case dependencies have changed
+          esy cleanup .
 
       - name: Install npm packages
         run: yarn --frozen-lockfile

--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -56,7 +56,7 @@ jobs:
         uses: actions/cache@v1
         with:
           path: ${{ steps.opam-root-dir-path.outputs.dir }}
-          # opam cache is coupled to esy lock files, both caches will be wiped whenever esy deps change
+          # opam cache is coupled to esy lock files, so both caches will be wiped whenever esy deps change
           key:
             opam-${{ matrix.os }}-${{ matrix.ocaml-version }}-${{
             hashFiles('**/index.json') }}

--- a/.prettierrc.json
+++ b/.prettierrc.json
@@ -1,3 +1,11 @@
 {
-  "proseWrap": "always"
+  "proseWrap": "always",
+  "overrides": [
+    {
+      "files": "*.yml",
+      "options": {
+        "proseWrap": "preserve"
+      }
+    }
+  ]
 }


### PR DESCRIPTION
This PR adds caching for all esy, yarn and opam.

- yarn caching is taken from GH actions [example](https://github.com/actions/cache/blob/master/examples.md#node---yarn).
- esy from hello-reason [workflow](https://github.com/esy-ocaml/hello-reason/tree/master/.github/workflows).
- opam is more rough, it just takes the whole opam root folder calling `opam config var root` and stores it.

There are still ~5min that are spent calling the "use OCaml" action, as I guess it creates the switch etc. This is unnecessary as the cache has everything already, but I don't know if there's a cross-platform way to just install opam. If there is, we could use it when the workflow detects a cache hit.

### Times

Before ([example](https://github.com/ocamllabs/vscode-ocaml-platform/actions/runs/100010339)): 32m 0s 

After ([example](https://github.com/jchavarri/vscode-ocaml-platform/actions/runs/100038544)): 11m 57s 