### PR TITLE
fix reason syntax highlighting of and module

### DIFF
--- a/syntaxes/reason.json
+++ b/syntaxes/reason.json
@@ -792,7 +792,7 @@
     "module-item-module": {
       "comment": "NOTE: this is to support the let-module case without the let prefix",
       "begin": "\\b(module)\\b[[:space:]]*(?!\\b(type)\\b|$)",
-      "end": "(;)|(?=}|\\b(and|class|constraint|exception|external|include|inherit|let|method|module|nonrec|open|private|type|val|with)\\b)",
+      "end": "(;)|(?=}|\\b(class|constraint|exception|external|include|inherit|let|method|module|nonrec|open|private|type|val|with)\\b)",
       "beginCaptures": {
         "1": { "name": "storage.type message.error" }
       },


### PR DESCRIPTION
The previous PR fixed the content of the first module, this one fixes the next module starting with `and`, as you can see the and isn't highlighted, in the first case

```reason
module rec X: {} = {}
and Y: {} = {};

let rec abc = 1
and def = 1
```