### PR TITLE
Fix Dune Formatting 

### DIFF
--- a/src/DuneFormatter.ml
+++ b/src/DuneFormatter.ml
@@ -16,7 +16,7 @@ let format (document : TextDocument.t) _options _token =
   Cmd.make ~cmd:(Path.ofString "dune") ()
   |> Promise.Result.bind (fun duneCmd ->
          Cmd.output duneCmd
-           ~args:[| "format-dune-file"; document.fileName |]
+           ~args:[| "format-dune-file"  |]
            ~stdin:documentText)
   |> Promise.map (function
        | Ok stdout -> [| TextEdit.replace fullDocumentRange stdout |]


### PR DESCRIPTION
The dune formatting should only pass the document contents through stdin. A bug that was left in passed the document fileName, which formatted the outdated version of the file.