### PR TITLE
Fix interaction between character literals and comments/escaped quotes in OCaml files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Change Log
 
+## Unreleased
+
+- Fix interaction between character literals and comments/escaped quotes in
+  OCaml files (#348)
+
 ## 1.1.0
 
 - Highlight method keyword in ocaml interface (#340)

--- a/syntaxes/ocaml.json
+++ b/syntaxes/ocaml.json
@@ -152,6 +152,10 @@
     "strings-in-comments": {
       "patterns": [
         {
+          "comment": "char literal",
+          "match": "'(\\\\)?.'"
+        },
+        {
           "comment": "string literal",
           "begin": "\"",
           "end": "\""
@@ -235,11 +239,6 @@
     "characters": {
       "patterns": [
         {
-          "comment": "character literal",
-          "name": "string.quoted.other.ocaml constant.character.ocaml",
-          "match": "'.'"
-        },
-        {
           "comment": "character literal from escaped backslash",
           "name": "string.quoted.other.ocaml constant.character.ocaml",
           "match": "'(\\\\\\\\)'",
@@ -276,6 +275,11 @@
           "captures": {
             "1": { "name": "invalid.illegal.unknown-escape.ocaml" }
           }
+        },
+        {
+          "comment": "character literal",
+          "name": "string.quoted.other.ocaml constant.character.ocaml",
+          "match": "'.'"
         }
       ]
     },


### PR DESCRIPTION
| Before | After |
| - | - |
| ![before](https://user-images.githubusercontent.com/25037249/91929814-1b90a280-ec94-11ea-9137-5bfdc9df1b1d.png) | ![after](https://user-images.githubusercontent.com/25037249/91929819-1df2fc80-ec94-11ea-970b-87372184c635.png) |

