### PR TITLE
Remove indentationRules for parentheses

### DIFF
--- a/languages/ocaml.json
+++ b/languages/ocaml.json
@@ -23,8 +23,8 @@
     ["\"", "\""]
   ],
   "indentationRules": {
-    "decreaseIndentPattern": "^\\s*(end|done|with|in|else)\\b|^\\s*;;|^[^\\(\"]*\\)",
-    "increaseIndentPattern": "^.*(\\([^)\"\\n]*|begin)$|\\bobject\\s*$|\\blet [a-zA-Z0-9_-]+( [^ ]+)* =\\s*$|method!?[ \\t]+.*=[ \\t]*$|->[ \\t]*$|\\b(for|while)(_lwt)?[ \\t]+.*[ \\t]+do[ \\t]*$|(\\btry(_lwt)?$|\\bif\\s+.*\\sthen$|\\belse|[:=]\\s*sig|=\\s*struct)\\s*$",
+    "decreaseIndentPattern": "^\\s*(end|done|with|in|else)\\b|^\\s*;;",
+    "increaseIndentPattern": "\\b(begin|object)\\s*$|\\blet [a-zA-Z0-9_-]+( [^ ]+)* =\\s*$|method!?[ \\t]+.*=[ \\t]*$|->[ \\t]*$|\\b(for|while)(_lwt)?[ \\t]+.*[ \\t]+do[ \\t]*$|(\\btry(_lwt)?$|\\bif\\s+.*\\sthen$|\\belse|[:=]\\s*sig|=\\s*struct)\\s*$",
     "indentNextLinePattern": "(?!\\bif.*then.*(else.*|(;|[ \\t]in)[ \\t]*$))\\bif|\\bthen[ \\t]*$|\\belse[ \\t]*$$"
   }
 }


### PR DESCRIPTION
VSCode already handles indentation for the configured `brackets`, so the regex that handled parentheses in `indentationRules` was unnecessary.

The identation rules for parentheses were also causing problems for some users. 