### PR TITLE
Infer interface when switching to an non-existing interface

### DIFF
--- a/src/extension_instance.ml
+++ b/src/extension_instance.ml
@@ -57,7 +57,8 @@ let start_language_server toolchain =
   let ocaml_lsp = Ocaml_lsp.of_initialize_result initialize_result in
   if
     (not (Ocaml_lsp.has_interface_specific_lang_id ocaml_lsp))
-    || not (Ocaml_lsp.can_handle_switch_impl_intf ocaml_lsp)
+    || (not (Ocaml_lsp.can_handle_switch_impl_intf ocaml_lsp))
+    || not (Ocaml_lsp.can_handle_infer_intf ocaml_lsp)
     (* TODO: switch to ocaml-lsp version based approach
        Using [initializeResult] of [LanguageClient] we can get ocaml-lsp's version.
        We can use versions instead of capabilities to suggest the user to update their

--- a/src/ocaml_lsp.ml
+++ b/src/ocaml_lsp.ml
@@ -3,9 +3,14 @@ open! Import
 type t =
   { interfaceSpecificLangId : bool
   ; handleSwitchImplIntf : bool
+  ; handleInferIntf : bool
   }
 
-let default = { interfaceSpecificLangId = false; handleSwitchImplIntf = false }
+let default =
+  { interfaceSpecificLangId = false
+  ; handleSwitchImplIntf = false
+  ; handleInferIntf = false
+  }
 
 let default_field key decode default json =
   let open Jsonoo.Decode in
@@ -22,7 +27,10 @@ let of_json (json : Jsonoo.t) =
       default_field "handleSwitchImplIntf" bool default.handleSwitchImplIntf
         json
     in
-    { interfaceSpecificLangId; handleSwitchImplIntf }
+    let handleInferIntf =
+      default_field "handleInferIntf" bool default.handleInferIntf json
+    in
+    { interfaceSpecificLangId; handleSwitchImplIntf; handleInferIntf }
   with Jsonoo.Decode_error _ ->
     show_message `Warn
       "unexpected experimental capabilities from lsp server. Some features \
@@ -41,3 +49,5 @@ let of_initialize_result (t : LanguageClient.InitializeResult.t) =
 let has_interface_specific_lang_id t = t.interfaceSpecificLangId
 
 let can_handle_switch_impl_intf t = t.handleSwitchImplIntf
+
+let can_handle_infer_intf t = t.handleSwitchImplIntf

--- a/src/ocaml_lsp.mli
+++ b/src/ocaml_lsp.mli
@@ -7,3 +7,5 @@ val of_initialize_result : LanguageClient.InitializeResult.t -> t
 val has_interface_specific_lang_id : t -> bool
 
 val can_handle_switch_impl_intf : t -> bool
+
+val can_handle_infer_intf : t -> bool


### PR DESCRIPTION
This PR changes the behavior of the switch implementation-interface feature to initialize the interface with an inferred one when switching to a non-existing file.

It depends on https://github.com/ocaml/ocaml-lsp/pull/308.

I implemented a custom request `ocamllsp/inferIntf` in `ocaml-lsp`, because running a codeAction automatically did not seem like a good way to implement this. The code action is still in place though: when switching to an existing interface, we can select some text and replace it with the inferred interface.