### PR TITLE
fix esy snippet to include proper dune version

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,9 @@ npm install esy --global
     "@opam/ocaml-lsp-server": "ocaml/ocaml-lsp:ocaml-lsp-server.opam",
     "@opam/reason": "*",
     "ocaml": "4.6.x"
+  },
+  "resolutions": {
+    "@opam/dune": "2.5.1"
   }
 }
 ```


### PR DESCRIPTION
without pinning the right dune version users get the OCaml version error in the end as esy tries to install dune v2.6.2

```
    The ocamlfind's secondary toolchain does not seem to be correctly
    installed.
    Dune requires OCaml 4.07 or later to compile.
    Please either upgrade your compile or configure a secondary OCaml compiler
    (in opam, this can be done by installing the ocamlfind-secondary package).
    error: command failed: 'ocaml' 'bootstrap.ml' '-j' '4' (exited with 2)
    esy-build-package: exiting with errors above...
    
  building @opam/dune@opam:2.6.2
esy: exiting due to errors above
```