### PR TITLE
Use syntax name for character which is consistent with other programming languages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 - Stop highlighting ocaml unit/array/list literals with bold (#416)
 - Add a snippet `struct end` with prefix `struct` (#420)
 - Only restart the language server for the `ocaml.server.restart` command (#426)
+- Use highlighting for character literals which is consistent with other languages in VS Code (#428)
 
 ## 1.3.3
 

--- a/syntaxes/ocaml.json
+++ b/syntaxes/ocaml.json
@@ -277,7 +277,7 @@
         },
         {
           "comment": "character literal",
-          "name": "string.quoted.other.ocaml constant.character.ocaml",
+          "name": "string.quoted.single.ocaml",
           "match": "'.'"
         }
       ]


### PR DESCRIPTION
`string.quoted.single` (without `character.constant`) is the syntax name used in other programming languages; e.g.,

- https://github.com/microsoft/vscode/blob/master/extensions/cpp/syntaxes/c.tmLanguage.json
- https://github.com/microsoft/vscode/blob/master/extensions/cpp/syntaxes/cpp.tmLanguage.json
- https://github.com/microsoft/vscode/blob/master/extensions/fsharp/syntaxes/fsharp.tmLanguage.json
- https://github.com/microsoft/vscode/blob/master/extensions/rust/syntaxes/rust.tmLanguage.json