### PR TITLE
Make .ocamlformat syntax highlighting more distinct

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Unreleased
 
 - Highlight dashes in PKG names for .merlin files (#349)
+- Make .ocamlformat syntax highlighting more distinct (#350)
 
 ## 1.1.1
 

--- a/syntaxes/ocamlformat.json
+++ b/syntaxes/ocamlformat.json
@@ -14,7 +14,7 @@
     },
     {
       "comment": "equals sign",
-      "name": "keyword.operator.ocamlformat",
+      "name": "punctuation.separator.key-value.ocamlformat",
       "match": "="
     }
   ],
@@ -101,7 +101,7 @@
       "patterns": [
         {
           "comment": "boolean literal",
-          "name": "constant.language.ocamlformat",
+          "name": "string.other.ocamlformat",
           "match": "\\b(true|false)\\b"
         },
         {
@@ -110,79 +110,79 @@
           "match": "\\b([[:digit:]]+(\\.[[:digit:]]*)*)\\b"
         },
         {
-          "name": "constant.language.ocamlformat",
+          "name": "string.other.ocamlformat",
           "match": "\\b(after-when-possible|after|align|all|always|auto)\\b"
         },
         {
-          "name": "constant.language.ocamlformat",
+          "name": "string.other.ocamlformat",
           "match": "\\b(before-except-val|before|begin-line)\\b"
         },
         {
-          "name": "constant.language.ocamlformat",
+          "name": "string.other.ocamlformat",
           "match": "\\b(closing-on-separate-line|compact|conventional)\\b"
         },
         {
-          "name": "constant.language.ocamlformat",
+          "name": "string.other.ocamlformat",
           "match": "\\b(decimal|default|double-semicolon)\\b"
         },
         {
-          "name": "constant.language.ocamlformat",
+          "name": "string.other.ocamlformat",
           "match": "\\b(end-line)\\b"
         },
         {
-          "name": "constant.language.ocamlformat",
+          "name": "string.other.ocamlformat",
           "match": "\\b(fit-or-vertical|fit|force)\\b"
         },
         {
-          "name": "constant.language.ocamlformat",
+          "name": "string.other.ocamlformat",
           "match": "\\b(hexadecimal)\\b"
         },
         {
-          "name": "constant.language.ocamlformat",
+          "name": "string.other.ocamlformat",
           "match": "\\b(indent)\\b"
         },
         {
-          "name": "constant.language.ocamlformat",
+          "name": "string.other.ocamlformat",
           "match": "\\b(janestreet)\\b"
         },
         {
-          "name": "constant.language.ocamlformat",
+          "name": "string.other.ocamlformat",
           "match": "\\b(k-r|keyword-first)\\b"
         },
         {
-          "name": "constant.language.ocamlformat",
+          "name": "string.other.ocamlformat",
           "match": "\\b(long|loose)\\b"
         },
         {
-          "name": "constant.language.ocamlformat",
+          "name": "string.other.ocamlformat",
           "match": "\\b(multi-line-only)\\b"
         },
         {
-          "name": "constant.language.ocamlformat",
+          "name": "string.other.ocamlformat",
           "match": "\\b(natural|nested|never|no|normal)\\b"
         },
         {
-          "name": "constant.language.ocamlformat",
+          "name": "string.other.ocamlformat",
           "match": "\\b(ocamlformat)\\b"
         },
         {
-          "name": "constant.language.ocamlformat",
+          "name": "string.other.ocamlformat",
           "match": "\\b(parens|preserve-one|preserve)\\b"
         },
         {
-          "name": "constant.language.ocamlformat",
+          "name": "string.other.ocamlformat",
           "match": "\\b(separator|short|smart|space|sparse)\\b"
         },
         {
-          "name": "constant.language.ocamlformat",
+          "name": "string.other.ocamlformat",
           "match": "\\b(terminator|tight-decl|tight|toplevel)\\b"
         },
         {
-          "name": "constant.language.ocamlformat",
+          "name": "string.other.ocamlformat",
           "match": "\\b(unsafe-no|unset)\\b"
         },
         {
-          "name": "constant.language.ocamlformat",
+          "name": "string.other.ocamlformat",
           "match": "\\b(wrap)\\b"
         }
       ]


### PR DESCRIPTION
Closes #324

The equals operator is now `punctuation.separator.key-value`, which is the same value as equal signs in `.gitconfig` or `.conf` files. Whether or not this makes the equals sign a different color from the options depends on the user's theme.

The option values are now highlighting as strings, which makes them a different color from keywords in the Dark+ theme or numbers in the file.

---

VSCode Dark+
| Before | After |
| - | - |
| ![before-dark](https://user-images.githubusercontent.com/25037249/91934974-7977b700-eca1-11ea-928a-9983a6156a18.png) | ![after-dark](https://user-images.githubusercontent.com/25037249/91934982-7e3c6b00-eca1-11ea-95d1-80b4cc1f1a81.png) |

Monokai
| Before | After |
| - | - |
| ![before-monokai](https://user-images.githubusercontent.com/25037249/91935033-9dd39380-eca1-11ea-80e4-91989f1c9793.png) | ![after-monokai](https://user-images.githubusercontent.com/25037249/91935039-a0ce8400-eca1-11ea-8ff2-42cc2435e08c.png) |

