### PR TITLE
add support to binding operators on reason

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- Fix Reason syntax highlighting of binding operators (#291)
 - Fix syntax highlighting of empty comments (#276)
 - Fix syntax highlighting of floating attributes (#281)
 - Improve highlighting of external declarations (#282)

--- a/syntaxes/reason.json
+++ b/syntaxes/reason.json
@@ -113,13 +113,19 @@
       "begin": "/\\*",
       "end": "\\*/",
       "name": "comment.block",
-      "patterns": [{ "include": "#comment-block" }]
+      "patterns": [
+        { "include": "#comment-block-doc" },
+        { "include": "#comment-block" }
+      ]
     },
     "comment-block-doc": {
       "begin": "/\\*\\*(?!/)",
       "end": "\\*/",
       "name": "comment.block.documentation",
-      "patterns": [{ "include": "#comment-block" }]
+      "patterns": [
+        { "include": "#comment-block-doc" },
+        { "include": "#comment-block" }
+      ]
     },
     "condition-lhs": {
       "begin": "(?<![#\\-:!?.@*/&%^+<=>|~$\\\\])([\\?])(?![#\\-:!?.@*/&%^+<=>|~$\\\\])",
@@ -219,7 +225,8 @@
           ]
         },
         { "include": "#jsx-attributes" },
-        { "include": "#jsx-body" }
+        { "include": "#jsx-body" },
+        { "include": "#comment" }
       ]
     },
     "jsx-tail": {
@@ -444,10 +451,12 @@
       "patterns": [{ "include": "#signature-expression" }]
     },
     "module-item-let": {
-      "begin": "\\b(let)\\b",
+      "begin": "\\b(let)((%)([[:word:]\\.]+))?\\b",
       "end": "(;)|(?=}|\\b(class|constraint|exception|external|include|inherit|let|method|nonrec|open|private|type|val|with)\\b)",
       "beginCaptures": {
-        "1": { "name": "storage.type" }
+        "1": { "name": "storage.type" },
+        "3": { "name": "keyword.control.less" },
+        "4": { "name": "entity.name.class" }
       },
       "endCaptures": {
         "1": {


### PR DESCRIPTION
Actually it was synchronized with RLS [reason.json](https://github.com/jaredly/reason-language-server/blob/master/editor-extensions/vscode/reason.json)