### PR TITLE
Fix launch.json and tasks.json for js_of_ocaml

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -10,7 +10,9 @@
       "type": "extensionHost",
       "request": "launch",
       "runtimeExecutable": "${execPath}",
-      "outFiles": ["${workspaceRoot}/**/*.bs.js"],
+      "outFiles": [
+        "${workspaceRoot}/_build/default/src/vscode_ocaml_platform.bc.js"
+      ],
       "args": [
         "--disable-extensions",
         "--extensionDevelopmentPath=${workspaceFolder}"
@@ -21,7 +23,9 @@
       "type": "extensionHost",
       "request": "launch",
       "runtimeExecutable": "${execPath}",
-      "outFiles": ["${workspaceRoot}/**/*.bs.js"],
+      "outFiles": [
+        "${workspaceRoot}/_build/default/src/vscode_ocaml_platform.bc.js"
+      ],
       "args": ["--extensionDevelopmentPath=${workspaceFolder}"]
     }
   ]

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -4,10 +4,10 @@
   "version": "2.0.0",
   "tasks": [
     {
-      "type": "npm",
-      "script": "watch",
-      "problemMatcher": "$tsc-watch",
-      "isBackground": true,
+      "type": "shell",
+      "command": "dune build @vscode -w",
+      "label": "dune build @vscode -w",
+      "problemMatcher": "$ocamlc",
       "presentation": {
         "reveal": "never"
       },


### PR DESCRIPTION
They previously had references to BuckleScript files or build system.