### PR TITLE
Support error messages without characters in problem matcher

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@
   languages in VS Code (#428)
 - Allow using `${workspaceFolder:folder_name}` placeholder variables in sandbox
   configurations for portable settings.json files (#424)
+- Fix OCaml problem matcher for warning codes and error messages without
+  characters (#429)
 
 ## 1.3.3
 

--- a/package.json
+++ b/package.json
@@ -197,7 +197,7 @@
         ],
         "pattern": [
           {
-            "regexp": "^\\s*\\bFile\\b\\s*\"(.*)\",\\s*\\blines?\\b\\s*(\\d+)(?:-(\\d+))?,\\s*\\bcharacters\\b\\s*(\\d+)-(\\d+)\\s*:\\s*$",
+            "regexp": "^\\s*\\bFile\\b\\s*\"(.*)\",\\s*\\blines?\\b\\s*(\\d+)(?:-(\\d+))?(?:,\\s*\\bcharacters\\b\\s*(\\d+)-(\\d+)\\s*)?:\\s*$",
             "file": 1,
             "line": 2,
             "endLine": 3,

--- a/package.json
+++ b/package.json
@@ -205,7 +205,7 @@
             "endColumn": 5
           },
           {
-            "regexp": "^(?:\\s*\\bParse\\b\\s*)?\\s*\\b([Ee]rror|Warning)\\b\\s*(?:\\(\\s*\\bwarning\\b\\s*(\\d+)\\))?\\s*:\\s*(.*)$",
+            "regexp": "^(?:\\s*\\bParse\\b\\s*)?\\s*\\b([Ee]rror|Warning)\\b\\s*(?:(?:\\(\\s*\\bwarning\\b\\s*)?(\\d+)\\)?)?\\s*:\\s*(.*)$",
             "severity": 1,
             "code": 2,
             "message": 3

--- a/package.json
+++ b/package.json
@@ -567,6 +567,7 @@
   "scripts": {
     "test:esy": "node ./test/runEsyTests.js",
     "test:opam": "node ./test/runOpamTests.js",
+    "test:problems": "node ./test/runProblemMatcherTests.js",
     "test": "npm-run-all -s test:*",
     "package": "vsce package --yarn",
     "deploy": "vsce publish --yarn",

--- a/test/runProblemMatcherTests.js
+++ b/test/runProblemMatcherTests.js
@@ -1,0 +1,27 @@
+const path = require("path");
+
+const { runTests } = require("vscode-test");
+
+async function main() {
+  try {
+    // The folder containing the Extension Manifest package.json
+    // Passed to `--extensionDevelopmentPath`
+    const extensionDevelopmentPath = path.resolve(__dirname, "../");
+
+    // The path to the extension test script
+    // Passed to --extensionTestsPath
+    const extensionTestsPath = path.resolve(__dirname, "./suite/problems");
+
+    // Download VS Code, unzip it and run the integration test
+    await runTests({
+      extensionDevelopmentPath,
+      extensionTestsPath,
+      launchArgs: ["--disable-extensions"],
+    });
+  } catch (err) {
+    console.error("Failed to run tests");
+    process.exit(1);
+  }
+}
+
+main();

--- a/test/suite/problems.js
+++ b/test/suite/problems.js
@@ -1,0 +1,40 @@
+const path = require("path");
+const Mocha = require("mocha");
+const glob = require("glob");
+
+function run() {
+  // Create the mocha test
+  const mocha = new Mocha({
+    ui: "tdd",
+  });
+  // Use any mocha API
+  mocha.useColors(true);
+
+  const testsRoot = path.resolve(__dirname, "..");
+
+  return new Promise((c, e) => {
+    let files = ["problems.test.js"].map((f) =>
+      path.resolve(testsRoot, "suite", f)
+    );
+
+    // Add files to the test suite
+    files.forEach((f) => mocha.addFile(path.resolve(testsRoot, f)));
+
+    try {
+      // Run the mocha test
+      mocha.run((failures) => {
+        if (failures > 0) {
+          e(new Error(`${failures} tests failed.`));
+        } else {
+          c();
+        }
+      });
+    } catch (err) {
+      e(err);
+    }
+  });
+}
+
+module.exports = {
+  run,
+};

--- a/test/suite/problems.test.js
+++ b/test/suite/problems.test.js
@@ -1,0 +1,81 @@
+const assert = require("assert");
+
+let problemLocations = {
+  'File "file.ml", line 4, characters 6-7:': [
+    "file.ml",
+    "4",
+    undefined,
+    "6",
+    "7",
+  ],
+
+  'File "helloworld.ml", lines 4-7, characters 6-3:': [
+    "helloworld.ml",
+    "4",
+    "7",
+    "6",
+    "3",
+  ],
+
+  'File "src/intf_error.ml", line 1:': [
+    "src/intf_error.ml",
+    "1",
+    undefined,
+    undefined,
+    undefined,
+  ],
+};
+
+let problemMessages = {
+  "Error: This expression has type int": [
+    "Error",
+    undefined,
+    "This expression has type int",
+  ],
+
+  "Warning: Cannot safely evaluate the definition of the following cycle": [
+    "Warning",
+    undefined,
+    "Cannot safely evaluate the definition of the following cycle",
+  ],
+
+  "Warning 26: unused variable y.": ["Warning", "26", "unused variable y."],
+
+  "Error (warning 8): this pattern-matching is not exhaustive.": [
+    "Error",
+    "8",
+    "this pattern-matching is not exhaustive.",
+  ],
+};
+
+suite("Basic tests", () => {
+  test("Problem Matcher tests", async () => {
+    let locationRegex = new RegExp(
+      '^\\s*\\bFile\\b\\s*"(.*)",\\s*\\blines?\\b\\s*(\\d+)(?:-(\\d+))?(?:,\\s*\\bcharacters\\b\\s*(\\d+)-(\\d+)\\s*)?:\\s*$'
+    );
+
+    let messageRegex = new RegExp(
+      "^(?:\\s*\\bParse\\b\\s*)?\\s*\\b([Ee]rror|Warning)\\b\\s*(?:\\(\\s*\\bwarning\\b\\s*(\\d+)\\))?\\s*:\\s*(.*)$"
+    );
+
+    for (const [problem, expected] of Object.entries(problemLocations)) {
+      let captures = problem.match(locationRegex);
+      assert.notStrictEqual(
+        captures,
+        null,
+        "Location regex should match: " + problem
+      );
+      assert.deepStrictEqual(captures.slice(1), expected);
+    }
+
+    for (const [problem, expected] of Object.entries(problemMessages)) {
+      let captures = problem.match(messageRegex);
+      assert.notStrictEqual(
+        captures,
+        null,
+        "Message regex should match: " + problem
+      );
+      assert.deepStrictEqual(captures.slice(1), expected);
+    }
+  });
+});

--- a/test/suite/problems.test.js
+++ b/test/suite/problems.test.js
@@ -55,7 +55,7 @@ suite("Basic tests", () => {
     );
 
     let messageRegex = new RegExp(
-      "^(?:\\s*\\bParse\\b\\s*)?\\s*\\b([Ee]rror|Warning)\\b\\s*(?:\\(\\s*\\bwarning\\b\\s*(\\d+)\\))?\\s*:\\s*(.*)$"
+      "^(?:\\s*\\bParse\\b\\s*)?\\s*\\b([Ee]rror|Warning)\\b\\s*(?:(?:\\(\\s*\\bwarning\\b\\s*)?(\\d+)\\)?)?\\s*:\\s*(.*)$"
     );
 
     for (const [problem, expected] of Object.entries(problemLocations)) {


### PR DESCRIPTION
fix #425 

The error message about an implementation file not matching its signature
does not contain characters. The characters group of the problem match
must hence be optional.

```
File "virtuality2d/src/consts.ml", line 1:
Error: The implementation virtuality2d/src/consts.pp.ml
does not match the interface virtuality2d/src/.virtuality2d.objs/byte/virtuality2d__Consts.cmi:
Values do not match: val g : float is not included in val g : string
File "virtuality2d/src/consts.mli", line 1, characters 0-14:
Expected declaration
File "virtuality2d/src/consts.ml", line 1, characters 4-5:
Actual declaration
```

Note that I have only tested the regex in https://regex101.com/r/13ldQG/1