### PR TITLE
Fix syntax highlighting of module constraints

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 - Improve highlighting of external declarations (#282)
 - Highlight unprefixed opam files (#284)
 - Fix syntax highlighting of `module type of` (#285)
+- Fix syntax highlighting of module constraints (#286)
 
 ## 0.8.0
 

--- a/syntaxes/ocaml.interface.json
+++ b/syntaxes/ocaml.interface.json
@@ -48,7 +48,7 @@
         },
         {
           "comment": "and declaration for let bindings, type declarations, class bindings, or class type definitions",
-          "match": "\\b(and)\\s+((?:virtual|lazy)\\s+)?(_\\s+|'[A-Za-z][A-Za-z0-9_']*\\s+|\\(.*\\)\\s+)?([a-z_][A-Za-z0-9_']*)\\s+(?!,|::)",
+          "match": "\\b(and)\\s+(?!(?:module|type)\\s+)((?:virtual|lazy)\\s+)?(_\\s+|'[A-Za-z][A-Za-z0-9_']*\\s+|\\(.*\\)\\s+)?([a-z_][A-Za-z0-9_']*)\\s+(?!,|::)",
           "captures": {
             "1": { "name": "keyword.ocaml" },
             "2": { "name": "keyword.ocaml" },

--- a/syntaxes/ocaml.interface.json
+++ b/syntaxes/ocaml.interface.json
@@ -48,7 +48,7 @@
         },
         {
           "comment": "and declaration for let bindings, type declarations, class bindings, or class type definitions",
-          "match": "\\b(and)\\s+(?!(?:module|type)\\s+)((?:virtual|lazy)\\s+)?(_\\s+|'[A-Za-z][A-Za-z0-9_']*\\s+|\\(.*\\)\\s+)?([a-z_][A-Za-z0-9_']*)\\s+(?!,|::)",
+          "match": "\\b(and)\\s+(?!(?:module|type)\\b)((?:virtual|lazy)\\s+)?(_\\s+|'[A-Za-z][A-Za-z0-9_']*\\s+|\\(.*\\)\\s+)?([a-z_][A-Za-z0-9_']*)\\s+(?!,|::)",
           "captures": {
             "1": { "name": "keyword.ocaml" },
             "2": { "name": "keyword.ocaml" },


### PR DESCRIPTION
https://ocaml.org/releases/4.10/htmlman/modtypes.html#mod-constraint

| Old | New |
| - | - |
| ![old](https://user-images.githubusercontent.com/25037249/87477688-628be100-c5dd-11ea-99f2-6af827bd0cdf.png) | ![new](https://user-images.githubusercontent.com/25037249/87477695-661f6800-c5dd-11ea-93f4-4333845f9eec.png) |



