### PR TITLE
Fix error when ocaml.sandbox is unset

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,8 @@ _Please report any bugs you encounter._
 1. Install this extension from
    [the VSCode Marketplace](https://marketplace.visualstudio.com/items?itemName=ocamllabs.ocaml-platform)
    (or by entering `ext install ocamllabs.ocaml-platform` at the command palette
-   <kbd>Ctrl</kbd>+<kbd>P</kbd> (<kbd>Cmd</kbd>+<kbd>Shift</kbd>+<kbd>P</kbd> on MacOS)
+   <kbd>Ctrl</kbd>+<kbd>P</kbd> (<kbd>Cmd</kbd>+<kbd>Shift</kbd>+<kbd>P</kbd> on
+   MacOS)
 2. Open a OCaml/ReasonML project (`File > Add Folder to Workspace...`)
 3. Install [OCaml-LSP](https://github.com/ocaml/ocaml-lsp) with
    [opam](https://github.com/ocaml/opam) or [esy](https://github.com/esy/esy).
@@ -113,7 +114,8 @@ configured VSCode shell and shell arguments will be used instead.
 ## Commands
 
 You can execute it by entering the following command at the command palette
-<kbd>Ctrl</kbd>+<kbd>P</kbd> (<kbd>Cmd</kbd>+<kbd>Shift</kbd>+<kbd>P</kbd> on MacOS).
+<kbd>Ctrl</kbd>+<kbd>P</kbd> (<kbd>Cmd</kbd>+<kbd>Shift</kbd>+<kbd>P</kbd> on
+MacOS).
 
 | Name                         | Description                        | Keyboard Shortcuts | Menu Contents |
 | ---------------------------- | ---------------------------------- | ------------------ | ------------- |

--- a/src/bindings/Vscode.ml
+++ b/src/bindings/Vscode.ml
@@ -82,7 +82,9 @@ end
 module WorkspaceConfiguration = struct
   type t
 
-  external get : t -> string -> Js.Json.t Js.Nullable.t = "get" [@@bs.send]
+  external get' : t -> string -> Js.Json.t Js.Nullable.t = "get" [@@bs.send]
+
+  let get t k = Js.Nullable.toOption (get' t k)
 
   type configurationTarget =
     | Global [@bs.as 1]

--- a/src/bindings/Vscode.ml
+++ b/src/bindings/Vscode.ml
@@ -82,7 +82,7 @@ end
 module WorkspaceConfiguration = struct
   type t
 
-  external get : t -> string -> Js.Json.t option = "get" [@@bs.send]
+  external get : t -> string -> Js.Json.t Js.Nullable.t = "get" [@@bs.send]
 
   type configurationTarget =
     | Global [@bs.as 1]

--- a/src/bindings/Vscode.mli
+++ b/src/bindings/Vscode.mli
@@ -101,7 +101,7 @@ end
 module WorkspaceConfiguration : sig
   type t
 
-  val get : t -> string -> Js.Json.t option
+  val get : t -> string -> Js.Json.t Js.Nullable.t
 
   type configurationTarget =
     | Global

--- a/src/bindings/Vscode.mli
+++ b/src/bindings/Vscode.mli
@@ -101,7 +101,7 @@ end
 module WorkspaceConfiguration : sig
   type t
 
-  val get : t -> string -> Js.Json.t Js.Nullable.t
+  val get : t -> string -> Js.Json.t option
 
   type configurationTarget =
     | Global

--- a/src/opam.mli
+++ b/src/opam.mli
@@ -1,5 +1,3 @@
-open Import
-
 module Switch : sig
   type t =
     | Local of Path.t

--- a/src/settings.ml
+++ b/src/settings.ml
@@ -11,7 +11,7 @@ let create ~scope ~key ~ofJson ~toJson = { scope; key; toJson; ofJson }
 
 let get ?section t =
   let section = Workspace.getConfiguration ?section () in
-  match Js.Nullable.toOption (WorkspaceConfiguration.get section t.key) with
+  match WorkspaceConfiguration.get section t.key with
   | None -> None
   | Some v -> (
     match t.ofJson v with

--- a/src/settings.ml
+++ b/src/settings.ml
@@ -11,15 +11,13 @@ let create ~scope ~key ~ofJson ~toJson = { scope; key; toJson; ofJson }
 
 let get ?section t =
   let section = Workspace.getConfiguration ?section () in
-  match WorkspaceConfiguration.get section t.key with
+  match Js.Nullable.toOption (WorkspaceConfiguration.get section t.key) with
   | None -> None
   | Some v -> (
     match t.ofJson v with
     | s -> Some s
     | exception Json.Decode.DecodeError msg ->
-      let (_ : unit Promise.t) =
-        Window.showErrorMessage (sprintf "Setting %s is invalid: %s" t.key msg)
-      in
+      message `Error "Setting %s is invalid: %s" t.key msg;
       None )
 
 let set ?section t v =


### PR DESCRIPTION
Closes #357

Currently when extension activates and `ocaml.sandbox` is unset, the editor shows 2 error messages:
![old](https://user-images.githubusercontent.com/25037249/92297649-74f80c00-eef6-11ea-8303-4341104c5e53.png)

`Settings.get` was supposed to handle null and undefined gracefully, but bucklescript doesn't seem to consider `null` as `None`.


This PR changes `WorkspaceConfiguration.get` to return `Js.Nullable.t`, which can be safely converted into an `option` in order to handle nulls correctly. The extra error message no longer appears.