### PR TITLE
Remove inconsistent Esy tests

### DIFF
--- a/test/suite/esy.test.js
+++ b/test/suite/esy.test.js
@@ -45,26 +45,6 @@ suite("Basic tests", () => {
     );
     if (process.platform != "win32" && process.platform != "win64") {
       assert.equal(
-        reasonDiagnostics.length,
-        1,
-        "There should only be one diagnostic in the Reason source file"
-      );
-      assert.equal(
-        reasonDiagnostics[0].message,
-        "Warning 26: unused variable foo."
-      );
-      assert.equal(
-        reasonDiagnostics[0].severity,
-        1,
-        "Severity of this diagnostic should be 1 (Warning). It was " +
-          reasonDiagnostics[0].severity
-      );
-      assert.equal(reasonDiagnostics[0].range.start.line, 3);
-      assert.equal(reasonDiagnostics[0].range.start.character, 6);
-      assert.equal(reasonDiagnostics[0].range.end.line, 3);
-      assert.equal(reasonDiagnostics[0].range.end.character, 9);
-
-      assert.equal(
         ocamlDiagnostics.length,
         1,
         "There should only be one diagnostic in the OCaml source file"

--- a/test/suite/esy.test.js
+++ b/test/suite/esy.test.js
@@ -30,41 +30,6 @@ suite("Basic tests", () => {
       "Must be identified as an OCaml document"
     );
 
-    function delay(timeout) {
-      return new Promise((resolve) => {
-        setTimeout(resolve, timeout);
-      });
-    }
-
-    await delay(1000);
-    let reasonDiagnostics = await vscode.languages.getDiagnostics(
-      Uri.file(path.join(projectPath, "bin", "SampleEsyApp.re"))
-    );
-    let ocamlDiagnostics = await vscode.languages.getDiagnostics(
-      Uri.file(path.join(projectPath, "bin", "CamlUtil.ml"))
-    );
-    if (process.platform != "win32" && process.platform != "win64") {
-      assert.equal(
-        ocamlDiagnostics.length,
-        1,
-        "There should only be one diagnostic in the OCaml source file"
-      );
-      assert.equal(
-        ocamlDiagnostics[0].message,
-        "Warning 26: unused variable bar."
-      );
-      assert.equal(
-        ocamlDiagnostics[0].severity,
-        1,
-        "Severity of this diagnostic should be 1 (Warning). It was " +
-          ocamlDiagnostics[0].severity
-      );
-      assert.equal(ocamlDiagnostics[0].range.start.line, 1);
-      assert.equal(ocamlDiagnostics[0].range.start.character, 6);
-      assert.equal(ocamlDiagnostics[0].range.end.line, 1);
-      assert.equal(ocamlDiagnostics[0].range.end.character, 9);
-    }
-
     // TODO: the plugin could support build related tasks
     // const expected = [
     //   { subcommand: "build", group: vscode.TaskGroup.Build },


### PR DESCRIPTION
The `There should only be one diagnostic in the Reason source file` test seem to fail in the CI randomly. 

I don't believe we've received any issues from Reason users about problems with diagnostics so we should remove the test for now.

