### PR TITLE
Fix highlighting of rec keyword in type-annotated functions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 - Make .ocamlformat syntax highlighting more distinct (#350)
 - Improve highlighting of path elements and strings in .merlin files (#355)
 - Fix highlighting of comments that contain quoted string literals (#363)
+- Fix highlighting of rec keyword in type-annotated functions (#364)
 
 ## 1.1.1
 

--- a/syntaxes/ocaml.json
+++ b/syntaxes/ocaml.json
@@ -348,7 +348,7 @@
         },
         {
           "comment": "let expression",
-          "match": "\\b(let)[[:space:]]+(?!lazy\\b(?!'))(rec[[:space:]]+)?([[:lower:]_][[:word:]']*)[[:space:]]+(?!,|::)",
+          "match": "\\b(let)[[:space:]]+(?!lazy\\b(?!'))(rec[[:space:]]+)?(?!rec\\b(?!'))([[:lower:]_][[:word:]']*)[[:space:]]+(?!,|::)",
           "captures": {
             "1": { "name": "keyword.ocaml" },
             "2": { "name": "keyword.ocaml" },


### PR DESCRIPTION

The last function's highlighting was fixed:
| Before | After |
| - | - |
| ![before](https://user-images.githubusercontent.com/25037249/92632864-0533a980-f287-11ea-8445-4acd630cd764.png) | ![after](https://user-images.githubusercontent.com/25037249/92632914-082e9a00-f287-11ea-8b54-512425f0b3ad.png) |