### PR TITLE
Highlight floating attributes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Unreleased
 
 - Fix syntax highlighting of empty comments (#276)
+- Fix syntax highlighting of floating attributes (#281)
 
 ## 0.8.0
 

--- a/syntaxes/ocaml.json
+++ b/syntaxes/ocaml.json
@@ -262,7 +262,7 @@
     },
 
     "attributes": {
-      "begin": "\\[(@|@@|@@)\\s*([a-zA-Z_]+(\\.[a-zA-Z0-9_']+)*)",
+      "begin": "\\[(@|@@|@@@)\\s*([a-zA-Z_]+(\\.[a-zA-Z0-9_']+)*)",
       "end": "\\]",
       "beginCaptures": {
         "1": { "name": "keyword.operator.attribute.ocaml" },


### PR DESCRIPTION
https://caml.inria.fr/pub/docs/manual-ocaml/attributes.html#floating-attribute

Previously, only normal attributes and item attributes were highlighted due to a typo.