### PR TITLE
fix reason highlighting of module extension

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - Add the option to use a custom sandbox with a configurable command template
   (#322)
+- Fix Reason syntax highlighting of module extension (#335)
 
 ## 0.9.0
 

--- a/syntaxes/reason.json
+++ b/syntaxes/reason.json
@@ -499,7 +499,10 @@
       "beginCaptures": {
         "1": { "name": "keyword.control.less" }
       },
-      "patterns": [{ "include": "#structure-expression" }]
+      "patterns": [
+        { "include": "#structure-expression" },
+        { "include": "#extension-node" }
+      ]
     },
     "module-item-let-module-bind-name-params": {
       "begin": "\\b([[:upper:]][[:word:]]*)\\b",


### PR DESCRIPTION
Module extensions should be treated the same as pexp_extension

```reason
let x = [%y "abc"];
module X = [%y "abc"];
```