### PR TITLE
Remove ocaml.lsp.path as a listed configuration

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,11 +43,6 @@
           "type": "object",
           "default": null,
           "description": "Determines where to find the sandbox for a given project"
-        },
-        "ocaml.lsp.path": {
-          "type": "string",
-          "default": "ocamllsp",
-          "description": "Path to the LSP binary"
         }
       }
     },


### PR DESCRIPTION
It was already unused before and listed as deleted in earlier versions.