### PR TITLE
Clean up bindings

### DIFF
--- a/src/bindings/node/node.ml
+++ b/src/bindings/node/node.ml
@@ -15,9 +15,7 @@ module Process = struct
 end
 
 module JsError = struct
-  type t = Promise.error [@@js]
-
-  let ofPromiseError (error : Promise.error) =
+  let message (error : Promise.error) =
     let js_error = [%js.of: Promise.error] error in
     if Ojs.has_property js_error "message" then
       [%js.to: string] (Ojs.get js_error "message")
@@ -28,7 +26,7 @@ end
 module Buffer = struct
   type t = private Ojs.t [@@js]
 
-  val to_string : t -> string [@@js.call]
+  val toString : t -> string [@@js.call]
 
   val from : string -> t [@@js.global "Buffer.from"]
 
@@ -64,15 +62,15 @@ module Path = struct
 end
 
 module Fs = struct
-  val read_dir : string -> string list Promise.t [@@js.global "fs.readDir"]
+  val readDir : string -> string list Promise.t [@@js.global "fs.readDir"]
 
-  let read_dir path =
-    read_dir path
+  let readDir path =
+    readDir path
     |> Promise.then_ ~fulfilled:Promise.Result.return
     |> Promise.catch ~rejected:(fun error ->
-           Promise.return (Error (JsError.ofPromiseError error)))
+           Promise.return (Error (JsError.message error)))
 
-  val read_file : string -> string Promise.t [@@js.global "fs.readFile"]
+  val readFile : string -> string Promise.t [@@js.global "fs.readFile"]
 
   val exists : string -> bool Promise.t [@@js.global "fs.exists"]
 end
@@ -148,8 +146,8 @@ module ChildProcess = struct
     ( on_close cp @@ fun code ->
       resolve
         { exitCode = code
-        ; stdout = Buffer.to_string !stdout
-        ; stderr = Buffer.to_string !stderr
+        ; stdout = Buffer.toString !stdout
+        ; stderr = Buffer.toString !stderr
         } );
 
     match stdin with

--- a/src/bindings/node/node.mli
+++ b/src/bindings/node/node.mli
@@ -11,13 +11,7 @@ module Process : sig
 end
 
 module JsError : sig
-  type t = Promise.error
-
-  val t_of_js : Ojs.t -> t
-
-  val t_to_js : t -> Ojs.t
-
-  val ofPromiseError : Promise.error -> string
+  val message : Promise.error -> string
 end
 
 module Buffer : sig
@@ -27,7 +21,7 @@ module Buffer : sig
 
   val t_to_js : t -> Ojs.t
 
-  val to_string : t -> string
+  val toString : t -> string
 
   val from : string -> t
 
@@ -63,9 +57,9 @@ module Path : sig
 end
 
 module Fs : sig
-  val read_dir : string -> (string list, string) result Promise.t
+  val readDir : string -> (string list, string) result Promise.t
 
-  val read_file : string -> string Promise.t
+  val readFile : string -> string Promise.t
 
   val exists : string -> bool Promise.t
 end

--- a/src/esy.ml
+++ b/src/esy.ml
@@ -29,7 +29,7 @@ module Discover = struct
     | "package.json" as fname -> (
       let manifest_file = Path.(project_root / fname) |> Path.to_string in
       let open Promise.Syntax in
-      Fs.read_file manifest_file >>| fun manifest ->
+      Fs.readFile manifest_file >>| fun manifest ->
       match Jsonoo.try_parse_opt manifest with
       | None -> invalid_json project_root
       | Some json ->
@@ -45,7 +45,7 @@ module Discover = struct
 
   let parse_dir dir =
     let open Promise.Syntax in
-    Path.to_string dir |> Fs.read_dir
+    Path.to_string dir |> Fs.readDir
     >>| (function
           | Ok res -> res
           | Error err ->

--- a/src/vscode_ocaml_platform.ml
+++ b/src/vscode_ocaml_platform.ml
@@ -245,7 +245,7 @@ let activate (extension : ExtensionContext.t) =
   |> Promise.Result.iter ~error:(fun e ->
          if not is_fallback then message `Error "%s" e)
   |> Promise.catch ~rejected:(fun e ->
-         let error_message = Node.JsError.ofPromiseError e in
+         let error_message = Node.JsError.message e in
          message `Error "Error: %s" error_message;
          Promise.return ())
 

--- a/vscode/vscode/vscode.mli
+++ b/vscode/vscode/vscode.mli
@@ -828,10 +828,9 @@ end
 module Event : sig
   type 'a t = listener:('a -> unit) -> Disposable.t
 
-  val t_of_js : (Ojs.t -> 'a) -> Ojs.t -> listener:('a -> 'b) -> Disposable.t
+  val t_of_js : (Ojs.t -> 'a) -> Ojs.t -> 'a t
 
-  val t_to_js :
-    ('a -> Ojs.t) -> (listener:('a -> unit) -> Disposable.t) -> Ojs.t
+  val t_to_js : ('a -> Ojs.t) -> 'a t -> Ojs.t
 end
 
 module CancellationToken : sig


### PR DESCRIPTION
- Keeps the original naming conventions for Node functions.

- Adds some type annotation to the VSCode bindings to make it easier to understand.