### PR TITLE
Fix highlighting of empty comments

### DIFF
--- a/syntaxes/ocaml.json
+++ b/syntaxes/ocaml.json
@@ -121,6 +121,11 @@
     "comments": {
       "patterns": [
         {
+          "comment": "empty comment",
+          "name": "comment.block.ocaml",
+          "match": "\\(\\*\\*\\)"
+        },
+        {
           "comment": "ocamldoc comment",
           "name": "comment.doc.ocaml",
           "begin": "\\(\\*\\*",


### PR DESCRIPTION
Previously, an empty comment `(**)` would be handled as an unclosed ocamldoc comment which is incorrect.


| Old | New |
| - | - |
| ![old](https://user-images.githubusercontent.com/25037249/86500381-6732d880-bd45-11ea-8136-125895bac1cb.png) | ![new](https://user-images.githubusercontent.com/25037249/86500385-6bf78c80-bd45-11ea-9d39-d4f16987b495.png) |



