### PR TITLE
Allow using workspaceFolder placeholder variable for more portable sandbox configurations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@
 - Only restart the language server for the `ocaml.server.restart` command (#426)
 - Use highlighting for character literals which is consistent with other
   languages in VS Code (#428)
+- Allow using `${workspaceFolder}` placeholder variable in sandbox
+  configurations for portable settings.json files (#424)
 
 ## 1.3.3
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@
 - Only restart the language server for the `ocaml.server.restart` command (#426)
 - Use highlighting for character literals which is consistent with other
   languages in VS Code (#428)
-- Allow using `${workspaceFolder}` placeholder variable in sandbox
+- Allow using `${workspaceFolder:folder_name}` placeholder variables in sandbox
   configurations for portable settings.json files (#424)
 
 ## 1.3.3

--- a/src/settings.ml
+++ b/src/settings.ml
@@ -32,3 +32,25 @@ let string =
   let to_json = Jsonoo.Encode.string in
   let of_json = Jsonoo.Decode.string in
   create ~of_json ~to_json
+
+let workspace_folder_var = "${workspaceFolder}"
+
+let workspace_path () =
+  match Workspace.workspaceFolders () with
+  | workspace_folder :: _ ->
+    Some (workspace_folder |> WorkspaceFolder.uri |> Uri.fsPath)
+  | [] -> None
+
+let resolve_workspace_var setting =
+  let path =
+    match workspace_path () with
+    | Some path -> path
+    | None -> Process.cwd ()
+  in
+  String.substr_replace_all setting ~pattern:workspace_folder_var ~with_:path
+
+let substitute_workspace_var setting =
+  match workspace_path () with
+  | Some path ->
+    String.substr_replace_all setting ~pattern:path ~with_:workspace_folder_var
+  | None -> setting

--- a/src/settings.ml
+++ b/src/settings.ml
@@ -44,12 +44,14 @@ let resolve_workspace_vars setting =
     List.find ~f:pred (Workspace.workspaceFolders ())
   in
   let regexp = Js_of_ocaml.Regexp.regexp "\\$\\{workspaceFolder:([^}]+)\\}" in
-  let replacer matched = function
-    | [] -> assert false (* name will always be captured *)
-    | name :: _ -> (
+  let replacer ~matched ~captures ~offset:_ ~string:_ =
+    match captures with
+    | [ name ] -> (
       match find_folder name with
       | Some folder -> workspace_folder_path folder
       | None -> matched )
+    | _ -> assert false
+    (* name will always be captured *)
   in
   Interop.Regexp.replace setting ~regexp ~replacer
 

--- a/src/settings.mli
+++ b/src/settings.mli
@@ -14,3 +14,9 @@ val create :
   -> 'a t
 
 val string : scope:ConfigurationTarget.t -> key:string -> string t
+
+(** replace ${workspaceFolder} with the first workspace folder that is open *)
+val resolve_workspace_var : string -> string
+
+(** replace the path of the first open workspace folder with ${workspaceFolder} *)
+val substitute_workspace_var : string -> string

--- a/src/settings.mli
+++ b/src/settings.mli
@@ -15,8 +15,8 @@ val create :
 
 val string : scope:ConfigurationTarget.t -> key:string -> string t
 
-(** replace ${workspaceFolder} with the first workspace folder that is open *)
-val resolve_workspace_var : string -> string
+(** replace ${workspaceFolder:folder_name} variables with workspace folder paths *)
+val resolve_workspace_vars : string -> string
 
-(** replace the path of the first open workspace folder with ${workspaceFolder} *)
-val substitute_workspace_var : string -> string
+(** replace workspace folder paths with ${workspaceFolder:folder_name} variables *)
+val substitute_workspace_vars : string -> string

--- a/src/toolchain.ml
+++ b/src/toolchain.ml
@@ -77,7 +77,7 @@ module Package_manager = struct
 
     let of_json json =
       let open Jsonoo.Decode in
-      let decode_vars json = Settings.resolve_workspace_var (string json) in
+      let decode_vars json = Settings.resolve_workspace_vars (string json) in
       let kind = field "kind" Kind.of_json json in
       match (kind : Kind.t) with
       | Global -> Global
@@ -97,7 +97,7 @@ module Package_manager = struct
 
     let to_json (t : t) =
       let open Jsonoo.Encode in
-      let encode_vars str = string (Settings.substitute_workspace_var str) in
+      let encode_vars str = string (Settings.substitute_workspace_vars str) in
       let kind = ("kind", Kind.to_json (kind t)) in
       match t with
       | Global -> Jsonoo.Encode.object_ [ kind ]

--- a/src/toolchain.ml
+++ b/src/toolchain.ml
@@ -105,7 +105,7 @@ module Package_manager = struct
         object_ [ kind; ("root", encode_vars @@ Path.to_string manifest) ]
       | Opam switch ->
         object_ [ kind; ("switch", encode_vars @@ Opam.Switch.name switch) ]
-      | Custom template -> object_ [ kind; ("template", encode_vars template) ]
+      | Custom template -> object_ [ kind; ("template", string template) ]
 
     let t = Settings.create ~scope:Workspace ~key:"sandbox" ~of_json ~to_json
   end

--- a/vscode/interop/dune
+++ b/vscode/interop/dune
@@ -2,4 +2,6 @@
  (public_name vscode.interop)
  (name interop)
  (libraries js_of_ocaml gen_js_api)
+ (preprocess
+  (pps gen_js_api.ppx))
  (modes byte))

--- a/vscode/interop/interop.ml
+++ b/vscode/interop/interop.ml
@@ -35,9 +35,34 @@ module Regexp = struct
 
   let t_of_js : Ojs.t -> Js_of_ocaml.Regexp.regexp = Obj.magic
 
-  type replacer = string -> (string list[@js.variadic]) -> string [@@js]
+  val replace :
+       string
+    -> regexp:t
+    -> replacer:(string -> (Ojs.t list[@js.variadic]) -> string)
+    -> string
+    [@@js.call]
 
-  val replace : string -> regexp:t -> replacer:replacer -> string [@@js.call]
+  type replacer =
+       matched:string
+    -> captures:string list
+    -> offset:int
+    -> string:string
+    -> string
+
+  let replace s ~regexp ~replacer =
+    let rec separate acc = function
+      | offset :: string :: _ when Ojs.type_of offset = "number" ->
+        (List.rev acc, [%js.to: int] offset, [%js.to: string] string)
+      | capture :: args -> separate ([%js.to: string] capture :: acc) args
+      | _ -> assert false
+      (* replacer arguments will always be terminated with
+         a numeric offset and final string *)
+    in
+    let js_replacer matched args =
+      let captures, offset, string = separate [] args in
+      replacer ~matched ~captures ~offset ~string
+    in
+    replace s ~regexp ~replacer:js_replacer
 end
 
 module Dict = struct

--- a/vscode/interop/interop.ml
+++ b/vscode/interop/interop.ml
@@ -34,6 +34,10 @@ module Regexp = struct
   let t_to_js : Js_of_ocaml.Regexp.regexp -> Ojs.t = Obj.magic
 
   let t_of_js : Ojs.t -> Js_of_ocaml.Regexp.regexp = Obj.magic
+
+  type replacer = string -> (string list[@js.variadic]) -> string [@@js]
+
+  val replace : string -> regexp:t -> replacer:replacer -> string [@@js.call]
 end
 
 module Dict = struct

--- a/vscode/interop/interop.mli
+++ b/vscode/interop/interop.mli
@@ -18,6 +18,10 @@ module Regexp : sig
   val t_to_js : Js_of_ocaml.Regexp.regexp -> Ojs.t
 
   val t_of_js : Ojs.t -> Js_of_ocaml.Regexp.regexp
+
+  type replacer = string -> string list -> string
+
+  val replace : string -> regexp:t -> replacer:replacer -> string
 end
 
 module Dict : sig

--- a/vscode/interop/interop.mli
+++ b/vscode/interop/interop.mli
@@ -19,7 +19,12 @@ module Regexp : sig
 
   val t_of_js : Ojs.t -> Js_of_ocaml.Regexp.regexp
 
-  type replacer = string -> string list -> string
+  type replacer =
+       matched:string
+    -> captures:string list
+    -> offset:int
+    -> string:string
+    -> string
 
   val replace : string -> regexp:t -> replacer:replacer -> string
 end


### PR DESCRIPTION
Closes #374

Allows using `${workspaceFolder}` for the sandbox setting's manifest/switch/template. Since this only replaces the variable, it's done during the JSON serialization/deserialization. Relative paths are still not supported, so no command execution logic was changed.

In a workspace editor, it resolves `${workspaceFolder}` with the path of the first workspace folder. If no workspace folders are open, `${workspaceFolder}` is resolved with the value of `Process.cwd`.

When selecting a sandbox, if the path of the workspace folder appears in a discovered configuration, it will be substituted with `${workspaceFolder}`. This makes the sandbox configurations portable by default.