### PR TITLE
Fix highlighting of comments that contain quoted string literals

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 - Highlight dashes in PKG names for .merlin files (#349)
 - Make .ocamlformat syntax highlighting more distinct (#350)
 - Improve highlighting of path elements and strings in .merlin files (#355)
+- Fix highlighting of comments that contain quoted string literals (#363)
 
 ## 1.1.1
 

--- a/syntaxes/ocaml.json
+++ b/syntaxes/ocaml.json
@@ -162,8 +162,8 @@
         },
         {
           "comment": "quoted string literal",
-          "begin": "\\{[^|]*\\|",
-          "end": "\\|[^}]*\\}"
+          "begin": "\\{[[:lower:]_]*\\|",
+          "end": "\\|[[:lower:]_]*\\}"
         }
       ]
     },


### PR DESCRIPTION
Closes #362 

[quoted-string-id](https://caml.inria.fr/pub/docs/manual-ocaml/lex.html#quoted-string-id) can only contain lowercase letters or underscores in a comment.