### PR TITLE
slightly simplify vscode bindings

### DIFF
--- a/src/Toolchain.ml
+++ b/src/Toolchain.ml
@@ -249,7 +249,9 @@ let makeResources kind = kind
 
 let selectAndSave () =
   let open Promise.O in
-  let workspaceFolders = Vscode.Workspace.workspaceFolders () in
+  let workspaceFolders =
+    Vscode.Workspace.workspaceFolders |. Belt.Option.getWithDefault [||]
+  in
   sandboxCandidates ~workspaceFolders >>= fun candidates ->
   selectPackageManager candidates >>| function
   | None -> None

--- a/src/bindings/Vscode.ml
+++ b/src/bindings/Vscode.ml
@@ -74,9 +74,7 @@ end
 module WorkspaceConfiguration = struct
   type t
 
-  external get' : t -> string -> Js.Json.t Js.Nullable.t = "get" [@@bs.send]
-
-  let get workspaceConfig key = get' workspaceConfig key |> Js.Nullable.toOption
+  external get : t -> string -> Js.Json.t option = "get" [@@bs.send]
 
   type configurationTarget =
     | Global [@bs.as 1]
@@ -103,16 +101,11 @@ module Workspace = struct
 
   type cancellationToken = { isCancellationRequested : bool }
 
-  external _name : string Js.Nullable.t = "name"
+  external name : string option = "name"
     [@@bs.module "vscode"] [@@bs.scope "workspace"]
 
-  let name () = Js.Nullable.toOption _name
-
-  external _workspaceFolders : Folder.t array Js.Nullable.t = "workspaceFolders"
+  external workspaceFolders : Folder.t array option = "workspaceFolders"
     [@@bs.module "vscode"] [@@bs.scope "workspace"]
-
-  let workspaceFolders () =
-    Js.Nullable.toOption _workspaceFolders |. Belt.Option.getWithDefault [||]
 
   external onDidOpenTextDocument : (TextDocument.event -> unit) -> unit
     = "onDidOpenTextDocument"
@@ -187,33 +180,28 @@ module Window = struct
     external create : ?title:string -> unit -> t = "" [@@bs.obj]
   end
 
-  external showQuickPick' :
-    string array -> QuickPickOptions.t -> string Js.Nullable.t Promise.t
+  external showQuickPick :
+    string array -> QuickPickOptions.t -> string option Promise.t
     = "showQuickPick"
     [@@bs.module "vscode"] [@@bs.scope "window"]
-
-  let showQuickPick choices quickPickOptions =
-    showQuickPick' choices quickPickOptions
-    |> Promise.map (fun choice -> choice |> Js.Nullable.toOption)
 
   external _showQuickPickItems :
        QuickPickItem.t array
     -> QuickPickOptions.t
-    -> QuickPickItem.t Js.Nullable.t Promise.t = "showQuickPick"
+    -> QuickPickItem.t option Promise.t = "showQuickPick"
     [@@bs.module "vscode"] [@@bs.scope "window"]
 
   let showQuickPickItems choices options =
     _showQuickPickItems (Array.of_list (List.map fst choices)) options
     |> Promise.map (fun choice ->
-           choice |> Js.Nullable.toOption
-           |. Belt.Option.map (fun q -> List.assq q choices))
+           choice |. Belt.Option.map (fun q -> List.assq q choices))
 
   external showInformationMessage : string -> unit Promise.t
     = "showInformationMessage"
     [@@bs.module "vscode"] [@@bs.scope "window"]
 
   external _showInformationMessage' :
-    string -> MessageItem.t array -> MessageItem.t Js.Nullable.t Promise.t
+    string -> MessageItem.t array -> MessageItem.t option Promise.t
     = "showInformationMessage"
     [@@bs.module "vscode"] [@@bs.scope "window"] [@@bs.variadic]
 
@@ -225,8 +213,7 @@ module Window = struct
     in
     _showInformationMessage' msg (choices |> List.map fst |> Array.of_list)
     |> Promise.map (fun choice ->
-           choice |> Js.Nullable.toOption
-           |. Belt.Option.map (fun q -> List.assq q choices))
+           choice |. Belt.Option.map (fun q -> List.assq q choices))
 
   external showErrorMessage : string -> 'a Promise.t = "showErrorMessage"
     [@@bs.module "vscode"] [@@bs.scope "window"]

--- a/src/bindings/Vscode.mli
+++ b/src/bindings/Vscode.mli
@@ -211,9 +211,9 @@ module Workspace : sig
 
   type cancellationToken = { isCancellationRequested : bool }
 
-  val name : unit -> string option
+  val name : string option
 
-  val workspaceFolders : unit -> Folder.t array
+  val workspaceFolders : Folder.t array option
 
   val onDidOpenTextDocument : (TextDocument.event -> unit) -> unit
 

--- a/src/settings.ml
+++ b/src/settings.ml
@@ -24,7 +24,7 @@ let get t =
       None )
 
 let set t v =
-  match Vscode.Workspace.name () with
+  match Vscode.Workspace.name with
   | None -> Promise.return ()
   | Some _ ->
     let scope = WorkspaceConfiguration.configurationTargetToJs t.scope in


### PR DESCRIPTION
Some of the functions/properties there return `undefined` if no values. Bucklescript compiles `None` option type to `undefined` (and vice-versa). So you can just type their return values as `option(t)` and bucklescript will do the conversion automatically.

See: https://bucklescript.github.io/docs/en/null-undefined-option#interoperate-with-javascript-undefined-and-null

`Js.Nullable.t` should be used when the value can be `undefined` OR `null`. For functions that can return `undefined` or `null`, a `[@bs.return nullable]` directive exists to convert it to `option` : https://bucklescript.github.io/docs/en/return-value-wrapping