### PR TITLE
Don't highlight struct keyword in mli files

### DIFF
--- a/syntaxes/ocaml.interface.json
+++ b/syntaxes/ocaml.interface.json
@@ -142,7 +142,7 @@
         {
           "comment": "reserved ocaml keyword (in interfaces)",
           "name": "keyword.other.ocaml.interface",
-          "match": "\\b(and|as|class|constraint|end|exception|external|functor|in|include|inherit|let\\s+open|module|mutable|nonrec|object|of|open|private|sig|struct|type|val|virtual|with)\\b"
+          "match": "\\b(and|as|class|constraint|end|exception|external|functor|in|include|inherit|let\\s+open|module|mutable|nonrec|object|of|open|private|sig|type|val|virtual|with)\\b"
         }
       ]
     }


### PR DESCRIPTION
I can't find any documentation of the`struct` keyword being used in .mli files, so it was probably a typo.