### PR TITLE
Reword Command Titles

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,22 +37,22 @@
       {
         "command": "ocaml.select-sandbox",
         "category": "OCaml",
-        "title": "Select sandbox for this workspace"
+        "title": "Select a Sandbox for this Workspace"
       },
       {
         "command": "ocaml.server.restart",
         "category": "OCaml",
-        "title": "Restart language server"
+        "title": "Restart Language Server"
       },
       {
         "command": "ocaml.open-terminal",
         "category": "OCaml",
-        "title": "Open a terminal (current sandbox)"
+        "title": "Create Terminal (Current Sandbox)"
       },
       {
         "command": "ocaml.open-terminal-select",
         "category": "OCaml",
-        "title": "Open a terminal (select a sandbox)"
+        "title": "Create Terminal (Select a Sandbox)"
       }
     ],
     "configuration": {


### PR DESCRIPTION
Makes the command titles Title-Case to follow the conventions of extension commands.

Also changes the title for "Open a Terminal" to "Create Terminal" to match the VSCode command. I'm not sure if it's necessary to change the command IDs too.