### PR TITLE
Add syntax highlighting for new ocamlformat values

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@
 - Fix syntax highlighting of `module type of` (#285)
 - Fix syntax highlighting of module constraints (#286)
 - Fix syntax highlighting of lazy bindings (#287)
+- Add syntax highlighting for new ocamlformat values: `after-when-possible`,
+  `before-except-val`, and `unset` (#288)
 
 ## 0.8.0
 

--- a/syntaxes/ocamlformat.json
+++ b/syntaxes/ocamlformat.json
@@ -111,11 +111,11 @@
         },
         {
           "name": "constant.language.ocamlformat",
-          "match": "\\b(after|align|all|always|auto)\\b"
+          "match": "\\b(after-when-possible|after|align|all|always|auto)\\b"
         },
         {
           "name": "constant.language.ocamlformat",
-          "match": "\\b(before|begin-line)\\b"
+          "match": "\\b(before-except-val|before|begin-line)\\b"
         },
         {
           "name": "constant.language.ocamlformat",
@@ -179,7 +179,7 @@
         },
         {
           "name": "constant.language.ocamlformat",
-          "match": "\\b(unsafe-no)\\b"
+          "match": "\\b(unsafe-no|unset)\\b"
         },
         {
           "name": "constant.language.ocamlformat",


### PR DESCRIPTION
Add syntax highlighting for new ocamlformat values: 

- `after-when-possible`

-  `before-except-val`

- `unset`

https://github.com/ocaml-ppx/ocamlformat/commit/6fb5a8c607b7fb93812870e059dcabe562f88bf5#diff-8f3203cb16efbd72472f28cf96bab086

https://github.com/ocaml-ppx/ocamlformat/commit/403e0206705c47b1f5b123871ca51028d43d878c#diff-8f3203cb16efbd72472f28cf96bab086