### PR TITLE
Highlight rec keyword in OCaml mli files for recursive modules

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Change Log
 
+## Unreleased
+
+- Highlight `rec` keyword in OCaml mli files for recursive modules (#434)
+
 ## 1.4.0
 
 - Stop highlighting ocaml unit/array/list literals with bold (#416)

--- a/syntaxes/ocaml.interface.json
+++ b/syntaxes/ocaml.interface.json
@@ -151,7 +151,7 @@
         {
           "comment": "reserved ocaml keyword (in interfaces)",
           "name": "keyword.other.ocaml.interface",
-          "match": "\\b(and|as|class|constraint|end|exception|external|functor|in|include|inherit|let[[:space:]]+open|method|module|mutable|nonrec|object|of|open|private|sig|type|val|virtual|with)\\b(?!')"
+          "match": "\\b(and|as|class|constraint|end|exception|external|functor|in|include|inherit|let[[:space:]]+open|method|module|mutable|nonrec|object|of|open|private|rec|sig|type|val|virtual|with)\\b(?!')"
         }
       ]
     }


### PR DESCRIPTION
Recursive modules types use the rec keyword in mli files: https://ocaml.org/releases/4.11/htmlman/manual024.html#s%3Arecursive-modules