### PR TITLE
Add support of 4.09+ multi lines errors in problem matcher

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 - Add .mld syntax highlighting
 - Add highlighting for Cppo directives in OCaml files
 - Add highlighting for more toplevel and topfind directives in OCaml files
+- OCaml problem matcher now understands multi line errors emitted by 4.09 (#229)
 
 ## 0.6.1
 

--- a/package.json
+++ b/package.json
@@ -78,11 +78,12 @@
         ],
         "pattern": [
           {
-            "regexp": "^\\s*\\bFile\\b\\s*\"(.*)\",\\s*\\bline\\b\\s*(\\d+),\\s*\\bcharacters\\b\\s*(\\d+)-(\\d+)\\s*:\\s*$",
+            "regexp": "^\\s*\\bFile\\b\\s*\"(.*)\",\\s*\\blines?\\b\\s*(\\d+)(?:-(\\d+))?,\\s*\\bcharacters\\b\\s*(\\d+)-(\\d+)\\s*:\\s*$",
             "file": 1,
             "line": 2,
-            "column": 3,
-            "endColumn": 4
+            "endLine": 3,
+            "column": 4,
+            "endColumn": 5
           },
           {
             "regexp": "^(?:\\s*\\bParse\\b\\s*)?\\s*\\b([Ee]rror|Warning)\\b\\s*(?:\\(\\s*\\bwarning\\b\\s*(\\d+)\\))?\\s*:\\s*(.*)$",


### PR DESCRIPTION
Since ocaml 4.09, when an error covers multiple lines, the message
emitted by the compiler looks like this:

```
File "robustmatch.ml", lines 33-37, characters 6-23:
Warning 8: this pattern-matching is not exhaustive.
Here is an example of a case that is not matched:
(AB, MAB, A)
```

This commit detects the presence of an eventual end line. Support of
previous version of the compiler or single line errors is preserved.