### PR TITLE
Fix syntax highlighting of module type of

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 - Fix syntax highlighting of floating attributes (#281)
 - Improve highlighting of external declarations (#282)
 - Highlight unprefixed opam files (#284)
+- Fix syntax highlighting of `module type of` (#285)
 
 ## 0.8.0
 

--- a/syntaxes/ocaml.interface.json
+++ b/syntaxes/ocaml.interface.json
@@ -28,6 +28,15 @@
           "match": "~[a-z_][A-Za-z0-9_']*"
         },
         {
+          "comment": "module type of",
+          "match": "\\b(module)\\s+(type)\\s+(of)\\b",
+          "captures": {
+            "1": { "name": "keyword.ocaml" },
+            "2": { "name": "keyword.ocaml" },
+            "3": { "name": "keyword.ocaml" }
+          }
+        },
+        {
           "comment": "type declaration",
           "match": "\\b(type)\\s+(nonrec\\s+)?(_\\s+|[+-]?'[A-Za-z][A-Za-z0-9_']*\\s+|\\(.*\\)\\s+)?([a-z_][A-Za-z0-9_']*)",
           "captures": {


### PR DESCRIPTION
http://caml.inria.fr/pub/docs/manual-ocaml/moduletypeof.html

| Old | New |
| - | - |
| ![old](https://user-images.githubusercontent.com/25037249/87217818-53b5dd80-c302-11ea-92ce-3b46e779d7cd.png) | ![new](https://user-images.githubusercontent.com/25037249/87217820-5b758200-c302-11ea-8dee-cb0e94259670.png) |

