### PR TITLE
Fix path handling on Windows

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - Fix incomplete error message for missing commands (#400)
 - Fix highlighting of quoted string literals that contain quotes (#403)
+- Fix path handling for global sandboxes on Windows (#401)
 
 ## 1.3.1
 

--- a/src/bindings/node/node.ml
+++ b/src/bindings/node/node.ml
@@ -48,6 +48,10 @@ end
 module Path = struct
   val delimiter : string [@@js.global "path.delimiter"]
 
+  let delimiter =
+    assert (String.length delimiter = 1);
+    delimiter.[0]
+
   val basename : string -> string [@@js.global "path.basename"]
 
   val dirname : string -> string [@@js.global "path.dirname"]

--- a/src/bindings/node/node.ml
+++ b/src/bindings/node/node.ml
@@ -45,6 +45,20 @@ module Stream = struct
   val end_ : t -> unit [@@js.call]
 end
 
+module Path = struct
+  val delimiter : string [@@js.global "path.delimiter"]
+
+  val basename : string -> string [@@js.global "path.basename"]
+
+  val dirname : string -> string [@@js.global "path.dirname"]
+
+  val extname : string -> string [@@js.global "path.extname"]
+
+  val isAbsolute : string -> bool [@@js.global "path.isAbsolute"]
+
+  val join : (string list[@js.variadic]) -> string [@@js.global "path.join"]
+end
+
 module Fs = struct
   val read_dir : string -> string list Promise.t [@@js.global "fs.readDir"]
 

--- a/src/bindings/node/node.mli
+++ b/src/bindings/node/node.mli
@@ -49,7 +49,7 @@ module Stream : sig
 end
 
 module Path : sig
-  val delimiter : string
+  val delimiter : char
 
   val basename : string -> string
 

--- a/src/bindings/node/node.mli
+++ b/src/bindings/node/node.mli
@@ -48,6 +48,20 @@ module Stream : sig
   val end_ : t -> unit
 end
 
+module Path : sig
+  val delimiter : string
+
+  val basename : string -> string
+
+  val dirname : string -> string
+
+  val extname : string -> string
+
+  val isAbsolute : string -> bool
+
+  val join : string list -> string
+end
+
 module Fs : sig
   val read_dir : string -> (string list, string) result Promise.t
 

--- a/src/bindings/node/node_stub.js
+++ b/src/bindings/node/node_stub.js
@@ -1,5 +1,4 @@
 var fs = require("fs");
-var child_process = require("child_process");
 var promisify = require("util").promisify;
 
 joo_global_object.fs = {
@@ -8,7 +7,6 @@ joo_global_object.fs = {
   exists: promisify(fs.exists),
 };
 
-joo_global_object.child_process = {
-  exec: child_process.exec,
-  spawn: child_process.spawn,
-};
+joo_global_object.child_process = require("child_process");
+
+joo_global_object.path = require("path");

--- a/src/import.ml
+++ b/src/import.ml
@@ -9,11 +9,6 @@ module Process = Node.Process
 module ChildProcess = Node.ChildProcess
 module Fs = Node.Fs
 
-let env_sep =
-  match Sys.unix with
-  | true -> ':'
-  | false -> ';'
-
 let property_exists json property =
   Ojs.has_property (Jsonoo.t_to_js json) property
 

--- a/src/path.ml
+++ b/src/path.ml
@@ -8,7 +8,7 @@ let of_string s = s
 
 let to_string s = s
 
-let delimiter = Node.Path.delimiter.[0]
+let delimiter = Node.Path.delimiter
 
 let is_absolute t = Node.Path.isAbsolute t
 

--- a/src/path.ml
+++ b/src/path.ml
@@ -8,35 +8,34 @@ let of_string s = s
 
 let to_string s = s
 
-let is_absolute t = Filename.is_absolute t
+let delimiter = Node.Path.delimiter.[0]
+
+let is_absolute t = Node.Path.isAbsolute t
 
 let compare = String.compare
 
-let dirname = Filename.dirname
+let dirname = Node.Path.dirname
 
-let extname t =
-  match Filename.split_extension t with
-  | _, Some ext -> ext
-  | _, None -> ""
+let extname = Node.Path.extname
 
-let basename t = Filename.basename t
+let basename = Node.Path.basename
 
-let ( / ) = Filename.concat
+let join x y = Node.Path.join [ x; y ]
 
-let relative = ( / )
+let ( / ) = join
 
-let relative_all p xs = List.fold_left xs ~f:Filename.concat ~init:p
+let relative = join
 
-let join x y = Filename.concat x y
+let relative_all p xs = List.fold_left xs ~f:join ~init:p
 
 let with_ext x ~ext = x ^ ext
 
 let is_root = function
   | "" -> true
-  | x -> String.equal (Filename.dirname x) x
+  | x -> equal (dirname x) x
 
 let parent x =
   if is_root x then
     None
   else
-    Some (Filename.dirname x)
+    Some (dirname x)

--- a/src/path.mli
+++ b/src/path.mli
@@ -8,6 +8,8 @@ val of_string : string -> t
 
 val to_string : t -> string
 
+val delimiter : char
+
 val is_absolute : t -> bool
 
 val compare : t -> t -> int
@@ -18,13 +20,13 @@ val extname : t -> string
 
 val basename : t -> string
 
+val join : t -> t -> t
+
 val ( / ) : t -> string -> t
 
 val relative : t -> string -> t
 
 val relative_all : t -> string list -> t
-
-val join : t -> t -> t
 
 val with_ext : t -> ext:string -> t
 


### PR DESCRIPTION
Under the Js_of_ocaml build of the extension, `Sys.unix` is always true, which prevents the `Filename` module and `candidates` function from handling Windows paths properly. 

This PR switches to using the Node `path` module for filename functions, and `Platform.t` for the candidates function. 