### PR TITLE
Register ocamllex and menhir with language server

### DIFF
--- a/src/Extension.ml
+++ b/src/Extension.ml
@@ -13,6 +13,8 @@ module Client = struct
     let documentSelector : Vscode.LanguageClient.documentSelectorItem array =
       [| { scheme = "file"; language = "ocaml" }
        ; { scheme = "file"; language = "ocaml.interface" }
+       ; { scheme = "file"; language = "ocaml.ocamllex" }
+       ; { scheme = "file"; language = "ocaml.menhir" }
        ; { scheme = "file"; language = "reason" }
       |]
     in


### PR DESCRIPTION
> By the way, I just realized that we need to register `mly`, `mll` files with the server for this to work on the server side. We should probably do that first in a separate PR.

_Originally posted by @rgrinberg in https://github.com/ocamllabs/vscode-ocaml-platform/pull/270#issuecomment-653849011_