### PR TITLE
fix reason syntax highlighting of rec modules

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
 - Fix Reason syntax highlighting of binding operators (#291)
 - Fix Reason syntax highlighting of type extensions (#292)
 - Improve syntax highlighting of OCaml comments that contain strings (#289)
+- Fix Reason syntax highlighting of recursive modules (#295)
 
 ## 0.8.0
 

--- a/syntaxes/reason.json
+++ b/syntaxes/reason.json
@@ -792,7 +792,7 @@
     "module-item-module": {
       "comment": "NOTE: this is to support the let-module case without the let prefix",
       "begin": "\\b(module)\\b[[:space:]]*(?!\\b(type)\\b|$)",
-      "end": "(;)|(?=}|\\b(and|class|constraint|exception|external|include|inherit|let|method|module|nonrec|open|private|rec|type|val|with)\\b)",
+      "end": "(;)|(?=}|\\b(and|class|constraint|exception|external|include|inherit|let|method|module|nonrec|open|private|type|val|with)\\b)",
       "beginCaptures": {
         "1": { "name": "storage.type message.error" }
       },


### PR DESCRIPTION
Currently there is a problem with recursive modules as you can see here, there is no way that rec can close anything actually, so it's probably a global problem, but made the local fix

```reason
module A: {
  module B: {}
};
module rec X: {
  module Y: {}
};