### PR TITLE
Highlight method keyword in ocaml interface

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 - Add the option to use a custom sandbox with a configurable command template
   (#322)
 - Fix Reason syntax highlighting of module extension (#335)
+- Highlight method keyword in ocaml interface (#340)
 
 ## 0.9.0
 

--- a/syntaxes/ocaml.interface.json
+++ b/syntaxes/ocaml.interface.json
@@ -151,7 +151,7 @@
         {
           "comment": "reserved ocaml keyword (in interfaces)",
           "name": "keyword.other.ocaml.interface",
-          "match": "\\b(and|as|class|constraint|end|exception|external|functor|in|include|inherit|let[[:space:]]+open|module|mutable|nonrec|object|of|open|private|sig|type|val|virtual|with)\\b(?!')"
+          "match": "\\b(and|as|class|constraint|end|exception|external|functor|in|include|inherit|let[[:space:]]+open|method|module|mutable|nonrec|object|of|open|private|sig|type|val|virtual|with)\\b(?!')"
         }
       ]
     }


### PR DESCRIPTION
The `method` keyword is valid in class types/specifications, which appear in .mli files and module signatures.