### PR TITLE
Fix vscodeignore for semver node_module

### DIFF
--- a/.vscodeignore
+++ b/.vscodeignore
@@ -20,6 +20,7 @@ Makefile
 
 !_build/default/src/vscode_ocaml_platform.bc.js
 
+!node_modules/semver/**
 !node_modules/vscode-jsonrpc/**
 !node_modules/vscode-languageclient/**
 !node_modules/vscode-languageserver-protocol/**


### PR DESCRIPTION
Previously semver was incorrectly ignored for packaging the vsix.