### PR TITLE
fix reason syntax highlighting of type extensions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- Fix Reason syntax highlighting of type extensions (#292)
 - Fix syntax highlighting of empty comments (#276)
 - Fix syntax highlighting of floating attributes (#281)
 - Improve highlighting of external declarations (#282)

--- a/syntaxes/reason.json
+++ b/syntaxes/reason.json
@@ -141,7 +141,7 @@
       "patterns": [
         {
           "begin": "\\[(%{1,3})",
-          "end": "(?=[^_\\.'[:word:]])",
+          "end": "(?=[^_\\.'[:word:]])\\:?",
           "beginCaptures": {
             "1": { "name": "keyword.control.less" }
           },


### PR DESCRIPTION
It was missing the `:` that exists on Reason when doing type extensions

Buggy example(as you can see on github):
```reason
let x = [%sigi: type t];
let x = 1;
```