### PR TITLE
Add ocaml.debounce.server configuration option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@
 
 - Stop automatically highlighting suffixed META files (#565)
 
+- Add `ocaml.debounce.server` configuration option to control the amount of time
+  the language server waits before recognizing requests
+
 ## 1.8.1
 
 - Revert automatic installation of platform tools

--- a/README.md
+++ b/README.md
@@ -91,20 +91,21 @@ esy
 This extension provides options in VSCode's configuration settings. You can find
 the settings under `File > Preferences > Settings`.
 
-| Name                               | Description                                                                                             | Default |
-| ---------------------------------- | ------------------------------------------------------------------------------------------------------- | ------- |
-| `ocaml.sandbox`                    | Determines where to find the sandbox for a given project                                                | `null`  |
-| `ocaml.dune.autoDetect`            | Controls whether dune tasks should be automatically detected.                                           | `true`  |
-| `ocaml.trace.server`               | Controls the logging output of the language server. Valid settings are `off`, `messages`, or `verbose`. | `off`   |
-| `ocaml.useOcamlEnv`                | Controls whether to use ocaml-env for opam commands from OCaml for Windows.                             | `true`  |
-| `ocaml.terminal.shell.linux`       | The path of the shell that the sandbox terminal uses on Linux                                           | `null`  |
-| `ocaml.terminal.shell.osx`         | The path of the shell that the sandbox terminal uses on macOS                                           | `null`  |
-| `ocaml.terminal.shell.windows`     | The path of the shell that the sandbox terminal uses on Windows                                         | `null`  |
-| `ocaml.terminal.shellArgs.linux`   | The command line arguments that the sandbox terminal uses on Linux                                      | `null`  |
-| `ocaml.terminal.shellArgs.osx`     | The command line arguments that the sandbox terminal uses on macOS                                      | `null`  |
-| `ocaml.terminal.shellArgs.windows` | The command line arguments that the sandbox terminal uses on Window                                     | `null`  |
-| `ocaml.repl.path`                  | The path of the REPL that the extension uses                                                            | `null`  |
-| `ocaml.repl.args`                  | The REPL arguments that the extension uses                                                              | `null`  |
+| Name                               | Description                                                                                                 | Default |
+| ---------------------------------- | ----------------------------------------------------------------------------------------------------------- | ------- |
+| `ocaml.sandbox`                    | Determines where to find the sandbox for a given project                                                    | `null`  |
+| `ocaml.dune.autoDetect`            | Controls whether dune tasks should be automatically detected.                                               | `true`  |
+| `ocaml.trace.server`               | Controls the logging output of the language server. Valid settings are `off`, `messages`, or `verbose`.     | `off`   |
+| `ocaml.debounce.server`            | Controls the amount of time (in seconds) that the language server should wait before recognizing a request. | `0.25`  |
+| `ocaml.useOcamlEnv`                | Controls whether to use ocaml-env for opam commands from OCaml for Windows.                                 | `true`  |
+| `ocaml.terminal.shell.linux`       | The path of the shell that the sandbox terminal uses on Linux                                               | `null`  |
+| `ocaml.terminal.shell.osx`         | The path of the shell that the sandbox terminal uses on macOS                                               | `null`  |
+| `ocaml.terminal.shell.windows`     | The path of the shell that the sandbox terminal uses on Windows                                             | `null`  |
+| `ocaml.terminal.shellArgs.linux`   | The command line arguments that the sandbox terminal uses on Linux                                          | `null`  |
+| `ocaml.terminal.shellArgs.osx`     | The command line arguments that the sandbox terminal uses on macOS                                          | `null`  |
+| `ocaml.terminal.shellArgs.windows` | The command line arguments that the sandbox terminal uses on Window                                         | `null`  |
+| `ocaml.repl.path`                  | The path of the REPL that the extension uses                                                                | `null`  |
+| `ocaml.repl.args`                  | The REPL arguments that the extension uses                                                                  | `null`  |
 
 If `ocaml.terminal.shell.*` or `ocaml.terminal.shellArgs.*` is `null`, the
 configured VSCode shell and shell arguments will be used instead.

--- a/package.json
+++ b/package.json
@@ -346,6 +346,11 @@
           ],
           "default": "off"
         },
+        "ocaml.debounce.server": {
+          "description": "Controls the amount of time (in seconds) that the language server should wait before recognizing a request.",
+          "type": "number",
+          "default": "0.25"
+        },
         "ocaml.useOcamlEnv": {
           "type": "boolean",
           "default": true,


### PR DESCRIPTION
Closes #273

I think all of the logic can be implemented on the language server side with  [`workspace/configuration`](https://microsoft.github.io/language-server-protocol/specification.html#workspace_configuration) and  [`didChangeConfiguration`](https://microsoft.github.io/language-server-protocol/specification.html#workspace_didChangeConfiguration).