### PR TITLE
Use Oniguruma character classes in syntaxes

### DIFF
--- a/syntaxes/META.json
+++ b/syntaxes/META.json
@@ -13,7 +13,7 @@
       "patterns": [
         {
           "comment": "assignment or addition",
-          "match": "\\b([A-Za-z0-9_.]+)\\s*(\\+?=)\\s*(\".*\")",
+          "match": "\\b([[:word:].]+)[[:space:]]*(\\+?=)[[:space:]]*(\".*\")",
           "captures": {
             "1": { "name": "entity.name.tag.META" },
             "2": { "name": "keyword.operator.META" },
@@ -22,11 +22,11 @@
         },
         {
           "comment": "assignment or addition with formal predicates",
-          "begin": "\\b([A-Za-z0-9_.]+)\\s*\\(",
+          "begin": "\\b([[:word:].]+)[[:space:]]*\\(",
           "beginCaptures": {
             "1": { "name": "entity.name.tag.META" }
           },
-          "end": "\\)\\s*(\\+?=)\\s*(\".*\")",
+          "end": "\\)[[:space:]]*(\\+?=)[[:space:]]*(\".*\")",
           "endCaptures": {
             "1": { "name": "keyword.operator.META" },
             "2": { "name": "string.quoted.double.META" }
@@ -42,7 +42,7 @@
         },
         {
           "comment": "subpackage",
-          "begin": "\\b(package)\\s*(\"[^.]*\")\\s*\\(",
+          "begin": "\\b(package)[[:space:]]*(\"[^.]*\")[[:space:]]*\\(",
           "beginCaptures": {
             "1": { "name": "keyword.other.META" },
             "2": { "name": "string.quoted.double.META" }

--- a/syntaxes/atd.json
+++ b/syntaxes/atd.json
@@ -16,7 +16,7 @@
     "annotations": {
       "patterns": [
         {
-          "begin": "(<)\\s*([a-z_][A-Za-z0-9_']*)",
+          "begin": "(<)[[:space:]]*([[:lower:]_][[:word:]']*)",
           "end": ">",
           "beginCaptures": {
             "1": { "name": "keyword.other.atd" },
@@ -28,7 +28,7 @@
       ]
     },
     "definitions": {
-      "match": "\\b(type)\\s+('[A-Za-z][A-Za-z0-9_']*\\s+|\\(.*\\)\\s*)?([a-z_][A-Za-z0-9_']*)",
+      "match": "\\b(type)[[:space:]]+('[[:alpha:]][[:word:]']*[[:space:]]+|\\(.*\\)[[:space:]]*)?([[:lower:]_][[:word:]']*)",
       "captures": {
         "1": { "name": "keyword.other.atd" },
         "2": { "patterns": [{ "include": "$self" }] },
@@ -37,14 +37,14 @@
     },
     "keywords": {
       "name": "keyword.other.atd",
-      "match": "\\b(type|of|inherit)\\b"
+      "match": "\\b(type|of|inherit)\\b(?!')"
     },
     "types": {
       "patterns": [
         {
           "comment": "type parameter",
           "name": "storage.type.ocaml.atd",
-          "match": "'[A-Za-z][A-Za-z0-9_']*\\b"
+          "match": "'[[:alpha:]][[:word:]']*\\b"
         },
         {
           "comment": "builtin type",

--- a/syntaxes/cram.json
+++ b/syntaxes/cram.json
@@ -73,12 +73,12 @@
         {
           "comment": "octal escape",
           "name": "constant.character.escape.cram",
-          "match": "\\\\0[0-9]+"
+          "match": "\\\\0[[:digit:]]+"
         },
         {
           "comment": "hex escape",
           "name": "constant.character.escape.cram",
-          "match": "\\\\x[A-Fa-f0-9]{2}"
+          "match": "\\\\x[[:xdigit:]]{2}"
         },
         {
           "comment": "other escaped character",
@@ -150,7 +150,7 @@
           "patterns": [
             {
               "name": "constant.numeric.decimal.integer.regex",
-              "match": "[0-9]+"
+              "match": "[[:digit:]]+"
             }
           ]
         }

--- a/syntaxes/dune-project.json
+++ b/syntaxes/dune-project.json
@@ -8,7 +8,7 @@
       "patterns": [
         {
           "comment": "lang",
-          "begin": "\\(\\s*(lang)\\s+(dune)\\b",
+          "begin": "\\([[:space:]]*(lang)[[:space:]]+(dune)\\b",
           "end": "\\)",
           "beginCaptures": {
             "1": { "name": "keyword.language.dune-project" },
@@ -19,7 +19,7 @@
 
         {
           "comment": "name",
-          "begin": "\\(\\s*(name)\\b",
+          "begin": "\\([[:space:]]*(name)\\b",
           "end": "\\)",
           "beginCaptures": {
             "1": { "name": "keyword.language.dune-project" }
@@ -30,7 +30,7 @@
 
         {
           "comment": "version",
-          "begin": "\\(\\s*(version)\\b",
+          "begin": "\\([[:space:]]*(version)\\b",
           "end": "\\)",
           "beginCaptures": {
             "1": { "name": "keyword.language.dune-project" }
@@ -41,7 +41,7 @@
 
         {
           "comment": "implicit_transitive_deps",
-          "begin": "\\(\\s*(implicit_transitive_deps)\\b",
+          "begin": "\\([[:space:]]*(implicit_transitive_deps)\\b",
           "end": "\\)",
           "beginCaptures": {
             "1": { "name": "keyword.language.dune-project" }
@@ -51,7 +51,7 @@
 
         {
           "comment": "wrapped_executables",
-          "begin": "\\(\\s*(wrapped_executables)\\b",
+          "begin": "\\([[:space:]]*(wrapped_executables)\\b",
           "end": "\\)",
           "beginCaptures": {
             "1": { "name": "keyword.language.dune-project" }
@@ -61,7 +61,7 @@
 
         {
           "comment": "explicit_js_mode",
-          "match": "\\(\\s*(explicit_js_mode)\\s*\\)",
+          "match": "\\([[:space:]]*(explicit_js_mode)[[:space:]]*\\)",
           "captures": {
             "1": { "name": "keyword.language.dune-project" }
           }
@@ -69,7 +69,7 @@
 
         {
           "comment": "dialect",
-          "begin": "\\(\\s*(dialect)\\b",
+          "begin": "\\([[:space:]]*(dialect)\\b",
           "end": "\\)",
           "beginCaptures": {
             "1": { "name": "keyword.language.dune-project" }
@@ -77,7 +77,7 @@
           "patterns": [
             {
               "comment": "name",
-              "begin": "\\(\\s*(name)\\b",
+              "begin": "\\([[:space:]]*(name)\\b",
               "end": "\\)",
               "beginCaptures": {
                 "1": { "name": "keyword.language.dune-project" }
@@ -88,7 +88,7 @@
 
             {
               "comment": "implementation/interface",
-              "begin": "\\(\\s*(implementation|interface)\\b",
+              "begin": "\\([[:space:]]*(implementation|interface)\\b",
               "end": "\\)",
               "beginCaptures": {
                 "1": { "name": "keyword.language.dune-project" }
@@ -96,7 +96,7 @@
               "patterns": [
                 {
                   "comment": "extension/preprocess/format",
-                  "begin": "\\(\\s*(extension|preprocess|format)\\b",
+                  "begin": "\\([[:space:]]*(extension|preprocess|format)\\b",
                   "end": "\\)",
                   "beginCaptures": {
                     "1": { "name": "keyword.language.dune-project" }
@@ -112,7 +112,7 @@
 
         {
           "comment": "formatting",
-          "begin": "\\(\\s*(formatting)\\b",
+          "begin": "\\([[:space:]]*(formatting)\\b",
           "end": "\\)",
           "beginCaptures": {
             "1": { "name": "keyword.language.dune-project" }
@@ -123,7 +123,7 @@
               "match": "\\b(disabled)\\b"
             },
             {
-              "begin": "\\(\\s*(enabled_for)\\b",
+              "begin": "\\([[:space:]]*(enabled_for)\\b",
               "end": "\\)",
               "beginCaptures": {
                 "1": { "name": "keyword.language.dune-project" }
@@ -136,7 +136,7 @@
 
         {
           "comment": "generate_opam_files",
-          "begin": "\\(\\s*(generate_opam_files)\\b",
+          "begin": "\\([[:space:]]*(generate_opam_files)\\b",
           "end": "\\)",
           "beginCaptures": {
             "1": { "name": "keyword.language.dune-project" }
@@ -146,7 +146,7 @@
 
         {
           "comment": "package",
-          "begin": "\\(\\s*(package)\\b",
+          "begin": "\\([[:space:]]*(package)\\b",
           "end": "\\)",
           "beginCaptures": {
             "1": { "name": "keyword.language.dune-project" }
@@ -154,7 +154,7 @@
           "patterns": [
             {
               "comment": "name",
-              "begin": "\\(\\s*(name)\\b",
+              "begin": "\\([[:space:]]*(name)\\b",
               "end": "\\)",
               "beginCaptures": {
                 "1": { "name": "keyword.language.dune-project" }
@@ -165,7 +165,7 @@
 
             {
               "comment": "synopsis/description",
-              "begin": "\\(\\s*(synopsis|description)\\b",
+              "begin": "\\([[:space:]]*(synopsis|description)\\b",
               "end": "\\)",
               "beginCaptures": {
                 "1": { "name": "keyword.language.dune-project" }
@@ -175,7 +175,7 @@
 
             {
               "comment": "depends/conflicts/depopts",
-              "begin": "\\(\\s*(depends|conflicts|depopts)\\b",
+              "begin": "\\([[:space:]]*(depends|conflicts|depopts)\\b",
               "end": "\\)",
               "beginCaptures": {
                 "1": { "name": "keyword.language.dune-project" }
@@ -184,11 +184,11 @@
                 {
                   "comment": "dependency",
                   "name": "variable.other.declaration.dune-project",
-                  "match": "\\b([a-zA-Z_-]+)\\b"
+                  "match": "\\b([[:alpha:]-]+)\\b"
                 },
                 {
                   "comment": "dependency constraint",
-                  "begin": "\\(\\s*([a-zA-Z_-]+)\\b",
+                  "begin": "\\([[:space:]]*([[:alpha:]-]+)\\b",
                   "end": "\\)",
                   "beginCaptures": {
                     "1": { "name": "variable.other.declaration.dune-project" }
@@ -201,7 +201,7 @@
 
             {
               "comment": "tags",
-              "begin": "\\(\\s*(tags)\\b",
+              "begin": "\\([[:space:]]*(tags)\\b",
               "end": "\\)",
               "beginCaptures": {
                 "1": { "name": "keyword.language.dune-project" }
@@ -212,7 +212,7 @@
 
             {
               "comment": "deprecated_package_names",
-              "begin": "\\(\\s*(deprecated_package_names)\\b",
+              "begin": "\\([[:space:]]*(deprecated_package_names)\\b",
               "end": "\\)",
               "beginCaptures": {
                 "1": { "name": "keyword.language.dune-project" }
@@ -227,7 +227,7 @@
 
         {
           "comment": "using",
-          "begin": "\\(\\s*(using)(\\s+menhir)?\\b",
+          "begin": "\\([[:space:]]*(using)([[:space:]]+menhir)?\\b",
           "end": "\\)",
           "beginCaptures": {
             "1": { "name": "keyword.language.dune-project" },
@@ -244,7 +244,7 @@
       "patterns": [
         {
           "comment": "license",
-          "begin": "\\(\\s*(license)\\b",
+          "begin": "\\([[:space:]]*(license)\\b",
           "end": "\\)",
           "beginCaptures": {
             "1": { "name": "keyword.language.dune-project" }
@@ -255,7 +255,7 @@
 
         {
           "comment": "authors/maintainers",
-          "begin": "\\(\\s*(authors|maintainers)\\b",
+          "begin": "\\([[:space:]]*(authors|maintainers)\\b",
           "end": "\\)",
           "beginCaptures": {
             "1": { "name": "keyword.language.dune-project" }
@@ -265,7 +265,7 @@
 
         {
           "comment": "source",
-          "begin": "\\(\\s*(source)\\b",
+          "begin": "\\([[:space:]]*(source)\\b",
           "end": "\\)",
           "beginCaptures": {
             "1": { "name": "keyword.language.dune-project" }
@@ -273,7 +273,7 @@
           "patterns": [
             {
               "comment": "github",
-              "begin": "\\(\\s*(github)\\b",
+              "begin": "\\([[:space:]]*(github)\\b",
               "end": "\\)",
               "beginCaptures": {
                 "1": { "name": "keyword.language.dune-project" }
@@ -289,7 +289,7 @@
             },
             {
               "comment": "uri",
-              "begin": "\\(\\s*(uri)\\b",
+              "begin": "\\([[:space:]]*(uri)\\b",
               "end": "\\)",
               "beginCaptures": {
                 "1": { "name": "keyword.language.dune-project" }
@@ -302,7 +302,7 @@
 
         {
           "comment": "bug_reports/homepage/documentation",
-          "begin": "\\(\\s*(bug_reports|homepage|documentation)\\b",
+          "begin": "\\([[:space:]]*(bug_reports|homepage|documentation)\\b",
           "end": "\\)",
           "beginCaptures": {
             "1": { "name": "keyword.language.dune-project" }
@@ -339,12 +339,12 @@
         {
           "comment": "symbol",
           "name": "constant.symbol.dune",
-          "match": "(:[a-zA-Z_-]+)\\b"
+          "match": "(:[[:alpha:]-]+)\\b"
         },
         {
           "comment": "number or version",
           "name": "constant.numeric.dune",
-          "match": "\\b([0-9](\\.[0-9]+)+)\\b"
+          "match": "\\b([[:digit:]](\\.[[:digit:]]+)+)\\b"
         },
         {
           "comment": "true or false",
@@ -361,14 +361,14 @@
         },
         {
           "comment": "boolean/predicate language",
-          "begin": "\\(\\s*(=|<>|>=|<=|<|>)",
+          "begin": "\\([[:space:]]*(=|<>|>=|<=|<|>)",
           "end": "\\)",
           "beginCaptures": { "1": { "name": "keyword.operator.dune" } },
           "patterns": [{ "include": "#general" }]
         },
         {
           "comment": "boolean/predicate language",
-          "begin": "\\(\\s*(and|or|not)\\b",
+          "begin": "\\([[:space:]]*(and|or|not)\\b",
           "end": "\\)",
           "beginCaptures": { "1": { "name": "keyword.operator.dune" } },
           "patterns": [{ "include": "#general" }]
@@ -400,12 +400,12 @@
         {
           "comment": "character from decimal ASCII code",
           "name": "constant.character.escape.dune",
-          "match": "\\\\[0-9]{3}"
+          "match": "\\\\[[:digit:]]{3}"
         },
         {
           "comment": "character from hexadecimal ASCII code",
           "name": "constant.character.escape.dune",
-          "match": "\\\\x[0-9A-Fa-f]{2}"
+          "match": "\\\\x[[:xdigit:]]{2}"
         },
         {
           "comment": "escaped variable",

--- a/syntaxes/dune-workspace.json
+++ b/syntaxes/dune-workspace.json
@@ -8,7 +8,7 @@
       "patterns": [
         {
           "comment": "lang",
-          "begin": "\\(\\s*(lang)\\s+(dune)\\b",
+          "begin": "\\([[:space:]]*(lang)[[:space:]]+(dune)\\b",
           "end": "\\)",
           "beginCaptures": {
             "1": { "name": "keyword.language.dune-workspace" },
@@ -19,7 +19,7 @@
 
         {
           "comment": "profile",
-          "begin": "\\(\\s*(profile)\\b",
+          "begin": "\\([[:space:]]*(profile)\\b",
           "end": "\\)",
           "beginCaptures": {
             "1": { "name": "keyword.language.dune-workspace" }
@@ -30,7 +30,7 @@
 
         {
           "comment": "env",
-          "begin": "\\(\\s*(env)\\b",
+          "begin": "\\([[:space:]]*(env)\\b",
           "end": "\\)",
           "beginCaptures": {
             "1": { "name": "keyword.language.dune-workspace" }
@@ -40,7 +40,7 @@
 
         {
           "comment": "context",
-          "begin": "\\(\\s*(context)\\b",
+          "begin": "\\([[:space:]]*(context)\\b",
           "end": "\\)",
           "beginCaptures": {
             "1": { "name": "keyword.language.dune-workspace" }
@@ -53,7 +53,7 @@
             },
             {
               "comment": "opam/default",
-              "begin": "\\(\\s*(opam|default)\\b",
+              "begin": "\\([[:space:]]*(opam|default)\\b",
               "end": "\\)",
               "beginCaptures": {
                 "1": { "name": "keyword.language.dune-workspace" }
@@ -61,7 +61,7 @@
               "patterns": [
                 {
                   "comment": "opam switch",
-                  "begin": "\\(\\s*(switch)\\b",
+                  "begin": "\\([[:space:]]*(switch)\\b",
                   "end": "\\)",
                   "beginCaptures": {
                     "1": { "name": "keyword.language.dune-workspace" }
@@ -71,7 +71,7 @@
 
                 {
                   "comment": "name",
-                  "begin": "\\(\\s*(name)\\b",
+                  "begin": "\\([[:space:]]*(name)\\b",
                   "end": "\\)",
                   "beginCaptures": {
                     "1": { "name": "keyword.language.dune-workspace" }
@@ -81,7 +81,7 @@
 
                 {
                   "comment": "root",
-                  "begin": "\\(\\s*(root)\\b",
+                  "begin": "\\([[:space:]]*(root)\\b",
                   "end": "\\)",
                   "beginCaptures": {
                     "1": { "name": "keyword.language.dune-workspace" }
@@ -91,7 +91,7 @@
 
                 {
                   "comment": "merlin",
-                  "begin": "\\(\\s*(merlin)\\b",
+                  "begin": "\\([[:space:]]*(merlin)\\b",
                   "end": "\\)",
                   "beginCaptures": {
                     "1": { "name": "keyword.language.dune-workspace" }
@@ -101,7 +101,7 @@
 
                 {
                   "comment": "profile",
-                  "begin": "\\(\\s*(profile)\\b",
+                  "begin": "\\([[:space:]]*(profile)\\b",
                   "end": "\\)",
                   "beginCaptures": {
                     "1": { "name": "keyword.language.dune-workspace" }
@@ -111,7 +111,7 @@
 
                 {
                   "comment": "env",
-                  "begin": "\\(\\s*(env)\\b",
+                  "begin": "\\([[:space:]]*(env)\\b",
                   "end": "\\)",
                   "beginCaptures": {
                     "1": { "name": "keyword.language.dune-workspace" }
@@ -121,7 +121,7 @@
 
                 {
                   "comment": "toolchain",
-                  "begin": "\\(\\s*(toolchain)\\b",
+                  "begin": "\\([[:space:]]*(toolchain)\\b",
                   "end": "\\)",
                   "beginCaptures": {
                     "1": { "name": "keyword.language.dune-workspace" }
@@ -131,7 +131,7 @@
 
                 {
                   "comment": "host",
-                  "begin": "\\(\\s*(host)\\b",
+                  "begin": "\\([[:space:]]*(host)\\b",
                   "end": "\\)",
                   "beginCaptures": {
                     "1": { "name": "keyword.language.dune-workspace" }
@@ -141,7 +141,7 @@
 
                 {
                   "comment": "paths",
-                  "begin": "\\(\\s*(paths)\\b",
+                  "begin": "\\([[:space:]]*(paths)\\b",
                   "end": "\\)",
                   "beginCaptures": {
                     "1": { "name": "keyword.language.dune-workspace" }
@@ -151,7 +151,7 @@
 
                 {
                   "comment": "fdo",
-                  "begin": "\\(\\s*(fdo)\\b",
+                  "begin": "\\([[:space:]]*(fdo)\\b",
                   "end": "\\)",
                   "beginCaptures": {
                     "1": { "name": "keyword.language.dune-workspace" }
@@ -161,7 +161,7 @@
 
                 {
                   "comment": "disable_dynamically_linked_foreign_archives",
-                  "begin": "\\(\\s*(disable_dynamically_linked_foreign_archives)\\b",
+                  "begin": "\\([[:space:]]*(disable_dynamically_linked_foreign_archives)\\b",
                   "end": "\\)",
                   "beginCaptures": {
                     "1": { "name": "keyword.language.dune-workspace" }
@@ -171,7 +171,7 @@
 
                 {
                   "comment": "targets",
-                  "begin": "\\(\\s*(targets)\\b",
+                  "begin": "\\([[:space:]]*(targets)\\b",
                   "end": "\\)",
                   "beginCaptures": {
                     "1": { "name": "keyword.language.dune-workspace" }
@@ -215,12 +215,12 @@
         {
           "comment": "symbol",
           "name": "constant.symbol.dune",
-          "match": "(:[a-zA-Z_-]+)\\b"
+          "match": "(:[[:alpha:]-]+)\\b"
         },
         {
           "comment": "number or version",
           "name": "constant.numeric.dune",
-          "match": "\\b([0-9](\\.[0-9]+)+)\\b"
+          "match": "\\b([[:digit:]](\\.[[:digit:]]+)+)\\b"
         },
         {
           "comment": "true or false",
@@ -237,14 +237,14 @@
         },
         {
           "comment": "boolean/predicate language",
-          "begin": "\\(\\s*(=|<>|>=|<=|<|>)",
+          "begin": "\\([[:space:]]*(=|<>|>=|<=|<|>)",
           "end": "\\)",
           "beginCaptures": { "1": { "name": "keyword.operator.dune" } },
           "patterns": [{ "include": "#general" }]
         },
         {
           "comment": "boolean/predicate language",
-          "begin": "\\(\\s*(and|or|not)\\b",
+          "begin": "\\([[:space:]]*(and|or|not)\\b",
           "end": "\\)",
           "beginCaptures": { "1": { "name": "keyword.operator.dune" } },
           "patterns": [{ "include": "#general" }]
@@ -276,12 +276,12 @@
         {
           "comment": "character from decimal ASCII code",
           "name": "constant.character.escape.dune",
-          "match": "\\\\[0-9]{3}"
+          "match": "\\\\[[:digit:]]{3}"
         },
         {
           "comment": "character from hexadecimal ASCII code",
           "name": "constant.character.escape.dune",
-          "match": "\\\\x[0-9A-Fa-f]{2}"
+          "match": "\\\\x[[:xdigit:]]{2}"
         },
         {
           "comment": "escaped variable",

--- a/syntaxes/dune.json
+++ b/syntaxes/dune.json
@@ -8,7 +8,7 @@
     },
     {
       "name": "meta.stanza.dune",
-      "begin": "\\(\\s*(library|rule|executable|executables|rule|ocamllex|ocamlyacc|menhir|install|alias|copy_files|copy_files#|jbuild_version|include)\\s",
+      "begin": "\\([[:space:]]*(library|rule|executable|executables|rule|ocamllex|ocamlyacc|menhir|install|alias|copy_files|copy_files#|jbuild_version|include)[[:space:]]",
       "end": "\\)",
       "beginCaptures": {
         "1": {
@@ -23,7 +23,7 @@
     },
     {
       "name": "meta.stanza.library.field.dune",
-      "begin": "\\(\\s*(name|public_name|synopsis|install_c_headers|ppx_runtime_libraries|c_flags|cxx_flags|c_names|cxx_names|library_flags|c_library_flags|virtual_deps|modes|kind|wrapped|optional|self_build_stubs_archive|no_dynlink|ppx\\.driver)\\s",
+      "begin": "\\([[:space:]]*(name|public_name|synopsis|install_c_headers|ppx_runtime_libraries|c_flags|cxx_flags|c_names|cxx_names|library_flags|c_library_flags|virtual_deps|modes|kind|wrapped|optional|self_build_stubs_archive|no_dynlink|ppx\\.driver)[[:space:]]",
       "end": "\\)",
       "beginCaptures": {
         "1": {
@@ -38,7 +38,7 @@
     },
     {
       "name": "meta.stanza.rule.dune",
-      "begin": "\\(\\s*(targets|deps|locks|loc|mode|action)\\s",
+      "begin": "\\([[:space:]]*(targets|deps|locks|loc|mode|action)[[:space:]]",
       "beginCaptures": {
         "1": {
           "name": "keyword.other.dune"
@@ -53,7 +53,7 @@
     },
     {
       "name": "meta.mono-sexp.dune",
-      "match": "\\(\\s*(fallback|optional)\\s*\\)",
+      "match": "\\([[:space:]]*(fallback|optional)[[:space:]]*\\)",
       "captures": {
         "1": {
           "name": "keyword.other.dune"
@@ -62,7 +62,7 @@
     },
     {
       "name": "meta.stanza.rule.action.dune",
-      "begin": "\\(\\s*(run|chdir|setenv|with-stdout-to|with-stderr-to|with-outputs-to|ignore-stdout|ignore-stderr|ignore-outputs|progn|echo|cat|copy|copy#|system|bash|write-file|diff|diff\\?)\\s",
+      "begin": "\\([[:space:]]*(run|chdir|setenv|with-stdout-to|with-stderr-to|with-outputs-to|ignore-stdout|ignore-stderr|ignore-outputs|progn|echo|cat|copy|copy#|system|bash|write-file|diff|diff\\?)[[:space:]]",
       "end": "\\)",
       "beginCaptures": {
         "1": {
@@ -77,7 +77,7 @@
     },
     {
       "name": "meta.stanza.install.dune",
-      "begin": "\\(\\s*(section)\\s",
+      "begin": "\\([[:space:]]*(section)[[:space:]]",
       "end": "\\)",
       "beginCaptures": {
         "1": {
@@ -93,7 +93,7 @@
     },
     {
       "name": "meta.stanza.install.dune",
-      "begin": "\\(\\s*(files)\\s",
+      "begin": "\\([[:space:]]*(files)[[:space:]]",
       "end": "\\)",
       "beginCaptures": {
         "1": {
@@ -108,7 +108,7 @@
     },
     {
       "name": "meta.library.kind.dune",
-      "begin": "\\(\\s*(normal|ppx_deriver|ppx_rewriter)\\s",
+      "begin": "\\([[:space:]]*(normal|ppx_deriver|ppx_rewriter)[[:space:]]",
       "end": "\\)",
       "beginCaptures": {
         "1": {
@@ -118,7 +118,7 @@
     },
     {
       "name": "meta.stanza.executables.dune",
-      "begin": "\\(\\s*(name|link_executables|link_flags|modes)\\s",
+      "begin": "\\([[:space:]]*(name|link_executables|link_flags|modes)[[:space:]]",
       "end": "\\)",
       "beginCaptures": {
         "1": {
@@ -133,7 +133,7 @@
     },
     {
       "name": "meta.stanza.lib-or-exec.buildable.dune",
-      "begin": "\\(\\s*(preprocess|preprocessor_deps|lint|modules|modules_without_implementation|libraries|flags|ocamlc_flags|ocamlopt_flags|js_of_ocaml|allow_overlapping_dependencies|per_module)\\s",
+      "begin": "\\([[:space:]]*(preprocess|preprocessor_deps|lint|modules|modules_without_implementation|libraries|flags|ocamlc_flags|ocamlopt_flags|js_of_ocaml|allow_overlapping_dependencies|per_module)[[:space:]]",
       "end": "\\)",
       "beginCaptures": {
         "1": {
@@ -148,7 +148,7 @@
     },
     {
       "name": "meta.stanza.lib-or-exec.buildable.preprocess.dune",
-      "begin": "\\(\\s*(no_preprocessing|action|pps)\\s",
+      "begin": "\\([[:space:]]*(no_preprocessing|action|pps)[[:space:]]",
       "end": "\\)",
       "beginCaptures": {
         "1": {
@@ -163,7 +163,7 @@
     },
     {
       "name": "meta.stanza.lib-or-exec.buildable.preprocess_deps.dune",
-      "begin": "\\(\\s*(file|alias|alias_rec|glob_files|files_recursively_in)\\s",
+      "begin": "\\([[:space:]]*(file|alias|alias_rec|glob_files|files_recursively_in)[[:space:]]",
       "end": "\\)",
       "beginCaptures": {
         "1": {
@@ -178,7 +178,7 @@
     },
     {
       "name": "meta.stanza.lib-or-exec.buildable.libraries.dune",
-      "begin": "\\(\\s*(select)\\s",
+      "begin": "\\([[:space:]]*(select)[[:space:]]",
       "end": "\\)",
       "beginCaptures": {
         "1": {
@@ -201,7 +201,7 @@
     },
     {
       "name": "keyword.other.dune",
-      "match": "\\s(as|from|->)\\s"
+      "match": "[[:space:]](as|from|->)[[:space:]]"
     },
     {
       "name": "keyword.other.dune",
@@ -253,7 +253,7 @@
         },
         {
           "name": "comment.sexp.dune",
-          "begin": "#;\\s*\\(",
+          "begin": "#;[[:space:]]*\\(",
           "end": "\\)",
           "patterns": [
             {
@@ -341,7 +341,7 @@
       "patterns": [
         {
           "name": "meta.atom.dune",
-          "match": "\\b[^\\s]+\\b"
+          "match": "\\b[^[[:space:]]]+\\b"
         }
       ]
     }

--- a/syntaxes/menhir.json
+++ b/syntaxes/menhir.json
@@ -52,7 +52,7 @@
       "patterns": [
         {
           "comment": "rule name with optional parameter list",
-          "match": "([a-z][a-zA-Z0-9_]*)\\s*(?:\\(([^)]+)\\))?(?=\\s*:)",
+          "match": "([[:lower:]][[:word:]]*)[[:space:]]*(?:\\(([^)]+)\\))?(?=[[:space:]]*:)",
           "captures": {
             "1": {
               "comment": "rule name",
@@ -63,7 +63,7 @@
                 {
                   "comment": "rule parameter",
                   "name": "variable.parameter.rule.menhir",
-                  "match": "[a-zA-Z][a-zA-Z0-9_]*"
+                  "match": "[[:alpha:]][[:word:]]*"
                 }
               ]
             }
@@ -118,7 +118,7 @@
 
     "variables": {
       "comment": "labeled semantic value identifier",
-      "match": "([a-z][a-zA-Z0-9_]*)\\s*=",
+      "match": "([[:lower:]][[:word:]]*)[[:space:]]*=",
       "captures": { "1": { "name": "variable.parameter.value.menhir" } },
       "patterns": [{ "include": "#references" }]
     },
@@ -133,12 +133,12 @@
         {
           "comment": "reference to a token",
           "name": "entity.name.token.menhir",
-          "match": "[A-Z][a-zA-Z0-9_]*"
+          "match": "[[:upper:]][[:word:]]*"
         },
         {
           "comment": "reference to a production",
           "name": "entity.name.function.rule.menhir",
-          "match": "[a-z][a-zA-Z0-9_]*"
+          "match": "[[:lower:]][[:word:]]*"
         }
       ]
     },

--- a/syntaxes/oasis.json
+++ b/syntaxes/oasis.json
@@ -18,7 +18,7 @@
 
     "fields": {
       "comment": "labeled field",
-      "match": "^\\s*([a-zA-Z0-9_]+)(:|\\+:|\\$:)",
+      "match": "^[[:space:]]*([[:word:]]+)(:|\\+:|\\$:)",
       "captures": {
         "1": { "name": "entity.name.tag.oasis" },
         "2": { "name": "keyword.operator.oasis" }
@@ -27,7 +27,7 @@
 
     "sections": {
       "comment": "labeled section",
-      "begin": "^\\s*(Flag|Library|Object|Executable|Document|Test|SourceRepository)",
+      "begin": "^[[:space:]]*(Flag|Library|Object|Executable|Document|Test|SourceRepository)",
       "beginCaptures": { "1": { "name": "keyword.other.oasis" } },
       "end": "$",
       "contentName": "string.other.oasis"
@@ -62,7 +62,7 @@
     },
 
     "substitution": {
-      "match": "\\$[a-zA-Z0-9_]+",
+      "match": "\\$[[:word:]]+",
       "name": "constant.language.oasis"
     }
   }

--- a/syntaxes/ocaml.interface.json
+++ b/syntaxes/ocaml.interface.json
@@ -20,16 +20,16 @@
         {
           "comment": "optional labeled argument",
           "name": "variable.parameter.optional.ocaml",
-          "match": "\\?([a-z_][A-Za-z0-9_']*)?"
+          "match": "\\?([[:lower:]_][[:word:]']*)?"
         },
         {
           "comment": "labeled argument",
           "name": "variable.parameter.labeled.ocaml",
-          "match": "~[a-z_][A-Za-z0-9_']*"
+          "match": "~[[:lower:]_][[:word:]']*"
         },
         {
           "comment": "module type of",
-          "match": "\\b(module)\\s+(type)\\s+(of)\\b",
+          "match": "\\b(module)[[:space:]]+(type)[[:space:]]+(of)\\b",
           "captures": {
             "1": { "name": "keyword.ocaml" },
             "2": { "name": "keyword.ocaml" },
@@ -38,7 +38,7 @@
         },
         {
           "comment": "type declaration",
-          "match": "\\b(type)\\s+(nonrec\\s+)?(_\\s+|[+-]?'[A-Za-z][A-Za-z0-9_']*\\s+|\\(.*\\)\\s+)?([a-z_][A-Za-z0-9_']*)",
+          "match": "\\b(type)[[:space:]]+(nonrec[[:space:]]+)?(_[[:space:]]+|[+-]?'[[:alpha:]][[:word:]']*[[:space:]]+|\\(.*\\)[[:space:]]+)?([[:lower:]_][[:word:]']*)",
           "captures": {
             "1": { "name": "keyword.ocaml" },
             "2": { "name": "keyword.ocaml" },
@@ -48,7 +48,7 @@
         },
         {
           "comment": "and declaration for let bindings, type declarations, class bindings, class type definitions, or module constraints",
-          "match": "\\b(and)\\s+(?!(?:module|type|lazy)\\b)(virtual\\s+)?(_\\s+|'[A-Za-z][A-Za-z0-9_']*\\s+|\\(.*\\)\\s+)?([a-z_][A-Za-z0-9_']*)\\s+(?!,|::)",
+          "match": "\\b(and)[[:space:]]+(?!(?:module|type|lazy)\\b(?!'))(virtual[[:space:]]+)?(_[[:space:]]+|'[[:alpha:]][[:word:]']*[[:space:]]+|\\(.*\\)[[:space:]]+)?([[:lower:]_][[:word:]']*)[[:space:]]+(?!,|::)",
           "captures": {
             "1": { "name": "keyword.ocaml" },
             "2": { "name": "keyword.ocaml" },
@@ -58,12 +58,12 @@
         },
         {
           "comment": "external declaration",
-          "begin": "\\b(external)\\s+([a-z_][A-Za-z0-9_']*)?",
+          "begin": "\\b(external)[[:space:]]+([[:lower:]_][[:word:]']*)?",
           "beginCaptures": {
             "1": { "name": "keyword.ocaml" },
             "2": { "name": "entity.name.function.binding.ocaml" }
           },
-          "end": "(?<=]|\")\\s*$",
+          "end": "(?<=]|\")[[:space:]]*$",
           "patterns": [
             {
               "comment": "string literal",
@@ -76,7 +76,7 @@
         },
         {
           "comment": "val declaration for class instance variables",
-          "match": "\\b(val)\\s+(virtual)\\s+(mutable)\\s+([a-z_][A-Za-z0-9_']*)",
+          "match": "\\b(val)[[:space:]]+(virtual)[[:space:]]+(mutable)[[:space:]]+([[:lower:]_][[:word:]']*)",
           "captures": {
             "1": { "name": "keyword.ocaml" },
             "2": { "name": "keyword.ocaml" },
@@ -86,7 +86,7 @@
         },
         {
           "comment": "val declaration for let bindings or class instance variables",
-          "match": "\\b(val|val!)\\s+(mutable\\s+)?(virtual\\s+)?([a-z_][A-Za-z0-9_']*)",
+          "match": "\\b(val|val!)[[:space:]]+(mutable[[:space:]]+)?(virtual[[:space:]]+)?([[:lower:]_][[:word:]']*)",
           "captures": {
             "1": { "name": "keyword.ocaml" },
             "2": { "name": "keyword.ocaml" },
@@ -96,7 +96,7 @@
         },
         {
           "comment": "class method declaration",
-          "match": "\\b(method)\\s+(virtual)\\s+(private)\\s+([a-z_][A-Za-z0-9_']*)",
+          "match": "\\b(method)[[:space:]]+(virtual)[[:space:]]+(private)[[:space:]]+([[:lower:]_][[:word:]']*)",
           "captures": {
             "1": { "name": "keyword.ocaml" },
             "2": { "name": "keyword.ocaml" },
@@ -106,7 +106,7 @@
         },
         {
           "comment": "class method declaration",
-          "match": "\\b(method|method!)\\s+(private\\s+)?(virtual\\s+)?([a-z_][A-Za-z0-9_']*)",
+          "match": "\\b(method|method!)[[:space:]]+(private[[:space:]]+)?(virtual[[:space:]]+)?([[:lower:]_][[:word:]']*)",
           "captures": {
             "1": { "name": "keyword.ocaml" },
             "2": { "name": "keyword.ocaml" },
@@ -116,7 +116,7 @@
         },
         {
           "comment": "class specification or class type definition with type parameters",
-          "match": "\\b(class)\\s*(\\s+type)?(\\s+virtual)?\\s*(\\[.*\\])\\s*([a-z_][A-Za-z0-9_']*)",
+          "match": "\\b(class)[[:space:]]*([[:space:]]+type)?([[:space:]]+virtual)?[[:space:]]*(\\[.*\\])[[:space:]]*([[:lower:]_][[:word:]']*)",
           "captures": {
             "1": { "name": "keyword.ocaml" },
             "2": { "name": "keyword.ocaml" },
@@ -127,7 +127,7 @@
         },
         {
           "comment": "class specification or class type definition",
-          "match": "\\b(class)\\s+(type\\s+)?(virtual\\s+)?([a-z_][A-Za-z0-9_']*)",
+          "match": "\\b(class)[[:space:]]+(type[[:space:]]+)?(virtual[[:space:]]+)?([[:lower:]_][[:word:]']*)",
           "captures": {
             "1": { "name": "keyword.ocaml" },
             "2": { "name": "keyword.ocaml" },
@@ -137,7 +137,7 @@
         },
         {
           "comment": "named self in object",
-          "match": "\\b(object)\\s*\\(\\s*([a-z_][A-Za-z0-9_']*)",
+          "match": "\\b(object)[[:space:]]*\\([[:space:]]*([[:lower:]_][[:word:]']*)",
           "captures": {
             "1": { "name": "keyword.ocaml" },
             "2": { "name": "entity.name.function.binding.ocaml" }
@@ -151,7 +151,7 @@
         {
           "comment": "reserved ocaml keyword (in interfaces)",
           "name": "keyword.other.ocaml.interface",
-          "match": "\\b(and|as|class|constraint|end|exception|external|functor|in|include|inherit|let\\s+open|module|mutable|nonrec|object|of|open|private|sig|type|val|virtual|with)\\b"
+          "match": "\\b(and|as|class|constraint|end|exception|external|functor|in|include|inherit|let[[:space:]]+open|module|mutable|nonrec|object|of|open|private|sig|type|val|virtual|with)\\b(?!')"
         }
       ]
     }

--- a/syntaxes/ocaml.json
+++ b/syntaxes/ocaml.json
@@ -22,7 +22,7 @@
       "patterns": [
         {
           "comment": "line number directive",
-          "begin": "^\\s*(#)\\s*([0-9]+)",
+          "begin": "^[[:space:]]*(#)[[:space:]]*([[:digit:]]+)",
           "end": "$",
           "beginCaptures": {
             "1": { "name": "keyword.other.ocaml" },
@@ -35,7 +35,7 @@
           "patterns": [
             {
               "comment": "general, loading codes",
-              "begin": "^\\s*(#)\\s*(help|quit|cd|directory|remove_directory|load_rec|load|use|mod_use)",
+              "begin": "^[[:space:]]*(#)[[:space:]]*(help|quit|cd|directory|remove_directory|load_rec|load|use|mod_use)",
               "end": "$",
               "beginCaptures": {
                 "1": { "name": "keyword.other.ocaml" },
@@ -45,7 +45,7 @@
             },
             {
               "comment": "environment queries",
-              "begin": "^\\s*(#)\\s*(show_class_type|show_class|show_exception|show_module_type|show_module|show_type|show_val|show)",
+              "begin": "^[[:space:]]*(#)[[:space:]]*(show_class_type|show_class|show_exception|show_module_type|show_module|show_type|show_val|show)",
               "end": "$",
               "beginCaptures": {
                 "1": { "name": "keyword.other.ocaml" },
@@ -58,7 +58,7 @@
             },
             {
               "comment": "pretty-printing, tracing",
-              "begin": "^\\s*(#)\\s*(install_printer|print_depth|print_length|remove_printer|trace|untrace_all|untrace)",
+              "begin": "^[[:space:]]*(#)[[:space:]]*(install_printer|print_depth|print_length|remove_printer|trace|untrace_all|untrace)",
               "end": "$",
               "beginCaptures": {
                 "1": { "name": "keyword.other.ocaml" },
@@ -71,7 +71,7 @@
             },
             {
               "comment": "compiler options",
-              "begin": "^\\s*(#)\\s*(labels|ppx|principal|rectypes|warn_error|warnings)",
+              "begin": "^[[:space:]]*(#)[[:space:]]*(labels|ppx|principal|rectypes|warn_error|warnings)",
               "end": "$",
               "beginCaptures": {
                 "1": { "name": "keyword.other.ocaml" },
@@ -86,7 +86,7 @@
         },
         {
           "comment": "topfind directives",
-          "begin": "^\\s*(#)\\s*(require|list|camlp4o|camlp4r|predicates|thread)",
+          "begin": "^[[:space:]]*(#)[[:space:]]*(require|list|camlp4o|camlp4r|predicates|thread)",
           "end": "$",
           "beginCaptures": {
             "1": { "name": "keyword.other.ocaml" },
@@ -96,7 +96,7 @@
         },
         {
           "comment": "cppo directives",
-          "begin": "^\\s*(#)\\s*(define|undef|ifdef|ifndef|if|else|elif|endif|include|warning|error|ext|endext)",
+          "begin": "^[[:space:]]*(#)[[:space:]]*(define|undef|ifdef|ifndef|if|else|elif|endif|include|warning|error|ext|endext)",
           "end": "$",
           "beginCaptures": {
             "1": { "name": "keyword.other.ocaml" },
@@ -169,10 +169,10 @@
         {
           "comment": "quoted string literal",
           "name": "string.quoted.braced.ocaml",
-          "begin": "\\{(%%?[A-Za-z_][A-Za-z0-9_']*(\\.[A-Za-z_][A-Za-z0-9_']*)*\\s*)?[a-z_]*\\|",
-          "end": "\\|[a-z_]*\\}",
+          "begin": "\\{(%%?[[:alpha:]_][[:word:]']*(\\.[[:alpha:]_][[:word:]']*)*[[:space:]]*)?[[:lower:]_]*\\|",
+          "end": "\\|[[:lower:]_]*\\}",
           "beginCaptures": {
-            "1": { "patterns": [{ "include": "$self" }] }
+            "1": { "name": "keyword.other.extension.ocaml" }
           },
           "patterns": [{ "include": "#strings" }]
         },
@@ -200,12 +200,12 @@
             {
               "comment": "character from decimal ASCII code",
               "name": "constant.character.escape.ocaml",
-              "match": "\\\\[0-9]{3}"
+              "match": "\\\\[[:digit:]]{3}"
             },
             {
               "comment": "character from hexadecimal ASCII code",
               "name": "constant.character.escape.ocaml",
-              "match": "\\\\x[0-9A-Fa-f]{2}"
+              "match": "\\\\x[[:xdigit:]]{2}"
             },
             {
               "comment": "character from octal ASCII code",
@@ -215,12 +215,12 @@
             {
               "comment": "unicode character escape sequence",
               "name": "constant.character.escape.ocaml",
-              "match": "\\\\u\\{[0-9A-Fa-f]{1,6}\\}"
+              "match": "\\\\u\\{[[:xdigit:]]{1,6}\\}"
             },
             {
               "comment": "printf format string",
               "name": "constant.character.printf.ocaml",
-              "match": "%[-0+ #]*([0-9]+|\\*)?(.([0-9]+|\\*))?[lLn]?[diunlLNxXosScCfFeEgGhHBbat!%@,]"
+              "match": "%[-0+ #]*([[:digit:]]+|\\*)?(.([[:digit:]]+|\\*))?[lLn]?[diunlLNxXosScCfFeEgGhHBbat!%@,]"
             },
             {
               "comment": "unknown escape sequence",
@@ -254,13 +254,13 @@
         {
           "comment": "character literal from decimal ASCII code",
           "name": "string.quoted.other.ocaml constant.character.ocaml",
-          "match": "'(\\\\[0-9]{3})'",
+          "match": "'(\\\\[[:digit:]]{3})'",
           "captures": { "1": { "name": "constant.character.escape.ocaml" } }
         },
         {
           "comment": "character literal from hexadecimal ASCII code",
           "name": "string.quoted.other.ocaml constant.character.ocaml",
-          "match": "'(\\\\x[0-9A-Fa-f]{2})'",
+          "match": "'(\\\\x[[:xdigit:]]{2})'",
           "captures": { "1": { "name": "constant.character.escape.ocaml" } }
         },
         {
@@ -281,7 +281,7 @@
     },
 
     "attributes": {
-      "begin": "\\[(@|@@|@@@)\\s*([a-zA-Z_]+(\\.[a-zA-Z0-9_']+)*)",
+      "begin": "\\[(@|@@|@@@)[[:space:]]*([[:alpha:]_]+(\\.[[:word:]']+)*)",
       "end": "\\]",
       "beginCaptures": {
         "1": { "name": "keyword.operator.attribute.ocaml" },
@@ -299,7 +299,7 @@
     },
 
     "extensions": {
-      "begin": "\\[(%|%%)\\s*([a-zA-Z_]+(\\.[a-zA-Z0-9_']+)*)",
+      "begin": "\\[(%|%%)[[:space:]]*([[:alpha:]_]+(\\.[[:word:]']+)*)",
       "end": "\\]",
       "beginCaptures": {
         "1": { "name": "keyword.operator.extension.ocaml" },
@@ -328,7 +328,7 @@
       "patterns": [
         {
           "comment": "for loop",
-          "match": "\\b(for)\\s+([a-z_][A-Za-z0-9_']*)",
+          "match": "\\b(for)[[:space:]]+([[:lower:]_][[:word:]']*)",
           "captures": {
             "1": { "name": "keyword.ocaml" },
             "2": { "name": "entity.name.function.binding.ocaml" }
@@ -336,7 +336,7 @@
         },
         {
           "comment": "local open/exception/module",
-          "match": "\\b(let)\\s+(open|exception|module)\\b",
+          "match": "\\b(let)[[:space:]]+(open|exception|module)\\b(?!')",
           "captures": {
             "1": { "name": "keyword.ocaml" },
             "2": { "name": "keyword.ocaml" }
@@ -344,7 +344,7 @@
         },
         {
           "comment": "let expression",
-          "match": "\\b(let)\\s+(?!lazy\\b)(rec\\s+)?([a-z_][A-Za-z0-9_']*)\\s+(?!,|::)",
+          "match": "\\b(let)[[:space:]]+(?!lazy\\b(?!'))(rec[[:space:]]+)?([[:lower:]_][[:word:]']*)[[:space:]]+(?!,|::)",
           "captures": {
             "1": { "name": "keyword.ocaml" },
             "2": { "name": "keyword.ocaml" },
@@ -353,7 +353,7 @@
         },
         {
           "comment": "using binding operators",
-          "match": "\\b(let|and)([$&*+\\-/=>@^|<][!?$&*+\\-/=>@^|%:]*)\\s*(?!lazy\\b)([a-z_][A-Za-z0-9_']*)\\s+(?!,|::)",
+          "match": "\\b(let|and)([$&*+\\-/=>@^|<][!?$&*+\\-/=>@^|%:]*)[[:space:]]*(?!lazy\\b(?!'))([[:lower:]_][[:word:]']*)[[:space:]]+(?!,|::)",
           "captures": {
             "1": { "name": "keyword.ocaml" },
             "2": { "name": "keyword.ocaml" },
@@ -362,7 +362,7 @@
         },
         {
           "comment": "first class module packing",
-          "match": "\\(\\s*(val)\\s+([a-z_][A-Za-z0-9_']*)",
+          "match": "\\([[:space:]]*(val)[[:space:]]+([[:lower:]_][[:word:]']*)",
           "captures": {
             "1": { "name": "keyword.ocaml" },
             "2": { "patterns": [{ "include": "$self" }] }
@@ -370,7 +370,7 @@
         },
         {
           "comment": "locally abstract types",
-          "match": "(?:\\(|(:))\\s*(type)((?:\\s+[a-z_][A-Za-z0-9_']*)+)",
+          "match": "(?:\\(|(:))[[:space:]]*(type)((?:[[:space:]]+[[:lower:]_][[:word:]']*)+)",
           "captures": {
             "1": {
               "name": "keyword.other.ocaml punctuation.other.colon punctuation.colon"
@@ -388,7 +388,7 @@
         {
           "comment": "reserved ocaml keyword",
           "name": "keyword.other.ocaml",
-          "match": "\\b(and|as|assert|begin|class|constraint|do|done|downto|else|end|exception|external|for|fun|function|functor|if|in|include|inherit|initializer|lazy|let|match|method|module|mutable|new|nonrec|object|of|open|private|rec|sig|struct|then|to|try|type|val|virtual|when|while|with)\\b"
+          "match": "\\b(and|as|assert|begin|class|constraint|do|done|downto|else|end|exception|external|for|fun|function|functor|if|in|include|inherit|initializer|lazy|let|match|method|module|mutable|new|nonrec|object|of|open|private|rec|sig|struct|then|to|try|type|val|virtual|when|while|with)\\b(?!')"
         }
       ]
     },
@@ -480,33 +480,33 @@
         {
           "comment": "floating point decimal literal with exponent",
           "name": "constant.numeric.decimal.float.ocaml",
-          "match": "\\b([0-9][0-9_]*(\\.[0-9_]*)?[eE][+-]?[0-9][0-9_]*[g-zG-Z]?)\\b"
+          "match": "\\b([[:digit:]][[:digit:]_]*(\\.[[:digit:]_]*)?[eE][+-]?[[:digit:]][[:digit:]_]*[g-zG-Z]?)\\b"
         },
         {
           "comment": "floating point decimal literal",
           "name": "constant.numeric.decimal.float.ocaml",
-          "match": "\\b([0-9][0-9_]*\\.[0-9_]*[g-zG-Z]?)\\b"
+          "match": "\\b([[:digit:]][[:digit:]_]*\\.[[:digit:]_]*[g-zG-Z]?)\\b"
         },
         {
           "comment": "floating point hexadecimal literal with exponent part",
           "name": "constant.numeric.hexadecimal.float.ocaml",
-          "match": "\\b((0x|0X)[0-9A-Fa-f][0-9A-Fa-f_]*(\\.[0-9A-Fa-f_]*)?[pP][+-]?[0-9][0-9_]*[g-zG-Z]?)\\b"
+          "match": "\\b((0x|0X)[[:xdigit:]][[:xdigit:]_]*(\\.[[:xdigit:]_]*)?[pP][+-]?[[:digit:]][[:digit:]_]*[g-zG-Z]?)\\b"
         },
         {
           "comment": "floating point hexadecimal literal",
           "name": "constant.numeric.hexadecimal.float.ocaml",
-          "match": "\\b((0x|0X)[0-9A-Fa-f][0-9A-Fa-f_]*\\.[0-9A-Fa-f_]*[g-zG-Z]?)\\b"
+          "match": "\\b((0x|0X)[[:xdigit:]][[:xdigit:]_]*\\.[[:xdigit:]_]*[g-zG-Z]?)\\b"
         },
 
         {
           "comment": "decimal integer literal",
           "name": "constant.numeric.decimal.integer.ocaml",
-          "match": "\\b([0-9][0-9_]*[lLng-zG-Z]?)\\b"
+          "match": "\\b([[:digit:]][[:digit:]_]*[lLng-zG-Z]?)\\b"
         },
         {
           "comment": "hexadecimal integer literal",
           "name": "constant.numeric.hexadecimal.integer.ocaml",
-          "match": "\\b((0x|0X)[0-9A-Fa-f][0-9A-Fa-f_]*[lLng-zG-Z]?)\\b"
+          "match": "\\b((0x|0X)[[:xdigit:]][[:xdigit:]_]*[lLng-zG-Z]?)\\b"
         },
         {
           "comment": "octal integer literal",
@@ -539,7 +539,7 @@
         {
           "comment": "type parameter",
           "name": "storage.type.ocaml",
-          "match": "'[A-Za-z][A-Za-z0-9_']*\\b"
+          "match": "'[[:alpha:]][[:word:]']*\\b"
         },
         {
           "comment": "builtin type",
@@ -554,17 +554,17 @@
         {
           "comment": "capital identifier for constructor, exception, or module",
           "name": "constant.language.capital-identifier.ocaml",
-          "match": "\\b[A-Z][A-Za-z0-9_']*('|\\b)"
+          "match": "\\b[[:upper:]][[:word:]']*('|\\b)"
         },
         {
           "comment": "lowercase identifier",
           "name": "source.ocaml",
-          "match": "\\b[a-z_][A-Za-z0-9_']*('|\\b)"
+          "match": "\\b[[:lower:]_][[:word:]']*('|\\b)"
         },
         {
           "comment": "polymorphic variant tag",
           "name": "constant.language.polymorphic-variant.ocaml",
-          "match": "\\`[A-Za-z][A-Za-z0-9_']*\\b"
+          "match": "\\`[[:alpha:]][[:word:]']*\\b"
         },
         {
           "comment": "empty list (can be used as a constructor)",

--- a/syntaxes/ocamlbuild.json
+++ b/syntaxes/ocamlbuild.json
@@ -19,7 +19,7 @@
     },
 
     "lines": {
-      "begin": "^\\s*",
+      "begin": "^[[:space:]]*",
       "end": "(:)|$",
       "endCaptures": { "1": { "name": "keyword.operator.ocamlbuild" } },
       "patterns": [{ "include": "#expressions" }]

--- a/syntaxes/ocamldoc.json
+++ b/syntaxes/ocamldoc.json
@@ -16,7 +16,7 @@
         {
           "comment": "ocamldoc documentation tag",
           "name": "keyword.doc-tag.ocamldoc",
-          "match": "\\@[a-z]+"
+          "match": "\\@[[:lower:]]+"
         },
         {
           "comment": "embedded ocaml source",

--- a/syntaxes/ocamlformat.json
+++ b/syntaxes/ocamlformat.json
@@ -107,7 +107,7 @@
         {
           "comment": "numeric literal",
           "name": "constant.numeric.decimal.ocamlformat",
-          "match": "\\b([0-9]+(\\.[0-9]*)*)\\b"
+          "match": "\\b([[:digit:]]+(\\.[[:digit:]]*)*)\\b"
         },
         {
           "name": "constant.language.ocamlformat",

--- a/syntaxes/ocamllex.json
+++ b/syntaxes/ocamllex.json
@@ -36,7 +36,7 @@
   ],
   "repository": {
     "rules": {
-      "match": "\\b(rule|and)\\s+([a-z][a-zA-Z0-9_']*('|\\b))",
+      "match": "\\b(rule|and)[[:space:]]+([[:lower:]][[:word:]']*('|\\b))",
       "captures": {
         "1": {
           "name": "keyword.other.ocamllex"
@@ -52,7 +52,7 @@
         {
           "comment": "ocamllex reserved keywords",
           "name": "keyword.other.ocamllex",
-          "match": "\\b(let|as|rule|and|parse|shortest|refill)\\b"
+          "match": "\\b(let|as|rule|and|parse|shortest|refill)\\b(?!')"
         },
         {
           "comment": "assignment operator",
@@ -100,7 +100,7 @@
         {
           "comment": "reference to regex pattern",
           "name": "entity.name.type.reference.ocamllex",
-          "match": "\\b[a-zA-Z][a-zA-Z0-9'_]*('|\\b)"
+          "match": "\\b[[:alpha:]][[:word:]']*('|\\b)"
         }
       ]
     }

--- a/syntaxes/opam-install.json
+++ b/syntaxes/opam-install.json
@@ -8,7 +8,7 @@
       "end": "$"
     },
     {
-      "match": "^\\s*(lib|lib_root|libexec|libexec_root|bin|sbin|toplevel|share|share_root|etc|doc|stublibs|man|misc)\\s*(:)",
+      "match": "^[[:space:]]*(lib|lib_root|libexec|libexec_root|bin|sbin|toplevel|share|share_root|etc|doc|stublibs|man|misc)[[:space:]]*(:)",
       "captures": {
         "1": { "name": "entity.name.tag.opam-install" },
         "2": { "name": "keyword.operator.opam-install" }

--- a/syntaxes/opam.json
+++ b/syntaxes/opam.json
@@ -26,7 +26,7 @@
 
     "fields": {
       "comment": "labeled field",
-      "match": "^([a-zA-Z0-9_\\-]*[a-zA-Z][a-zA-Z0-9_\\-]*)(:)",
+      "match": "^([[:word:]-]*[[:alpha:]][[:word:]-]*)(:)",
       "captures": {
         "1": { "name": "entity.name.tag.opam" },
         "2": { "name": "keyword.operator.opam" }
@@ -43,7 +43,7 @@
         {
           "comment": "integer literal",
           "name": "constant.numeric.decimal.opam",
-          "match": "(\\b|\\-?)[0-9]+\\b"
+          "match": "(\\b|\\-?)[[:digit:]]+\\b"
         },
         {
           "comment": "double-quote string literal",
@@ -66,7 +66,7 @@
         },
         {
           "comment": "identifier",
-          "match": "\\b([a-zA-Z0-9_\\-+]+)\\b",
+          "match": "\\b([[:word:]+-]+)\\b",
           "name": "variable.parameter.opam"
         }
       ]
@@ -87,12 +87,12 @@
         {
           "comment": "character from decimal ASCII code",
           "name": "constant.character.escape.opam",
-          "match": "\\\\[0-9]{3}"
+          "match": "\\\\[[:digit:]]{3}"
         },
         {
           "comment": "character from hexadecimal ASCII code",
           "name": "constant.character.escape.opam",
-          "match": "\\\\x[0-9A-Fa-f]{2}"
+          "match": "\\\\x[[:xdigit:]]{2}"
         },
         {
           "comment": "variable interpolation",


### PR DESCRIPTION
Inspired by the Reason grammar file, I have updated the other language syntaxes to use [Oniguruma character classes](https://github.com/kkos/oniguruma/blob/c5f0ad013490fb6db2a5cb5680028ebcb22fc486/doc/RE#L205) in regex when possible.

Makes it a little easier to read the syntax files.