### PR TITLE
add keyboard shortcut for destruct code action

### DIFF
--- a/package.json
+++ b/package.json
@@ -67,6 +67,13 @@
         "command": "ocaml.switch-impl-intf",
         "key": "Alt+O",
         "when": "editorLangId  == ocaml || editorLangId  == ocaml.interface || editorLangId == reason || editorLangId == ocaml.ocamllex || editorLangId == ocaml.menhir"
+      },
+      {
+        "command": "editor.action.codeAction",
+        "key": "Alt+D",
+        "args": {
+          "kind": "destruct"
+        }
       }
     ],
     "menus": {

--- a/package.json
+++ b/package.json
@@ -73,7 +73,8 @@
         "key": "Alt+D",
         "args": {
           "kind": "destruct"
-        }
+        },
+        "when": "editorLangId  == ocaml || editorLangId == reason"
       }
     ],
     "menus": {


### PR DESCRIPTION
On `alt+d`, user gets what they would otherwise get by `cmd+.` to open quick fix options and picking the only option that we have "destruct". 

![image](https://user-images.githubusercontent.com/16353531/94994257-ce576780-0596-11eb-9ada-7c97779cdcf6.png)

User still can open quick fix options and pick "destruct" from there or just click on `alt+d`.