### PR TITLE
Unify output channels for logging

### DIFF
--- a/src/Extension.ml
+++ b/src/Extension.ml
@@ -16,11 +16,12 @@ module Client = struct
        ; { scheme = "file"; language = "reason" }
       |]
     in
+    let outputChannel = Output.languageServerOutputChannel in
     let revealOutputChannelOn =
       Vscode.LanguageClient.RevealOutputChannelOn.tToJs Never
     in
-    Vscode.LanguageClient.clientOptions ~documentSelector ~revealOutputChannelOn
-      ()
+    Vscode.LanguageClient.clientOptions ~documentSelector ~outputChannel
+      ~revealOutputChannelOn ()
 end
 
 module Server = struct

--- a/src/Extension.ml
+++ b/src/Extension.ml
@@ -16,7 +16,7 @@ module Client = struct
        ; { scheme = "file"; language = "reason" }
       |]
     in
-    let outputChannel = Output.languageServerOutputChannel in
+    let (lazy outputChannel) = Output.languageServerOutputChannel in
     let revealOutputChannelOn =
       Vscode.LanguageClient.RevealOutputChannelOn.tToJs Never
     in

--- a/src/Output.ml
+++ b/src/Output.ml
@@ -1,0 +1,4 @@
+let languageServerOutputChannel =
+  Vscode.Window.createOutputChannel "OCaml Language Server"
+
+let extensionOutputChannel = Vscode.Window.createOutputChannel "OCaml Extension"

--- a/src/Output.ml
+++ b/src/Output.ml
@@ -1,4 +1,4 @@
 let languageServerOutputChannel =
   Vscode.Window.createOutputChannel "OCaml Language Server"
 
-let extensionOutputChannel = Vscode.Window.createOutputChannel "OCaml Extension"
+let extensionOutputChannel = Vscode.Window.createOutputChannel "OCaml Platform Extension"

--- a/src/Output.ml
+++ b/src/Output.ml
@@ -1,5 +1,5 @@
 let languageServerOutputChannel =
-  Vscode.Window.createOutputChannel "OCaml Language Server"
+  lazy (Vscode.Window.createOutputChannel "OCaml Language Server")
 
 let extensionOutputChannel =
-  Vscode.Window.createOutputChannel "OCaml Platform Extension"
+  lazy (Vscode.Window.createOutputChannel "OCaml Platform Extension")

--- a/src/Output.ml
+++ b/src/Output.ml
@@ -1,4 +1,5 @@
 let languageServerOutputChannel =
   Vscode.Window.createOutputChannel "OCaml Language Server"
 
-let extensionOutputChannel = Vscode.Window.createOutputChannel "OCaml Platform Extension"
+let extensionOutputChannel =
+  Vscode.Window.createOutputChannel "OCaml Platform Extension"

--- a/src/Output.mli
+++ b/src/Output.mli
@@ -1,5 +1,7 @@
-(** [languageServerOutputChannel] is the output channel that should be used by all ocamllsp LanguageClients *)
-val languageServerOutputChannel : Vscode.Window.OutputChannel.t
+(** [languageServerOutputChannel] is the output channel
+    that should be used by all ocamllsp LanguageClients *)
+val languageServerOutputChannel : Vscode.Window.OutputChannel.t Lazy.t
 
-(** [extensionOutputChannel] is the output channel that should be used for logs by the extension *)
-val extensionOutputChannel : Vscode.Window.OutputChannel.t
+(** [extensionOutputChannel] is the output channel
+    that should be used for logs by the extension *)
+val extensionOutputChannel : Vscode.Window.OutputChannel.t Lazy.t

--- a/src/Output.mli
+++ b/src/Output.mli
@@ -1,0 +1,5 @@
+(** [languageServerOutputChannel] is the output channel that should be used by all ocamllsp LanguageClients *)
+val languageServerOutputChannel : Vscode.Window.OutputChannel.t
+
+(** [extensionOutputChannel] is the output channel that should be used for logs by the extension *)
+val extensionOutputChannel : Vscode.Window.OutputChannel.t

--- a/src/bindings/Vscode.ml
+++ b/src/bindings/Vscode.ml
@@ -363,6 +363,27 @@ module Window = struct
     -> unit
     -> Terminal.t = "createTerminal"
     [@@bs.module "vscode"] [@@bs.scope "window"]
+
+  module OutputChannel = struct
+    type t = { name : string }
+
+    external append : t -> string -> unit = "append" [@@bs.send]
+
+    external appendLine : t -> string -> unit = "appendLine" [@@bs.send]
+
+    external clear : t -> unit = "clear" [@@bs.send]
+
+    external dispose : t -> unit = "dispose" [@@bs.send]
+
+    external hide : t -> unit = "hide" [@@bs.send]
+
+    external show : t -> ?preserveFocus:bool -> unit -> unit = "show"
+      [@@bs.send]
+  end
+
+  external createOutputChannel : string -> OutputChannel.t
+    = "createOutputChannel"
+    [@@bs.module "vscode"] [@@bs.scope "window"]
 end
 
 type memento
@@ -454,6 +475,7 @@ module LanguageClient = struct
 
   type clientOptions =
     { documentSelector : documentSelectorItem array
+    ; outputChannel : Window.OutputChannel.t [@bs.optional]
     ; revealOutputChannelOn : RevealOutputChannelOn.abs_t [@bs.optional]
     }
   [@@bs.deriving abstract]

--- a/src/bindings/Vscode.mli
+++ b/src/bindings/Vscode.mli
@@ -230,6 +230,24 @@ module Window : sig
     -> ?shellArgs:string array
     -> unit
     -> Terminal.t
+
+  module OutputChannel : sig
+    type t = { name : string }
+
+    val append : t -> string -> unit
+
+    val appendLine : t -> string -> unit
+
+    val clear : t -> unit
+
+    val dispose : t -> unit
+
+    val hide : t -> unit
+
+    val show : t -> ?preserveFocus:bool -> unit -> unit
+  end
+
+  val createOutputChannel : string -> OutputChannel.t
 end
 
 module Folder : sig
@@ -338,6 +356,7 @@ module LanguageClient : sig
 
   type clientOptions =
     { documentSelector : documentSelectorItem array
+    ; outputChannel : Window.OutputChannel.t [@bs.optional]
     ; revealOutputChannelOn : RevealOutputChannelOn.abs_t [@bs.optional]
     }
   [@@bs.deriving abstract]

--- a/src/import.ml
+++ b/src/import.ml
@@ -130,11 +130,10 @@ end = struct
 end
 
 let log fmt =
-  Printf.ksprintf
-    (Output.extensionOutputChannel |. Window.OutputChannel.appendLine)
-    fmt
+  let (lazy outputChannel) = Output.extensionOutputChannel in
+  Printf.ksprintf (outputChannel |. Window.OutputChannel.appendLine) fmt
 
 let logJson msg (fields : (string * Log.field) list) =
   let json = fields |. Js.Dict.fromList |. Json.stringifyAny ~space:2 () in
-  Output.extensionOutputChannel
-  |. Window.OutputChannel.appendLine (msg ^ " " ^ json ^ "\n")
+  let (lazy outputChannel) = Output.extensionOutputChannel in
+  outputChannel |. Window.OutputChannel.appendLine (msg ^ " " ^ json ^ "\n")

--- a/src/import.ml
+++ b/src/import.ml
@@ -96,6 +96,14 @@ module String = struct
       None
 end
 
+module Json = struct
+  include Json
+
+  external stringifyAny : 'a -> ?replacer:'b -> ?space:int -> unit -> string
+    = "stringify"
+    [@@bs.val] [@@bs.scope "JSON"]
+end
+
 let sprintf = Printf.sprintf
 
 let message kind fmt =
@@ -121,8 +129,12 @@ end = struct
   external field : _ -> field = "%identity"
 end
 
-let log fmt = Printf.ksprintf (fun x -> Js.Console.log x) fmt
+let log fmt =
+  Printf.ksprintf
+    (Output.extensionOutputChannel |. Window.OutputChannel.appendLine)
+    fmt
 
 let logJson msg (fields : (string * Log.field) list) =
-  let json = Js.Dict.fromList fields in
-  Js.Console.log2 msg json
+  let json = fields |. Js.Dict.fromList |. Json.stringifyAny ~space:2 () in
+  Output.extensionOutputChannel
+  |. Window.OutputChannel.appendLine (msg ^ " " ^ json ^ "\n")


### PR DESCRIPTION
Closes #231 

The `log` function now outputs to the *OCaml Extension* output channel.

All `LanguageClient` instances now share a single *OCaml Language Server* output channel, to avoid adding duplicate channels. Before, there were many duplicate channels with 1 or 2 log statements, but only one output channel was being used for all of the log statements.

| Before |
| - |
| ![many channels](https://user-images.githubusercontent.com/25037249/85375412-1cb29000-b4eb-11ea-892b-bafe93f6836c.png) |

These changes should make it easier for users and developers to understand what the extension and language server are doing.