### PR TITLE
Improve highlighting of labels and attributes/extensions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - Highlight method keyword in ocaml interface (#340)
 - Add support for opam template file (#342)
+- Improve highlighting of labels and attributes/extensions in OCaml files (#343)
 
 ## 1.0.0
 

--- a/syntaxes/ocaml.interface.json
+++ b/syntaxes/ocaml.interface.json
@@ -25,7 +25,7 @@
         {
           "comment": "labeled argument",
           "name": "variable.parameter.labeled.ocaml",
-          "match": "~[[:lower:]_][[:word:]']*"
+          "match": "~([[:lower:]_][[:word:]']*)?"
         },
         {
           "comment": "module type of",

--- a/syntaxes/ocaml.json
+++ b/syntaxes/ocaml.json
@@ -379,6 +379,26 @@
             "3": { "name": "entity.name.function.binding.ocaml" }
           }
         },
+        {
+          "comment": "optional labeled argument with type",
+          "begin": "(\\?)\\([[:space:]]*([[:lower:]_][[:word:]']*)",
+          "beginCaptures": {
+            "1": { "name": "variable.parameter.optional.ocaml" },
+            "2": { "name": "variable.parameter.optional.ocaml" }
+          },
+          "end": "\\)",
+          "patterns": [{ "include": "$self" }]
+        },
+        {
+          "comment": "labeled argument with type",
+          "begin": "(~)\\([[:space:]]*([[:lower:]_][[:word:]']*)",
+          "beginCaptures": {
+            "1": { "name": "variable.parameter.labeled.ocaml" },
+            "2": { "name": "variable.parameter.labeled.ocaml" }
+          },
+          "end": "\\)",
+          "patterns": [{ "include": "$self" }]
+        },
         { "include": "source.ocaml.interface#bindings" }
       ]
     },
@@ -524,6 +544,12 @@
           "comment": "unit literal",
           "name": "constant.language.ocaml strong",
           "match": "\\(\\)"
+        },
+        {
+          "comment": "parentheses",
+          "begin": "\\(",
+          "end": "\\)",
+          "patterns": [{ "include": "$self" }]
         },
 
         {

--- a/syntaxes/ocaml.json
+++ b/syntaxes/ocaml.json
@@ -530,6 +530,24 @@
           "comment": "empty array",
           "name": "constant.language.ocaml strong",
           "match": "\\[\\|\\|\\]"
+        },
+        {
+          "comment": "array",
+          "begin": "\\[\\|",
+          "end": "\\|\\]",
+          "patterns": [{ "include": "$self" }]
+        },
+
+        {
+          "comment": "empty list",
+          "name": "constant.language.ocaml strong",
+          "match": "\\[\\]"
+        },
+        {
+          "comment": "list",
+          "begin": "\\[",
+          "end": "]",
+          "patterns": [{ "include": "$self" }]
         }
       ]
     },


### PR DESCRIPTION
Highlighting of `~`:
| Old | New |
| - | - |
| ![label-old](https://user-images.githubusercontent.com/25037249/91643894-08f44000-e9ec-11ea-8b45-6d3b9f5764fb.png) | ![label-new](https://user-images.githubusercontent.com/25037249/91643897-0db8f400-e9ec-11ea-9270-78c92151be2a.png) |

Brackets inside of attributes/extension nodes interacted poorly; see the highlighting of the last `"vscode"`:
| Old | New |
| - | - |
| ![bracket-old](https://user-images.githubusercontent.com/25037249/91643887-f8dc6080-e9eb-11ea-8f73-f0237d34274a.png) | ![bracket-new](https://user-images.githubusercontent.com/25037249/91643928-48bb2780-e9ec-11ea-8687-21d7287f989f.png) |


