### PR TITLE
Fix fs.readFile binding

### DIFF
--- a/src/bindings/node/node.ml
+++ b/src/bindings/node/node.ml
@@ -70,7 +70,10 @@ module Fs = struct
     |> Promise.catch ~rejected:(fun error ->
            Promise.return (Error (JsError.message error)))
 
-  val readFile : string -> string Promise.t [@@js.global "fs.readFile"]
+  val readFile : string -> encoding:string -> string Promise.t
+    [@@js.global "fs.readFile"]
+
+  let readFile = readFile ~encoding:"utf8"
 
   val exists : string -> bool Promise.t [@@js.global "fs.exists"]
 end


### PR DESCRIPTION
`fs.readFile` can sometimes return a Buffer if the encoding is not provided: https://nodejs.org/api/fs.html#fs_fs_readfile_path_options_callback

From my quick testing, it seems that it only returns a Buffer if there are less than 24 characters in a file, which is why we didn't catch this issue before.