### PR TITLE
Improve syntax highlighting of OCaml comments that contain strings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 - Fix syntax highlighting of lazy bindings (#287)
 - Add syntax highlighting for new ocamlformat values: `after-when-possible`,
   `before-except-val`, and `unset` (#288)
+- Improve syntax highlighting of OCaml comments that contain strings (#289)
 
 ## 0.8.0
 

--- a/syntaxes/menhir.json
+++ b/syntaxes/menhir.json
@@ -100,17 +100,12 @@
 
     "comments": {
       "patterns": [
+        { "include": "source.ocaml#comments" },
         {
           "comment": "c-style block comment",
           "name": "comment.block.menhir",
           "begin": "/\\*",
           "end": "\\*/"
-        },
-        {
-          "comment": "ocaml-style block comment",
-          "name": "comment.block.other.menhir",
-          "begin": "\\(\\*",
-          "end": "\\*\\)"
         },
         {
           "comment": "c-style line comment",

--- a/syntaxes/ocaml.json
+++ b/syntaxes/ocaml.json
@@ -132,6 +132,7 @@
           "end": "\\*\\)",
           "patterns": [
             { "include": "source.ocaml.ocamldoc#markup" },
+            { "include": "#strings-in-comments" },
             { "include": "#comments" }
           ]
         },
@@ -140,7 +141,25 @@
           "name": "comment.block.ocaml",
           "begin": "\\(\\*",
           "end": "\\*\\)",
-          "patterns": [{ "include": "#comments" }]
+          "patterns": [
+            { "include": "#strings-in-comments" },
+            { "include": "#comments" }
+          ]
+        }
+      ]
+    },
+
+    "strings-in-comments": {
+      "patterns": [
+        {
+          "comment": "string literal",
+          "begin": "\"",
+          "end": "\""
+        },
+        {
+          "comment": "quoted string literal",
+          "begin": "\\{[^|]*\\|",
+          "end": "\\|[^}]*\\}"
         }
       ]
     },


### PR DESCRIPTION
OCaml comments can have strings inside of them. Previously the syntax highlighting did not handle this case and would end a comment earlier than the OCaml lexer.

| Old | New |
| - | - |
| ![old](https://user-images.githubusercontent.com/25037249/87732038-c569ad80-c780-11ea-9175-09f27079331b.png) | ![new](https://user-images.githubusercontent.com/25037249/87732029-bc78dc00-c780-11ea-8857-76f7e1231688.png) |

