### PR TITLE
Add `ocamlfind-secondary` dependency to the `esy` install instructions for BuckleScript

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,7 @@ npm install esy --global
 {
   "dependencies": {
     "@opam/ocaml-lsp-server": "1.1.0",
+    "@opam/ocamlfind-secondary": "*",
     "@opam/reason": "*",
     "ocaml": "4.6.x"
   }


### PR DESCRIPTION
I just tried to follow these instructions and it failed trying to build Dune. `ocaml-lsp` no longer builds on old versions of Dune, and new versions of Dune don't build on OCaml 4.06.

It turns out Dune supports building on old compilers via `ocamlfind-secondary` and then everything works.