### PR TITLE
Remove duplicate esy sandboxes from package manager selection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Unreleased
 
 - Fix sandbox functionality when a folder is not opened (#409)
+- Remove duplicate esy sandboxes from package manager selection (#412)
 
 ## 1.3.2
 

--- a/src/esy.ml
+++ b/src/esy.ml
@@ -26,10 +26,10 @@ module Discover = struct
     | n -> n
 
   let invalid_json file json_file =
-    Some
-      { file
-      ; status = Error ("unable to parse " ^ json_file ^ " file for Esy")
-      }
+    let message =
+      Printf.sprintf "Esy manifest file '%s' is not a valid json file" json_file
+    in
+    Some { file; status = Error message }
 
   let is_esy_compatible filename json =
     String.equal filename "esy.json"

--- a/src/esy.ml
+++ b/src/esy.ml
@@ -18,6 +18,8 @@ let make () =
 module Discover = struct
   let valid file = Some { file; status = Ok () }
 
+  let compare l r = Path.compare l.file r.file
+
   let invalid_json file = Some { file; status = Error "unable to parse json" }
 
   let parse_file project_root = function
@@ -56,6 +58,7 @@ module Discover = struct
               dir;
             [])
     >>= Promise.List.filter_map (parse_file dir)
+    >>| List.dedup_and_sort ~compare
 
   let parse_dirs_up dir =
     let rec loop parsed_dirs dir =

--- a/src/esy.ml
+++ b/src/esy.ml
@@ -25,30 +25,27 @@ module Discover = struct
     | 0 -> compare_status l.status r.status
     | n -> n
 
-  let invalid_package_json file =
-    Some { file; status = Error "unable to parse package.json" }
+  let invalid_json file json_file =
+    Some { file; status = Error ("unable to parse " ^ json_file) }
+
+  let is_esy_compatible filename json =
+    String.equal filename "esy.json"
+    || ( property_exists json "dependencies"
+       || property_exists json "devDependencies" )
+       && property_exists json "esy"
 
   let parse_file project_root = function
-    | "esy.json"
-    | "opam" ->
-      Promise.return (valid project_root)
+    | "opam" -> Promise.return (valid project_root)
     | s when String.equal (Caml.Filename.extension s) ".opam" ->
       Promise.return (valid project_root)
-    | "package.json" as fname -> (
+    | ("esy.json" | "package.json") as fname -> (
       let manifest_file = Path.(project_root / fname) |> Path.to_string in
       let open Promise.Syntax in
       Fs.readFile manifest_file >>| fun manifest ->
       match Jsonoo.try_parse_opt manifest with
-      | None -> invalid_package_json project_root
-      | Some json ->
-        if
-          ( property_exists json "dependencies"
-          || property_exists json "devDependencies" )
-          && property_exists json "esy"
-        then
-          valid project_root
-        else
-          None )
+      | None -> invalid_json project_root fname
+      | Some json when is_esy_compatible fname json -> valid project_root
+      | _ -> None )
     | _ -> Promise.return None
 
   let parse_dir dir =

--- a/src/esy.ml
+++ b/src/esy.ml
@@ -26,7 +26,10 @@ module Discover = struct
     | n -> n
 
   let invalid_json file json_file =
-    Some { file; status = Error ("unable to parse " ^ json_file) }
+    Some
+      { file
+      ; status = Error ("unable to parse " ^ json_file ^ " file for Esy")
+      }
 
   let is_esy_compatible filename json =
     String.equal filename "esy.json"

--- a/src/esy.ml
+++ b/src/esy.ml
@@ -18,7 +18,12 @@ let make () =
 module Discover = struct
   let valid file = Some { file; status = Ok () }
 
-  let compare l r = Path.compare l.file r.file
+  let compare l r =
+    let compare_file = Path.compare in
+    let compare_status = Result.compare Unit.compare String.compare in
+    match compare_file l.file r.file with
+    | 0 -> compare_status l.status r.status
+    | n -> n
 
   let invalid_json file = Some { file; status = Error "unable to parse json" }
 

--- a/src/esy.ml
+++ b/src/esy.ml
@@ -25,7 +25,8 @@ module Discover = struct
     | 0 -> compare_status l.status r.status
     | n -> n
 
-  let invalid_json file = Some { file; status = Error "unable to parse json" }
+  let invalid_package_json file =
+    Some { file; status = Error "unable to parse package.json" }
 
   let parse_file project_root = function
     | "esy.json"
@@ -38,7 +39,7 @@ module Discover = struct
       let open Promise.Syntax in
       Fs.readFile manifest_file >>| fun manifest ->
       match Jsonoo.try_parse_opt manifest with
-      | None -> invalid_json project_root
+      | None -> invalid_package_json project_root
       | Some json ->
         if
           ( property_exists json "dependencies"

--- a/src/toolchain.ml
+++ b/src/toolchain.ml
@@ -208,6 +208,7 @@ module Candidate = struct
         match package_manager with
         | Opam (_, Local _) -> Some "Local switch"
         | Opam (_, Named _) -> Some "Global switch"
+        | Esy _ -> Some "Esy"
         | _ -> None )
     in
     match package_manager with
@@ -219,7 +220,7 @@ module Candidate = struct
     | Esy (_, p) ->
       let project_name = Path.basename p in
       let project_path = Path.to_string p in
-      create ~detail:project_path ~label:project_name ~description:"Esy" ()
+      create ~detail:project_path ~label:project_name ?description ()
     | Global ->
       create ~label:"Global" ?description
         ~detail:"Global toolchain inherited from the environment" ()

--- a/src/toolchain.ml
+++ b/src/toolchain.ml
@@ -203,7 +203,7 @@ module Candidate = struct
     let create = QuickPickItem.create in
     let description =
       match status with
-      | Error s -> Some (Printf.sprintf "invalid: %s" s)
+      | Error s -> Some (Printf.sprintf "Invalid sandbox: %s" s)
       | Ok () -> (
         match package_manager with
         | Opam (_, Local _) -> Some "Local switch"


### PR DESCRIPTION
| Before | After |
| - | - |
| ![before](https://user-images.githubusercontent.com/25037249/96499407-39917280-1202-11eb-8ba1-7dccd0b81c92.png) | ![after](https://user-images.githubusercontent.com/25037249/96499415-3c8c6300-1202-11eb-9fde-27af43403b21.png) |

This won't show an option for invalid toolchains though:
https://github.com/ocamllabs/vscode-ocaml-platform/blob/a1e21d0f95304cdf3e3606c296d029eba01aeb7f/src/esy.ml#L34

Should the extension even show an option to select if the package.json is invalid?