### PR TITLE
Highlight unprefixed opam files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 - Fix syntax highlighting of empty comments (#276)
 - Fix syntax highlighting of floating attributes (#281)
 - Improve highlighting of external declarations (#282)
+- Highlight unprefixed opam files (#284)
 
 ## 0.8.0
 

--- a/package.json
+++ b/package.json
@@ -256,6 +256,9 @@
         "aliases": [
           "opam"
         ],
+        "filenames": [
+          "opam"
+        ],
         "extensions": [
           ".opam",
           ".opam.locked"


### PR DESCRIPTION
Sometimes opam files do not have a prefix like `packagename.opam` and are just `opam` (like in the opam-repository packages). 

Previously, only opam files with prefixes were highlighted. This PR adds detection for the unprefixed files.