### PR TITLE
Prettifies sandbox info in status bar and created terminal

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,6 +5,10 @@ build:
 	yarn build
 .PHONY: build
 
+test:
+	yarn test
+.PHONY: test
+
 fmt:
 	ocamlformat --inplace --enable-outside-detected-project $(OCAML_SRCFILES)
 	refmt --in-place $(REASON_SRCFILES)

--- a/src/Extension.ml
+++ b/src/Extension.ml
@@ -82,7 +82,15 @@ module Instance = struct
     let statusBarItem =
       Window.createStatusBarItem ~alignment:StatusBarAlignment.(tToJs Left) ()
     in
-    let statusBarText = Toolchain.toString toolchain in
+    let packageManager = Toolchain.packageManager toolchain in
+    let statusBarText =
+      let packageIcon =
+        "$(package)"
+        (* see https://code.visualstudio.com/api/references/icons-in-labels *)
+      in
+      Printf.sprintf "%s %s" packageIcon
+      @@ Toolchain.PackageManager.toPrettyString packageManager
+    in
     statusBarItem##text#=statusBarText;
     statusBarItem##command#=selectSandboxCommandId;
     StatusBarItem.show statusBarItem;

--- a/src/Extension.ml
+++ b/src/Extension.ml
@@ -83,8 +83,8 @@ module Instance = struct
       Window.createStatusBarItem ~alignment:StatusBarAlignment.(tToJs Left) ()
     in
     let statusBarText = Toolchain.toString toolchain in
-    statusBarItem ## text #= statusBarText;
-    statusBarItem ## command #= selectSandboxCommandId;
+    statusBarItem##text#=statusBarText;
+    statusBarItem##command#=selectSandboxCommandId;
     StatusBarItem.show statusBarItem;
     t.statusBarItem <- Some statusBarItem;
 

--- a/src/TerminalSandbox.ml
+++ b/src/TerminalSandbox.ml
@@ -76,7 +76,8 @@ let create toolchain =
       | PowerShell bin -> { bin; args = [ "-c"; "& " ^ commandLine ] } )
   in
   Cmd.log (Spawn command);
-  let name = Toolchain.toString toolchain in
+  let packageManager = Toolchain.packageManager toolchain in
+  let name = Toolchain.PackageManager.toPrettyString packageManager in
   let shellPath = Path.toString bin in
   let shellArgs = Array.of_list args in
   Window.createTerminal ~name ~shellPath ~shellArgs ()

--- a/src/Toolchain.ml
+++ b/src/Toolchain.ml
@@ -117,11 +117,25 @@ module PackageManager = struct
     | Opam (_, switch) -> Printf.sprintf "opam(%s)" (Opam.Switch.name switch)
     | Global -> "global"
     | Custom _ -> "custom"
+
+  let toPrettyString t =
+    let print_opam = Printf.sprintf "opam(%s)" in
+    let print_esy = Printf.sprintf "esy(%s)" in
+    match t with
+    | Esy (_, root) ->
+      let projectName = Path.basename root in
+      print_esy projectName
+    | Opam (_, Named name) -> print_opam name
+    | Opam (_, Local path) ->
+      let projectName = Path.basename path in
+      print_opam projectName
+    | Global -> "Global"
+    | Custom _ -> "Custom"
 end
 
 type resources = PackageManager.t
 
-let toString t = "OCaml Platform | " ^ PackageManager.toString t
+let packageManager (t : resources) : PackageManager.t = t
 
 let availablePackageManagers () =
   { PackageManager.Kind.Hmap.opam = Opam.make ()

--- a/src/Toolchain.ml
+++ b/src/Toolchain.ml
@@ -86,7 +86,7 @@ module PackageManager = struct
         Esy manifest
       | Opam ->
         let switch =
-          field "switch" (fun js -> Opam.Switch.ofString (string js)) json
+          field "switch" (fun js -> Opam.Switch.make (string js)) json
         in
         Opam switch
       | Custom ->

--- a/src/Toolchain.ml
+++ b/src/Toolchain.ml
@@ -129,8 +129,8 @@ module PackageManager = struct
     | Opam (_, Local path) ->
       let projectName = Path.basename path in
       print_opam projectName
-    | Global -> "Global"
-    | Custom _ -> "Custom"
+    | Global -> "Global OCaml"
+    | Custom _ -> "Custom OCaml"
 end
 
 type resources = PackageManager.t

--- a/src/Toolchain.ml
+++ b/src/Toolchain.ml
@@ -100,8 +100,7 @@ module PackageManager = struct
       | Global -> Json.Encode.object_ [ kind ]
       | Esy manifest ->
         object_ [ kind; ("root", string @@ Path.toString manifest) ]
-      | Opam sw ->
-        object_ [ kind; ("switch", string @@ Opam.Switch.toString sw) ]
+      | Opam sw -> object_ [ kind; ("switch", string @@ Opam.Switch.name sw) ]
       | Custom template -> object_ [ kind; ("template", string template) ]
 
     let t = Settings.create ~scope:Workspace ~key:"sandbox" ~ofJson ~toJson
@@ -115,8 +114,7 @@ module PackageManager = struct
 
   let toString = function
     | Esy (_, root) -> Printf.sprintf "esy(%s)" (Path.toString root)
-    | Opam (_, switch) ->
-      Printf.sprintf "opam(%s)" (Opam.Switch.toString switch)
+    | Opam (_, switch) -> Printf.sprintf "opam(%s)" (Opam.Switch.name switch)
     | Global -> "global"
     | Custom _ -> "custom"
 end
@@ -169,7 +167,7 @@ let ofSettings () : PackageManager.t option Promise.t =
         message `Warn
           "Workspace is configured to use the switch %s. This switch does not \
            exist."
-          (Opam.Switch.toString switch);
+          (Opam.Switch.name switch);
         None
       | true -> Some (PackageManager.Opam (opam, switch)) ) )
   | Some Global -> Promise.return (Some PackageManager.Global)
@@ -199,7 +197,7 @@ module Candidate = struct
     in
     match packageManager with
     | PackageManager.Opam (_, s) ->
-      let label = Opam.Switch.toString s in
+      let label = Opam.Switch.name s in
       create ?detail ~label ()
     | Esy (_, p) ->
       create ?detail ~label:(Path.toString p) ~description:"Esy" ()

--- a/src/Toolchain.mli
+++ b/src/Toolchain.mli
@@ -24,15 +24,17 @@ module PackageManager : sig
     | Custom of string
 
   val toString : t -> string
+
+  val toPrettyString : t -> string
 end
 
 type resources
 
-val toString : resources -> string
-
 val ofSettings : unit -> PackageManager.t option Promise.t
 
 val makeResources : PackageManager.t -> resources
+
+val packageManager : resources -> PackageManager.t
 
 (** [selectAndSave] requires the process environment the plugin is being run in
    (ie VSCode's process environment) and the project root and produces a promise

--- a/src/opam.ml
+++ b/src/opam.ml
@@ -11,7 +11,7 @@ module Switch = struct
     else
       Named line
 
-  let toString = function
+  let name = function
     | Named s -> s
     | Local p -> Path.toString p
 end
@@ -45,7 +45,7 @@ let switchList t =
     []
   | Ok out -> parseSwitchList out
 
-let switchArg switch = "--switch=" ^ Switch.toString switch
+let switchArg switch = "--switch=" ^ Switch.name switch
 
 let exec t ~switch ~args =
   Cmd.Spawn (Cmd.append t ("exec" :: switchArg switch :: "--" :: args))

--- a/src/opam.ml
+++ b/src/opam.ml
@@ -2,8 +2,8 @@ open Import
 
 module Switch = struct
   type t =
-    | Local of Path.t
-    | Named of string
+    | Local of Path.t  (** if switch name is directory name where it's stored *)
+    | Named of string  (** if switch is stored in ~/.opam *)
 
   let make switch_name =
     if switch_name.[0] = '/' then

--- a/src/opam.ml
+++ b/src/opam.ml
@@ -5,11 +5,11 @@ module Switch = struct
     | Local of Path.t
     | Named of string
 
-  let ofString line =
-    if line.[0] = '/' then
-      Local (Path.ofString line)
+  let make switch_name =
+    if switch_name.[0] = '/' then
+      Local (Path.ofString switch_name)
     else
-      Named line
+      Named switch_name
 
   let name = function
     | Named s -> s
@@ -31,7 +31,7 @@ let parseSwitchList out =
   let result =
     Belt.List.keepMap lines (function
       | "" -> None
-      | s -> Some (Switch.ofString s))
+      | s -> Some (Switch.make s))
   in
   log "%d switches" (List.length result);
   result

--- a/src/opam.mli
+++ b/src/opam.mli
@@ -3,7 +3,7 @@ module Switch : sig
     | Local of Path.t
     | Named of string
 
-  val ofString : string -> t
+  val make : string -> t
 
   val name : t -> string
 end

--- a/src/opam.mli
+++ b/src/opam.mli
@@ -5,7 +5,7 @@ module Switch : sig
 
   val ofString : string -> t
 
-  val toString : t -> string
+  val name : t -> string
 end
 
 type t


### PR DESCRIPTION
Shortens the sandbox info displayed in the status bar (at the bottom of the editor) and the created terminal. This is a "prettify" PR but I'm very excited about it! :-)

It now looks like this:

For global sandbox:

![image](https://user-images.githubusercontent.com/16353531/93714253-baa50d80-fb61-11ea-8e00-022eab8089ac.png)

For named opam switch (located in ~/.opam):

![image](https://user-images.githubusercontent.com/16353531/93714255-bc6ed100-fb61-11ea-8160-7892201f7ad5.png)

For local opam switch:

![image](https://user-images.githubusercontent.com/16353531/93714256-bd9ffe00-fb61-11ea-8231-fe9eae9e11ed.png)

For esy sandbox:

![image](https://user-images.githubusercontent.com/16353531/93714260-c09aee80-fb61-11ea-974c-4d141b6b8478.png)

For custom:

![image](https://user-images.githubusercontent.com/16353531/93714298-f0e28d00-fb61-11ea-9d3f-39f0cca4c5c2.png)

-------------

For the `Create Terminal` command:

Global:

![image](https://user-images.githubusercontent.com/16353531/93714340-50409d00-fb62-11ea-85f4-5bda332de8d7.png)

Sandbox: 

![image](https://user-images.githubusercontent.com/16353531/93714343-56cf1480-fb62-11ea-8b87-32f8f0f29dd6.png)
