### PR TITLE
Allow selecting specific configuration files for Esy sandboxes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 - Fix sandbox functionality when a folder is not opened (#409)
 - Remove duplicate esy sandboxes from package manager selection (#412)
+- Allow selecting specific configuration files (esy.json, package.json, .opam)
+  for Esy sandboxes (#415)
 
 ## 1.3.2
 

--- a/src/esy.ml
+++ b/src/esy.ml
@@ -38,7 +38,7 @@ module Discover = struct
 
   let invalid_json root json_file =
     let message =
-      Printf.sprintf "Esy manifest file '%s' is not a valid json file" json_file
+      Printf.sprintf "manifest file '%s' is not a valid json file" json_file
     in
     Some { manifest = { root; file = Some json_file }; status = Error message }
 

--- a/src/esy.mli
+++ b/src/esy.mli
@@ -4,13 +4,26 @@ type t
 
 val make : unit -> t option Promise.t
 
+module Manifest : sig
+  type t =
+    { root : Path.t
+    ; file : string option
+    }
+
+  val path : t -> Path.t
+
+  val to_string : t -> string
+
+  val to_pretty_string : t -> string
+end
+
 type discover =
-  { file : Path.t
+  { manifest : Manifest.t
   ; status : (unit, string) result
   }
 
 val discover : dir:Path.t -> discover list Promise.t
 
-val exec : t -> manifest:Path.t -> args:string list -> Cmd.t
+val exec : t -> manifest:Manifest.t -> args:string list -> Cmd.t
 
-val setup_toolchain : t -> manifest:Path.t -> unit Or_error.t Promise.t
+val setup_toolchain : t -> manifest:Manifest.t -> unit Or_error.t Promise.t

--- a/src/toolchain.ml
+++ b/src/toolchain.ml
@@ -208,15 +208,20 @@ module Candidate = struct
 
   let to_quick_pick { package_manager; status } =
     let create = QuickPickItem.create in
+    let pm_description =
+      match package_manager with
+      | Opam (_, Local _) -> Some "Local switch"
+      | Opam (_, Named _) -> Some "Global switch"
+      | Esy _ -> Some "Esy"
+      | _ -> None
+    in
     let description =
-      match status with
-      | Error s -> Some (Printf.sprintf "Invalid sandbox: %s" s)
-      | Ok () -> (
-        match package_manager with
-        | Opam (_, Local _) -> Some "Local switch"
-        | Opam (_, Named _) -> Some "Global switch"
-        | Esy _ -> Some "Esy"
-        | _ -> None )
+      match (pm_description, status) with
+      | Some pm, Error s ->
+        Some (Printf.sprintf "%s [Invalid sandbox: %s]" pm s)
+      | None, Error s -> Some (Printf.sprintf "[Invalid sandbox: %s]" s)
+      | Some pm, Ok () -> Some pm
+      | None, Ok () -> None
     in
     match package_manager with
     | Package_manager.Opam (_, Named name) -> create ~label:name ?description ()

--- a/src/toolchain.mli
+++ b/src/toolchain.mli
@@ -19,7 +19,7 @@
 module Package_manager : sig
   type t =
     | Opam of Opam.t * Opam.Switch.t
-    | Esy of Esy.t * Path.t
+    | Esy of Esy.t * Esy.Manifest.t
     | Global
     | Custom of string
 


### PR DESCRIPTION
The settings.json serialization/deserialization stay backwards compatible to not break users' current settings. 

With this configuration, the extension will run `esy -P /some/dir/lib.opam`
```json
"ocaml.sandbox": {
	"kind": "esy",
	"root": "/some/dir",
	"file": "lib.opam"
}
```

With this (old) configuration, the extension will continue to run `esy -P /some/dir`
```json
"ocaml.sandbox": {
	"kind": "esy",
	"root": "/some/dir"
}
```

@ulugbekna: how's the formatting for the item labels and descriptions?

| Before |
| - |
| <img width="601" alt="before" src="https://user-images.githubusercontent.com/25037249/96531447-87c46700-123e-11eb-996f-5cb0f0e226e5.png"> |

| After w/ Errors | After w/o Errors |
| - | - |
| <img width="601" alt="after" src="https://user-images.githubusercontent.com/25037249/96531460-8c891b00-123e-11eb-955a-2b48039272c5.png"> | <img width="601" alt="image" src="https://user-images.githubusercontent.com/25037249/96532384-a62b6200-1240-11eb-8d03-4dbe8cb0408f.png"> |