### PR TITLE
Only restart language server for ocaml.server.restart

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - Stop highlighting ocaml unit/array/list literals with bold (#416)
 - Add a snippet `struct end` with prefix `struct` (#420)
+- Only restart the language server for the `ocaml.server.restart` command (#426)
 
 ## 1.3.3
 


### PR DESCRIPTION
Suggested by @ulugbekna

Previously `ocaml.server.restart` would needlessly dispose and recreate the status bar item, dune formatter, and dune task provider when all it needs to do is restart the language server.