### PR TITLE
Update VSCode bindings for 1.50

### DIFF
--- a/src/dune_task_provider.ml
+++ b/src/dune_task_provider.ml
@@ -51,7 +51,7 @@ let get_shell_execution toolchain options =
     let args = List.map ~f:(fun a -> `String a) args in
     ShellExecution.makeCommandArgs ~command ~args ~options ()
 
-let compute_tasks ?token toolchain =
+let compute_tasks token toolchain =
   let open Promise.Syntax in
   let folders = Workspace.workspaceFolders () in
   let excludes =
@@ -59,7 +59,7 @@ let compute_tasks ?token toolchain =
     `String "{**/_*}"
   in
   let includes = `String "**/{dune,dune-project,dune-workspace}" in
-  Workspace.findFiles ~includes ~excludes ?token () >>| fun dunes ->
+  Workspace.findFiles ~includes ~excludes ~token () >>| fun dunes ->
   let tasks =
     List.map dunes ~f:(fun dune ->
         let scope, relative_path =
@@ -83,14 +83,14 @@ let compute_tasks ?token toolchain =
   in
   Some tasks
 
-let provide_tasks toolchain ?token () =
+let provide_tasks toolchain ~token =
   match Settings.get ~section:"ocaml" Setting.t with
   | None
   | Some false ->
     `Promise (Promise.return None)
-  | Some true -> `Promise (compute_tasks ?token toolchain)
+  | Some true -> `Promise (compute_tasks token toolchain)
 
-let resolve_tasks ~task ?token:_ () = `Promise (Promise.Option.return task)
+let resolve_tasks ~task ~token:_ = `Promise (Promise.Option.return task)
 
 let create () = ref None
 

--- a/vscode/vscode/vscode.ml
+++ b/vscode/vscode/vscode.ml
@@ -1709,25 +1709,17 @@ module TaskProvider = struct
   type t = private (* interface *) Ojs.t [@@js]
 
   val provideTasks :
-    t -> ?token:CancellationToken.t -> unit -> Task.t list ProviderResult.t
+    t -> token:CancellationToken.t -> Task.t list ProviderResult.t
     [@@js.call]
 
   val resolveTasks :
-       t
-    -> task:Task.t
-    -> ?token:CancellationToken.t
-    -> unit
-    -> Task.t ProviderResult.t
+    t -> task:Task.t -> token:CancellationToken.t -> Task.t ProviderResult.t
     [@@js.call]
 
   val create :
-       provideTasks:
-         (?token:CancellationToken.t -> unit -> Task.t list ProviderResult.t)
+       provideTasks:(token:CancellationToken.t -> Task.t list ProviderResult.t)
     -> resolveTasks:
-         (   task:Task.t
-          -> ?token:CancellationToken.t
-          -> unit
-          -> Task.t ProviderResult.t)
+         (task:Task.t -> token:CancellationToken.t -> Task.t ProviderResult.t)
     -> t
     [@@js.builder]
 end

--- a/vscode/vscode/vscode.mli
+++ b/vscode/vscode/vscode.mli
@@ -1718,23 +1718,15 @@ module TaskProvider : sig
   val t_to_js : t -> Ojs.t
 
   val provideTasks :
-    t -> ?token:CancellationToken.t -> unit -> Task.t list ProviderResult.t
+    t -> token:CancellationToken.t -> Task.t list ProviderResult.t
 
   val resolveTasks :
-       t
-    -> task:Task.t
-    -> ?token:CancellationToken.t
-    -> unit
-    -> Task.t ProviderResult.t
+    t -> task:Task.t -> token:CancellationToken.t -> Task.t ProviderResult.t
 
   val create :
-       provideTasks:
-         (?token:CancellationToken.t -> unit -> Task.t list ProviderResult.t)
+       provideTasks:(token:CancellationToken.t -> Task.t list ProviderResult.t)
     -> resolveTasks:
-         (   task:Task.t
-          -> ?token:CancellationToken.t
-          -> unit
-          -> Task.t ProviderResult.t)
+         (task:Task.t -> token:CancellationToken.t -> Task.t ProviderResult.t)
     -> t
 end
 


### PR DESCRIPTION
TaskProvider cancellation tokens are no longer optional in VSCode 1.50:

https://github.com/microsoft/vscode/blob/93c2f0fbf16c5a4b10e4d5f89737d9c2c25488a3/src/vs/vscode.d.ts#L6301

https://github.com/microsoft/vscode/blob/93c2f0fbf16c5a4b10e4d5f89737d9c2c25488a3/src/vs/vscode.d.ts#L6316