### PR TITLE
Update README instructions to use ocaml-lsp-server from the opam repository

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ npm install esy --global
 ```json
 {
   "dependencies": {
-    "@opam/ocaml-lsp-server": "ocaml/ocaml-lsp:ocaml-lsp-server.opam",
+    "@opam/ocaml-lsp-server": "1.1.0",
     "@opam/reason": "*",
     "ocaml": "4.6.x"
   }

--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ _Please report any bugs you encounter._
 2. Open a OCaml/ReasonML project (`File > Add Folder to Workspace...`)
 3. Install [OCaml-LSP](https://github.com/ocaml/ocaml-lsp) with
    [opam](https://github.com/ocaml/opam) or [esy](https://github.com/esy/esy).
+   E.g. `opam install ocaml-lsp-server`
 
 ### Windows
 


### PR DESCRIPTION
It took me a few seconds of thinking to realize I was supposed to install `ocaml-lsp-server` and not `lsp`.  This is a minor thing for experienced users but I could see it tripping newer users up for awhile with false starts.