### PR TITLE
Handle empty workspaceFolders list

### DIFF
--- a/vscode/vscode/vscode.ml
+++ b/vscode/vscode/vscode.ml
@@ -1755,7 +1755,7 @@ module Progress = struct
 end
 
 module Workspace = struct
-  val workspaceFolders : unit -> WorkspaceFolder.t list
+  val workspaceFolders : unit -> WorkspaceFolder.t maybe_list
     [@@js.get "vscode.workspace.workspaceFolders"]
 
   val name : unit -> string or_undefined [@@js.get "vscode.workspace.name"]


### PR DESCRIPTION
`workspaceFolders` is empty if no folder in vscode is open.

`maybe_list` turns `undefined` results into an empty list.