### PR TITLE
Redesign extension state (Instance)

### DIFF
--- a/src/cmd.ml
+++ b/src/cmd.ml
@@ -25,8 +25,8 @@ let candidates bin =
   | Win32 -> [ bin_ext ".exe"; bin_ext ".cmd" ]
   | _ -> [ bin ]
 
-let which path bin =
-  String.split ~on:Path.delimiter path
+let which path_env_var bin =
+  String.split ~on:Path.delimiter path_env_var
   |> Promise.List.find_map (fun p ->
          let p = Path.of_string p in
          candidates bin

--- a/src/cmd.ml
+++ b/src/cmd.ml
@@ -103,3 +103,6 @@ let output ?stdin (t : t) =
       (Printf.sprintf
          "Command failed with %s See output channel for more details"
          result.stderr)
+
+let equal_spawn s1 s2 =
+  Path.equal s1.bin s2.bin && List.equal String.equal s1.args s2.args

--- a/src/cmd.mli
+++ b/src/cmd.mli
@@ -26,3 +26,5 @@ val check : t -> t Or_error.t Promise.t
 val log : ?result:ChildProcess.return -> t -> unit
 
 val output : ?stdin:string -> t -> (stdout, stderr) result Promise.t
+
+val equal_spawn : spawn -> spawn -> bool

--- a/src/dune_formatter.ml
+++ b/src/dune_formatter.ml
@@ -23,7 +23,7 @@ let get_formatter toolchain ~document ~options:_ ~token:_ =
     match output with
     | Ok newText -> Some [ TextEdit.replace ~range ~newText ]
     | Error msg ->
-      message `Error "Dune formatting failed: %s" msg;
+      show_message `Error "Dune formatting failed: %s" msg;
       Some []
   in
   `Promise promise

--- a/src/dune_formatter.ml
+++ b/src/dune_formatter.ml
@@ -14,7 +14,7 @@ let get_formatter instance ~document ~options:_ ~token:_ =
   let command =
     let toolchain =
       (* we're gonna remove [value_exn] use later (we refactor instance creation) *)
-      Option.value_exn instance.Extension_instance.toolchain
+      instance.Extension_instance.toolchain
     in
     Toolchain.get_dune_command toolchain [ "format-dune-file" ]
   in

--- a/src/dune_formatter.ml
+++ b/src/dune_formatter.ml
@@ -14,7 +14,7 @@ let get_formatter instance ~document ~options:_ ~token:_ =
   let command =
     let toolchain =
       (* we're gonna remove [value_exn] use later (we refactor instance creation) *)
-      instance.Extension_instance.toolchain
+      Extension_instance.toolchain instance
     in
     Toolchain.get_dune_command toolchain [ "format-dune-file" ]
   in

--- a/src/dune_formatter.ml
+++ b/src/dune_formatter.ml
@@ -13,7 +13,6 @@ let get_formatter instance ~document ~options:_ ~token:_ =
   let document_text = TextDocument.getText document ~range () in
   let command =
     let toolchain =
-      (* we're gonna remove [value_exn] use later (we refactor instance creation) *)
       Extension_instance.toolchain instance
     in
     Toolchain.get_dune_command toolchain [ "format-dune-file" ]

--- a/src/dune_formatter.ml
+++ b/src/dune_formatter.ml
@@ -12,9 +12,7 @@ let get_formatter instance ~document ~options:_ ~token:_ =
   (* text of entire document *)
   let document_text = TextDocument.getText document ~range () in
   let command =
-    let toolchain =
-      Extension_instance.toolchain instance
-    in
+    let toolchain = Extension_instance.toolchain instance in
     Toolchain.get_dune_command toolchain [ "format-dune-file" ]
   in
   let output =

--- a/src/dune_formatter.ml
+++ b/src/dune_formatter.ml
@@ -34,7 +34,7 @@ let get_formatter instance ~document ~options:_ ~token:_ =
   in
   `Promise promise
 
-let register instance =
+let register extension instance =
   [ "dune"; "dune-project"; "dune-workspace" ]
   |> List.map ~f:(fun language ->
          let selector =
@@ -45,3 +45,5 @@ let register instance =
              ~provideDocumentFormattingEdits:(get_formatter instance)
          in
          Languages.registerDocumentFormattingEditProvider ~selector ~provider)
+  |> List.iter ~f:(fun disposable ->
+         ExtensionContext.subscribe extension ~disposable)

--- a/src/dune_formatter.mli
+++ b/src/dune_formatter.mli
@@ -3,7 +3,7 @@ type t
 val create : unit -> t
 
 (** register formatters for dune, dune-project, and dune-workspace files *)
-val register : t -> Toolchain.resources -> unit
+val register : t -> Toolchain.t -> unit
 
 (** dispose registered formatters *)
 val dispose : t -> unit

--- a/src/dune_formatter.mli
+++ b/src/dune_formatter.mli
@@ -1,9 +1,2 @@
-type t
-
-val create : unit -> t
-
 (** register formatters for dune, dune-project, and dune-workspace files *)
-val register : t -> Toolchain.t -> unit
-
-(** dispose registered formatters *)
-val dispose : t -> unit
+val register : Extension_instance.t -> Vscode.Disposable.t list

--- a/src/dune_formatter.mli
+++ b/src/dune_formatter.mli
@@ -1,2 +1,3 @@
-(** register formatters for dune, dune-project, and dune-workspace files *)
+(** register formatters for dune, dune-project, and dune-workspace files;
+    takes care of subscribing of the disposable to the execution context *)
 val register : Vscode.ExtensionContext.t -> Extension_instance.t -> unit

--- a/src/dune_formatter.mli
+++ b/src/dune_formatter.mli
@@ -1,2 +1,2 @@
 (** register formatters for dune, dune-project, and dune-workspace files *)
-val register : Extension_instance.t -> Vscode.Disposable.t list
+val register : Vscode.ExtensionContext.t -> Extension_instance.t -> unit

--- a/src/dune_task_provider.ml
+++ b/src/dune_task_provider.ml
@@ -87,7 +87,7 @@ let provide_tasks instance ~token =
   | Some false ->
     `Promise (Promise.return None)
   | Some true ->
-    let toolchain = instance.Extension_instance.toolchain in
+    let toolchain = Extension_instance.toolchain instance in
     `Promise (compute_tasks token toolchain)
 
 let resolve_tasks ~task ~token:_ = `Promise (Promise.Option.return task)

--- a/src/dune_task_provider.ml
+++ b/src/dune_task_provider.ml
@@ -87,7 +87,7 @@ let provide_tasks instance ~token =
   | Some false ->
     `Promise (Promise.return None)
   | Some true ->
-    let toolchain = Option.value_exn instance.Extension_instance.toolchain in
+    let toolchain = instance.Extension_instance.toolchain in
     `Promise (compute_tasks token toolchain)
 
 let resolve_tasks ~task ~token:_ = `Promise (Promise.Option.return task)

--- a/src/dune_task_provider.ml
+++ b/src/dune_task_provider.ml
@@ -92,8 +92,9 @@ let provide_tasks instance ~token =
 
 let resolve_tasks ~task ~token:_ = `Promise (Promise.Option.return task)
 
-let register instance =
+let register extension instance =
   let provideTasks = provide_tasks instance in
   let resolveTasks = resolve_tasks in
   let provider = TaskProvider.create ~provideTasks ~resolveTasks in
-  Tasks.registerTaskProvider ~type_:task_type ~provider
+  let disposable = Tasks.registerTaskProvider ~type_:task_type ~provider in
+  ExtensionContext.subscribe extension ~disposable

--- a/src/dune_task_provider.mli
+++ b/src/dune_task_provider.mli
@@ -8,6 +8,6 @@ type t
 
 val create : unit -> t
 
-val register : t -> Toolchain.resources -> unit
+val register : t -> Toolchain.t -> unit
 
 val dispose : t -> unit

--- a/src/dune_task_provider.mli
+++ b/src/dune_task_provider.mli
@@ -4,10 +4,4 @@
     file that it can find in the workspace. It doesn't parse the dune files.
 *)
 
-type t
-
-val create : unit -> t
-
-val register : t -> Toolchain.t -> unit
-
-val dispose : t -> unit
+val register : Extension_instance.t -> Vscode.Disposable.t

--- a/src/dune_task_provider.mli
+++ b/src/dune_task_provider.mli
@@ -4,4 +4,6 @@
     file that it can find in the workspace. It doesn't parse the dune files.
 *)
 
+(** registers dune task provider within the vscode task providers;
+    takes care of subscribing the disposable to the extension context *)
 val register : Vscode.ExtensionContext.t -> Extension_instance.t -> unit

--- a/src/dune_task_provider.mli
+++ b/src/dune_task_provider.mli
@@ -4,4 +4,4 @@
     file that it can find in the workspace. It doesn't parse the dune files.
 *)
 
-val register : Extension_instance.t -> Vscode.Disposable.t
+val register : Vscode.ExtensionContext.t -> Extension_instance.t -> unit

--- a/src/esy.ml
+++ b/src/esy.ml
@@ -62,7 +62,7 @@ module Discover = struct
     | Error err ->
       let dir = Path.to_string dir in
       log "unable to read dir %s. error %s" dir err;
-      message `Warn
+      show_message `Warn
         "Unable to read %s. No esy projects will be inferred from here" dir;
       Promise.return []
 
@@ -121,5 +121,5 @@ let setup_toolchain t ~manifest =
   | State.Ready -> ()
   | Pending ->
     let root_dir = Path.to_string manifest in
-    message `Info "Esy dependencies are not installed. Run esy under %s"
+    show_message `Info "Esy dependencies are not installed. Run esy under %s"
       root_dir

--- a/src/esy.ml
+++ b/src/esy.ml
@@ -123,3 +123,5 @@ let setup_toolchain t ~manifest =
     let root_dir = Path.to_string manifest in
     show_message `Info "Esy dependencies are not installed. Run esy under %s"
       root_dir
+
+let equal e1 e2 = Cmd.equal_spawn e1 e2

--- a/src/esy.mli
+++ b/src/esy.mli
@@ -14,3 +14,5 @@ val discover : dir:Path.t -> discover list Promise.t
 val exec : t -> manifest:Path.t -> args:string list -> Cmd.t
 
 val setup_toolchain : t -> manifest:Path.t -> unit Or_error.t Promise.t
+
+val equal : t -> t -> bool

--- a/src/extension_commands.ml
+++ b/src/extension_commands.ml
@@ -72,7 +72,7 @@ let switch_impl_intf =
       let document = TextEditor.document editor in
       let* client = instance.client in
       (* extension needs to be activated; otherwise, just ignore the switch try *)
-      let+ ocaml_lsp = instance.ocaml_lsp_capabilities in
+      let+ ocaml_lsp = instance.ocaml_lsp in
       (* same as for instance.client; ignore the try if it's None *)
       if Ocaml_lsp.can_handle_switch_impl_intf ocaml_lsp then
         Switch_impl_intf.request_switch client document

--- a/src/extension_commands.ml
+++ b/src/extension_commands.ml
@@ -1,0 +1,104 @@
+open Import
+
+type command =
+  { id : string
+  ; handler : Extension_instance.t -> unit -> unit
+  }
+
+let command id handler = { id; handler }
+
+let select_sandbox =
+  let handler (instance : Extension_instance.t) () =
+    let set_toolchain =
+      let open Promise.Syntax in
+      let* package_manager = Toolchain.select_and_save () in
+      match package_manager with
+      | None -> Promise.Result.return ()
+      | Some pm ->
+        Extension_instance.stop instance;
+        let t = Toolchain.make pm in
+        Extension_instance.start instance t
+    in
+    let (_ : unit Promise.t) =
+      Promise.Result.iter set_toolchain ~error:(show_message `Error "%s")
+    in
+    ()
+  in
+  command select_sandbox_command_id handler
+
+let restart_instance =
+  let handler (instance : Extension_instance.t) () =
+    let (_ : unit Promise.t) =
+      let open Promise.Syntax in
+      let* package_manager = Toolchain.of_settings () in
+      match package_manager with
+      | None ->
+        select_sandbox.handler instance ();
+        Promise.return ()
+      | Some pm ->
+        Extension_instance.stop_language_server instance;
+        Extension_instance.start_language_server instance (Toolchain.make pm)
+        |> Promise.Result.iter ~error:(show_message `Error "%s")
+    in
+    ()
+  in
+  command "ocaml.server.restart" handler
+
+let select_sandbox_and_open_terminal =
+  let handler _instance () =
+    let (_ : unit option Promise.t) =
+      let open Promise.Option.Syntax in
+      let+ pm = Toolchain.select () in
+      let toolchain = Toolchain.make pm in
+      Extension_instance.open_terminal toolchain
+    in
+    ()
+  in
+  command "ocaml.open-terminal-select" handler
+
+let open_terminal =
+  let handler (instance : Extension_instance.t) () =
+    match instance.toolchain with
+    | None -> select_sandbox_and_open_terminal.handler instance ()
+    | Some toolchain -> Extension_instance.open_terminal toolchain
+  in
+  command "ocaml.open-terminal" handler
+
+let switch_impl_intf =
+  let handler (instance : Extension_instance.t) () =
+    let try_switching () =
+      let open Option.O in
+      let* editor = Window.activeTextEditor () in
+      let document = TextEditor.document editor in
+      let* client = instance.client in
+      (* extension needs to be activated; otherwise, just ignore the switch try *)
+      let+ ocaml_lsp = instance.ocaml_lsp_capabilities in
+      (* same as for instance.client; ignore the try if it's None *)
+      if Ocaml_lsp.can_handle_switch_impl_intf ocaml_lsp then
+        Switch_impl_intf.request_switch client document
+      else
+        (* if, however, ocamllsp doesn't have the capability, recommend updating ocamllsp*)
+        Promise.return
+        @@ show_message `Warn
+             "The installed version of ocamllsp does not support switching \
+              between implementation and interface files. Consider updating \
+              ocamllsp."
+    in
+    let (_ : unit Promise.t option) = try_switching () in
+    ()
+  in
+  command "ocaml.switch-impl-intf" handler
+
+let register_all_commands extension instance =
+  let register_command { id; handler } =
+    let callback ~args:_ = handler instance () in
+    let disposable = Commands.registerCommand ~command:id ~callback in
+    ExtensionContext.subscribe extension ~disposable
+  in
+  List.iter ~f:register_command
+    [ select_sandbox
+    ; restart_instance
+    ; open_terminal
+    ; select_sandbox_and_open_terminal
+    ; switch_impl_intf
+    ]

--- a/src/extension_commands.ml
+++ b/src/extension_commands.ml
@@ -26,7 +26,7 @@ let select_sandbox =
   in
   command select_sandbox_command_id handler
 
-let restart_instance =
+let restart_language_server =
   let handler (instance : Extension_instance.t) () =
     let (_ : unit Promise.t) =
       let open Promise.Syntax in
@@ -97,7 +97,7 @@ let register_all_commands extension instance =
   in
   List.iter ~f:register_command
     [ select_sandbox
-    ; restart_instance
+    ; restart_language_server
     ; open_terminal
     ; select_sandbox_and_open_terminal
     ; switch_impl_intf

--- a/src/extension_commands.ml
+++ b/src/extension_commands.ml
@@ -7,7 +7,13 @@ type command =
            [handler extension_instance] is passed as a callback to [Commands.registerCommand] *)
   }
 
-let command id handler = { id; handler }
+let commands = ref []
+
+(** creates a new command and stores in a mutable [commands] list *)
+let command id handler =
+  let command = { id; handler } in
+  commands := command :: !commands;
+  command
 
 let select_sandbox =
   let handler (instance : Extension_instance.t) () =
@@ -99,10 +105,4 @@ let register_all_commands extension instance =
     let disposable = Commands.registerCommand ~command:id ~callback in
     ExtensionContext.subscribe extension ~disposable
   in
-  List.iter ~f:register_command
-    [ select_sandbox
-    ; restart_language_server
-    ; open_terminal
-    ; select_sandbox_and_open_terminal
-    ; switch_impl_intf
-    ]
+  List.iter ~f:register_command !commands

--- a/src/extension_commands.ml
+++ b/src/extension_commands.ml
@@ -13,7 +13,7 @@ let select_sandbox =
   let handler (instance : Extension_instance.t) () =
     let set_toolchain =
       let open Promise.Syntax in
-      let* package_manager = Toolchain.select_and_save () in
+      let* package_manager = Toolchain.select_sandbox_and_save () in
       match package_manager with
       | None (* selection cancelled *) -> Promise.Result.return ()
       | Some pm ->
@@ -50,7 +50,7 @@ let select_sandbox_and_open_terminal =
   let handler _instance () =
     let (_ : unit option Promise.t) =
       let open Promise.Option.Syntax in
-      let+ pm = Toolchain.select () in
+      let+ pm = Toolchain.select_sandbox () in
       let toolchain = Toolchain.make pm in
       Extension_instance.open_terminal toolchain
     in

--- a/src/extension_commands.ml
+++ b/src/extension_commands.ml
@@ -3,6 +3,8 @@ open Import
 type command =
   { id : string
   ; handler : Extension_instance.t -> unit -> unit
+        (* [handler] is intended to be used partially applied;
+           [handler extension_instance] is passed as a callback to [Commands.registerCommand] *)
   }
 
 let command id handler = { id; handler }
@@ -13,7 +15,7 @@ let select_sandbox =
       let open Promise.Syntax in
       let* package_manager = Toolchain.select_and_save () in
       match package_manager with
-      | None -> Promise.Result.return ()
+      | None (* selection cancelled *) -> Promise.Result.return ()
       | Some pm ->
         Extension_instance.stop instance;
         let t = Toolchain.make pm in

--- a/src/extension_commands.ml
+++ b/src/extension_commands.ml
@@ -38,7 +38,7 @@ let select_sandbox =
     in
     ()
   in
-  command select_sandbox_command_id handler
+  command Extension_consts.Commands.select_sandbox handler
 
 let restart_language_server =
   let handler (instance : Extension_instance.t) () =
@@ -54,7 +54,7 @@ let restart_language_server =
     in
     ()
   in
-  command "ocaml.server.restart" handler
+  command Extension_consts.Commands.restart_language_server handler
 
 let select_sandbox_and_open_terminal =
   let handler _instance () =
@@ -66,13 +66,13 @@ let select_sandbox_and_open_terminal =
     in
     ()
   in
-  command "ocaml.open-terminal-select" handler
+  command Extension_consts.Commands.select_sandbox_and_open_terminal handler
 
 let open_terminal =
   let handler (instance : Extension_instance.t) () =
     Extension_instance.open_terminal instance.toolchain
   in
-  command "ocaml.open-terminal" handler
+  command Extension_consts.Commands.open_terminal handler
 
 let switch_impl_intf =
   let handler (instance : Extension_instance.t) () =
@@ -97,7 +97,7 @@ let switch_impl_intf =
     let (_ : unit Promise.t option) = try_switching () in
     ()
   in
-  command "ocaml.switch-impl-intf" handler
+  command Extension_consts.Commands.switch_impl_intf handler
 
 let register_all_commands extension instance =
   let register_command { id; handler } =

--- a/src/extension_commands.mli
+++ b/src/extension_commands.mli
@@ -1,0 +1,31 @@
+type command = private
+  { id : string
+  ; handler : Extension_instance.t -> unit -> unit
+  }
+
+(** Module to manage commands[1] across the extension.
+
+    Module does not have public API for command creation on purpose.
+    One should only create new commands in [extension_commands.ml]
+    using [command] function and expose them here if they want to.
+
+    All commands are registered using [register_all_commands] in
+    [Vscode_ocaml_platform.activate].
+
+    [1] https://code.visualstudio.com/api/references/vscode-api#commands *)
+
+val select_sandbox : command
+
+val restart_language_server : command
+
+val select_sandbox_and_open_terminal : command
+
+val open_terminal : command
+
+val switch_impl_intf : command
+
+(** Registers commands with vscode.
+    Should be called in [Vscode_ocaml_platform.activate].
+    It subscribes the disposables to the extension context provided. *)
+val register_all_commands :
+  Vscode.ExtensionContext.t -> Extension_instance.t -> unit

--- a/src/extension_consts.ml
+++ b/src/extension_consts.ml
@@ -1,0 +1,15 @@
+let ocaml_prefixed key = "ocaml." ^ key
+
+module Commands = struct
+  let select_sandbox = ocaml_prefixed "select-sandbox"
+
+  let restart_language_server = ocaml_prefixed "server.restart"
+
+  let select_sandbox_and_open_terminal = ocaml_prefixed "open-terminal-select"
+
+  let open_terminal = ocaml_prefixed "open-terminal"
+
+  let switch_impl_intf = ocaml_prefixed "switch-impl-intf"
+end
+
+(* TODO: add other constants such as settings keywords etc *)

--- a/src/extension_instance.ml
+++ b/src/extension_instance.ml
@@ -1,0 +1,126 @@
+open Import
+
+type t =
+  { mutable toolchain : Toolchain.t option
+  ; mutable client : LanguageClient.t option
+  ; mutable ocaml_lsp_capabilities : Ocaml_lsp.t option
+  ; mutable sandbox_info : StatusBarItem.t option
+  ; dune_formatter : Dune_formatter.t
+  ; dune_task_provider : Dune_task_provider.t
+  }
+
+let create () =
+  { toolchain = None
+  ; client = None
+  ; ocaml_lsp_capabilities = None
+  ; sandbox_info = None
+  ; dune_formatter = Dune_formatter.create ()
+  ; dune_task_provider = Dune_task_provider.create ()
+  }
+
+let client_options () =
+  let documentSelector =
+    LanguageClient.DocumentSelector.
+      [| language "ocaml"
+       ; language "ocaml.interface"
+       ; language "ocaml.ocamllex"
+       ; language "ocaml.menhir"
+       ; language "reason"
+      |]
+  in
+  let (lazy outputChannel) = Output.language_server_output_channel in
+  let revealOutputChannelOn = LanguageClient.RevealOutputChannelOn.Never in
+  LanguageClient.ClientOptions.create ~documentSelector ~outputChannel
+    ~revealOutputChannelOn ()
+
+let server_options toolchain =
+  let command = Toolchain.get_lsp_command toolchain in
+  Cmd.log command;
+  match command with
+  | Shell command ->
+    let options = LanguageClient.ExecutableOptions.create ~shell:true () in
+    LanguageClient.Executable.create ~command ~options ()
+  | Spawn { bin; args } ->
+    let command = Path.to_string bin in
+    let options = LanguageClient.ExecutableOptions.create ~shell:false () in
+    LanguageClient.Executable.create ~command ~args ~options ()
+
+let stop_language_server t =
+  Option.iter t.client ~f:(fun client ->
+      LanguageClient.stop client;
+      t.client <- None)
+
+let stop t =
+  Dune_formatter.dispose t.dune_formatter;
+  Dune_task_provider.dispose t.dune_task_provider;
+
+  Option.iter t.sandbox_info ~f:(fun status_bar_item ->
+      StatusBarItem.dispose status_bar_item;
+      t.sandbox_info <- None);
+
+  stop_language_server t;
+
+  t.ocaml_lsp_capabilities <- None;
+  t.toolchain <- None
+
+let start_language_server t toolchain =
+  let open Promise.Result.Syntax in
+  let* () = Toolchain.run_setup toolchain in
+  let serverOptions = server_options toolchain in
+  let clientOptions = client_options () in
+  let client =
+    LanguageClient.make ~id:"ocaml" ~name:"OCaml Language Server" ~serverOptions
+      ~clientOptions ()
+  in
+  t.client <- Some client;
+  LanguageClient.start client;
+
+  let open Promise.Syntax in
+  let+ initialize_result = LanguageClient.readyInitializeResult client in
+  let ocaml_lsp = Ocaml_lsp.of_initialize_result initialize_result in
+  t.ocaml_lsp_capabilities <- Some ocaml_lsp;
+  if
+    (not (Ocaml_lsp.has_interface_specific_lang_id ocaml_lsp))
+    || not (Ocaml_lsp.can_handle_switch_impl_intf ocaml_lsp)
+  then
+    show_message `Warn
+      "The installed version of ocamllsp is out of date. Some features may be \
+       unavailable or degraded in functionality: switching between \
+       implementation and interface files, functionality in mli sources. \
+       Consider updating ocamllsp.";
+  Ok ()
+
+let make_sandbox_info toolchain =
+  let status_bar_item =
+    Window.createStatusBarItem ~alignment:StatusBarAlignment.Left ()
+  in
+  let package_manager = Toolchain.package_manager toolchain in
+  let status_bar_item_text =
+    let package_icon =
+      "$(package)"
+      (* see https://code.visualstudio.com/api/references/icons-in-labels *)
+    in
+    Printf.sprintf "%s %s" package_icon
+    @@ Toolchain.Package_manager.to_pretty_string package_manager
+  in
+  StatusBarItem.set_text status_bar_item status_bar_item_text;
+  StatusBarItem.set_command status_bar_item (`String select_sandbox_command_id);
+  StatusBarItem.show status_bar_item;
+  status_bar_item
+
+let start t toolchain =
+  t.toolchain <- Some toolchain;
+  Dune_formatter.register t.dune_formatter toolchain;
+  Dune_task_provider.register t.dune_task_provider toolchain;
+  t.sandbox_info <- Some (make_sandbox_info toolchain);
+  start_language_server t toolchain
+
+let open_terminal toolchain =
+  match Terminal_sandbox.create toolchain with
+  | Some terminal -> Terminal_sandbox.show terminal
+  | None ->
+    show_message `Error
+      "Could not open a terminal in the current sandbox. The toolchain may not \
+       have loaded yet."
+
+let disposable t = Disposable.make ~dispose:(fun () -> stop t)

--- a/src/extension_instance.ml
+++ b/src/extension_instance.ml
@@ -3,7 +3,7 @@ open Import
 type t =
   { mutable toolchain : Toolchain.t option
   ; mutable client : LanguageClient.t option
-  ; mutable ocaml_lsp_capabilities : Ocaml_lsp.t option
+  ; mutable ocaml_lsp : Ocaml_lsp.t option
   ; mutable sandbox_info : StatusBarItem.t option
   ; dune_formatter : Dune_formatter.t
   ; dune_task_provider : Dune_task_provider.t
@@ -12,7 +12,7 @@ type t =
 let create () =
   { toolchain = None
   ; client = None
-  ; ocaml_lsp_capabilities = None
+  ; ocaml_lsp = None
   ; sandbox_info = None
   ; dune_formatter = Dune_formatter.create ()
   ; dune_task_provider = Dune_task_provider.create ()
@@ -60,7 +60,7 @@ let stop t =
 
   stop_language_server t;
 
-  t.ocaml_lsp_capabilities <- None;
+  t.ocaml_lsp <- None;
   t.toolchain <- None
 
 let start_language_server t toolchain =
@@ -78,7 +78,7 @@ let start_language_server t toolchain =
   let open Promise.Syntax in
   let+ initialize_result = LanguageClient.readyInitializeResult client in
   let ocaml_lsp = Ocaml_lsp.of_initialize_result initialize_result in
-  t.ocaml_lsp_capabilities <- Some ocaml_lsp;
+  t.ocaml_lsp <- Some ocaml_lsp;
   if
     (not (Ocaml_lsp.has_interface_specific_lang_id ocaml_lsp))
     || not (Ocaml_lsp.can_handle_switch_impl_intf ocaml_lsp)

--- a/src/extension_instance.ml
+++ b/src/extension_instance.ml
@@ -133,11 +133,5 @@ let open_terminal toolchain =
 
 let disposable t =
   Disposable.make ~dispose:(fun () ->
-      (* [stop] is not defined in the toplevel module because
-         we don't want anyone to call it, only vscode when the extension is no longer needed;
-         a user calling [stop] would leave the extension in a corrupt state *)
-      let stop instance =
-        StatusBarItem.dispose instance.sandbox_info;
-        LanguageClient.stop instance.client
-      in
-      stop t)
+      StatusBarItem.dispose instance.sandbox_info;
+      LanguageClient.stop instance.client)

--- a/src/extension_instance.ml
+++ b/src/extension_instance.ml
@@ -133,5 +133,5 @@ let open_terminal toolchain =
 
 let disposable t =
   Disposable.make ~dispose:(fun () ->
-      StatusBarItem.dispose instance.sandbox_info;
-      LanguageClient.stop instance.client)
+      StatusBarItem.dispose t.sandbox_info;
+      LanguageClient.stop t.client)

--- a/src/extension_instance.ml
+++ b/src/extension_instance.ml
@@ -69,8 +69,8 @@ let start_language_server t toolchain =
   let serverOptions = server_options toolchain in
   let clientOptions = client_options () in
   let client =
-    LanguageClient.make ~id:"ocaml" ~name:"OCaml Language Server" ~serverOptions
-      ~clientOptions ()
+    LanguageClient.make ~id:"ocaml" ~name:"OCaml Platform VS Code extension"
+      ~serverOptions ~clientOptions ()
   in
   t.client <- Some client;
   LanguageClient.start client;

--- a/src/extension_instance.ml
+++ b/src/extension_instance.ml
@@ -68,7 +68,7 @@ let start_language_server toolchain =
 module Sandbox_info : sig
   val make : Toolchain.t -> StatusBarItem.t
 
-  val _update : StatusBarItem.t -> new_toolchain:Toolchain.t -> unit
+  val update : StatusBarItem.t -> new_toolchain:Toolchain.t -> unit
 end = struct
   let make_status_bar_item_text package_manager =
     Printf.sprintf "%s %s" LabelIcons.package
@@ -87,7 +87,7 @@ end = struct
     StatusBarItem.show status_bar_item;
     status_bar_item
 
-  let _update sandbox_info ~new_toolchain =
+  let update sandbox_info ~new_toolchain =
     let status_bar_item_text =
       make_status_bar_item_text @@ Toolchain.package_manager new_toolchain
     in
@@ -101,7 +101,7 @@ let make toolchain =
   { toolchain; client; ocaml_lsp; sandbox_info }
 
 let update_on_new_toolchain t new_toolchain =
-  Sandbox_info._update t.sandbox_info ~new_toolchain;
+  Sandbox_info.update t.sandbox_info ~new_toolchain;
   LanguageClient.stop t.client;
   let open Promise.Result.Syntax in
   let+ client, ocaml_lsp = start_language_server new_toolchain in

--- a/src/extension_instance.ml
+++ b/src/extension_instance.ml
@@ -7,6 +7,12 @@ type t =
   ; sandbox_info : StatusBarItem.t
   }
 
+let toolchain t = t.toolchain
+
+let language_client t = t.client
+
+let ocaml_lsp t = t.ocaml_lsp
+
 let client_options () =
   let documentSelector =
     LanguageClient.DocumentSelector.
@@ -64,6 +70,13 @@ let start_language_server toolchain =
        Consider updating ocamllsp.";
 
   Ok (client, ocaml_lsp)
+
+let restart_language_server t =
+  let open Promise.Result.Syntax in
+  LanguageClient.stop t.client;
+  let+ language_client, ocaml_lsp = start_language_server t.toolchain in
+  t.client <- language_client;
+  t.ocaml_lsp <- ocaml_lsp
 
 module Sandbox_info : sig
   val make : Toolchain.t -> StatusBarItem.t

--- a/src/extension_instance.ml
+++ b/src/extension_instance.ml
@@ -5,7 +5,6 @@ type t =
   ; mutable client : LanguageClient.t option
   ; mutable ocaml_lsp : Ocaml_lsp.t option
   ; mutable sandbox_info : StatusBarItem.t option
-  ; dune_formatter : Dune_formatter.t
   ; dune_task_provider : Dune_task_provider.t
   }
 
@@ -14,7 +13,6 @@ let create () =
   ; client = None
   ; ocaml_lsp = None
   ; sandbox_info = None
-  ; dune_formatter = Dune_formatter.create ()
   ; dune_task_provider = Dune_task_provider.create ()
   }
 
@@ -51,7 +49,6 @@ let stop_language_server t =
       t.client <- None)
 
 let stop t =
-  Dune_formatter.dispose t.dune_formatter;
   Dune_task_provider.dispose t.dune_task_provider;
 
   Option.iter t.sandbox_info ~f:(fun status_bar_item ->
@@ -110,7 +107,6 @@ let make_sandbox_info toolchain =
 
 let start t toolchain =
   t.toolchain <- Some toolchain;
-  Dune_formatter.register t.dune_formatter toolchain;
   Dune_task_provider.register t.dune_task_provider toolchain;
   t.sandbox_info <- Some (make_sandbox_info toolchain);
   start_language_server t toolchain

--- a/src/extension_instance.ml
+++ b/src/extension_instance.ml
@@ -120,8 +120,8 @@ let open_terminal toolchain =
 
 let disposable t =
   Disposable.make ~dispose:(fun () ->
-      (* [stop] is not defined in the toplevel module becase
-         we don't want anyone to it, only vscode when the extension is no longer needed;
+      (* [stop] is not defined in the toplevel module because
+         we don't want anyone to call it, only vscode when the extension is no longer needed;
          a user calling [stop] would leave the extension in a corrupt state *)
       let stop instance =
         StatusBarItem.dispose instance.sandbox_info;

--- a/src/extension_instance.ml
+++ b/src/extension_instance.ml
@@ -30,8 +30,8 @@ let client_options () =
   in
   let (lazy outputChannel) = Output.language_server_output_channel in
   let revealOutputChannelOn = LanguageClient.RevealOutputChannelOn.Never in
-  LanguageClient.ClientOptions.create ~documentSelector ~outputChannel
-    ~revealOutputChannelOn ()
+  LanguageClient.ClientOptions.create ~outputChannel ~revealOutputChannelOn
+    ~documentSelector ()
 
 let server_options toolchain =
   let command = Toolchain.get_lsp_command toolchain in

--- a/src/extension_instance.ml
+++ b/src/extension_instance.ml
@@ -5,16 +5,10 @@ type t =
   ; mutable client : LanguageClient.t option
   ; mutable ocaml_lsp : Ocaml_lsp.t option
   ; mutable sandbox_info : StatusBarItem.t option
-  ; dune_task_provider : Dune_task_provider.t
   }
 
 let create () =
-  { toolchain = None
-  ; client = None
-  ; ocaml_lsp = None
-  ; sandbox_info = None
-  ; dune_task_provider = Dune_task_provider.create ()
-  }
+  { toolchain = None; client = None; ocaml_lsp = None; sandbox_info = None }
 
 let client_options () =
   let documentSelector =
@@ -49,8 +43,6 @@ let stop_language_server t =
       t.client <- None)
 
 let stop t =
-  Dune_task_provider.dispose t.dune_task_provider;
-
   Option.iter t.sandbox_info ~f:(fun status_bar_item ->
       StatusBarItem.dispose status_bar_item;
       t.sandbox_info <- None);
@@ -107,7 +99,6 @@ let make_sandbox_info toolchain =
 
 let start t toolchain =
   t.toolchain <- Some toolchain;
-  Dune_task_provider.register t.dune_task_provider toolchain;
   t.sandbox_info <- Some (make_sandbox_info toolchain);
   start_language_server t toolchain
 

--- a/src/extension_instance.ml
+++ b/src/extension_instance.ml
@@ -83,7 +83,7 @@ end = struct
     in
     StatusBarItem.set_text status_bar_item status_bar_item_text;
     StatusBarItem.set_command status_bar_item
-      (`String select_sandbox_command_id);
+      (`String Extension_consts.Commands.select_sandbox);
     StatusBarItem.show status_bar_item;
     status_bar_item
 

--- a/src/extension_instance.mli
+++ b/src/extension_instance.mli
@@ -5,7 +5,6 @@ type t =
   ; mutable client : LanguageClient.t option
   ; mutable ocaml_lsp : Ocaml_lsp.t option
   ; mutable sandbox_info : StatusBarItem.t option
-  ; dune_task_provider : Dune_task_provider.t
   }
 
 val create : unit -> t

--- a/src/extension_instance.mli
+++ b/src/extension_instance.mli
@@ -5,7 +5,6 @@ type t =
   ; mutable client : LanguageClient.t option
   ; mutable ocaml_lsp : Ocaml_lsp.t option
   ; mutable sandbox_info : StatusBarItem.t option
-  ; dune_formatter : Dune_formatter.t
   ; dune_task_provider : Dune_task_provider.t
   }
 

--- a/src/extension_instance.mli
+++ b/src/extension_instance.mli
@@ -1,0 +1,24 @@
+open Import
+
+type t =
+  { mutable toolchain : Toolchain.t option
+  ; mutable client : LanguageClient.t option
+  ; mutable ocaml_lsp : Ocaml_lsp.t option
+  ; mutable sandbox_info : StatusBarItem.t option
+  ; dune_formatter : Dune_formatter.t
+  ; dune_task_provider : Dune_task_provider.t
+  }
+
+val create : unit -> t
+
+val start : t -> Toolchain.t -> (unit, string) result Promise.t
+
+val stop : t -> unit
+
+val start_language_server : t -> Toolchain.t -> (unit, string) result Promise.t
+
+val stop_language_server : t -> unit
+
+val open_terminal : Toolchain.t -> unit
+
+val disposable : t -> Disposable.t

--- a/src/extension_instance.mli
+++ b/src/extension_instance.mli
@@ -1,21 +1,19 @@
 open Import
 
 type t =
-  { mutable toolchain : Toolchain.t option
-  ; mutable client : LanguageClient.t option
-  ; mutable ocaml_lsp : Ocaml_lsp.t option
-  ; mutable sandbox_info : StatusBarItem.t option
+  { mutable toolchain : Toolchain.t
+  ; mutable client : LanguageClient.t
+  ; mutable ocaml_lsp : Ocaml_lsp.t
+  ; sandbox_info : StatusBarItem.t
   }
 
-val create : unit -> t
+val make : Toolchain.t -> (t, string) result Promise.t
 
-val start : t -> Toolchain.t -> (unit, string) result Promise.t
+val update_on_new_toolchain :
+  t -> Toolchain.t -> (unit, string) result Promise.t
 
-val stop : t -> unit
-
-val start_language_server : t -> Toolchain.t -> (unit, string) result Promise.t
-
-val stop_language_server : t -> unit
+val start_language_server :
+  Toolchain.t -> (LanguageClient.t * Ocaml_lsp.t, string) result Promise.t
 
 val open_terminal : Toolchain.t -> unit
 

--- a/src/extension_instance.mli
+++ b/src/extension_instance.mli
@@ -1,19 +1,22 @@
 open Import
 
-type t =
-  { mutable toolchain : Toolchain.t
-  ; mutable client : LanguageClient.t
-  ; mutable ocaml_lsp : Ocaml_lsp.t
-  ; sandbox_info : StatusBarItem.t
-  }
+type t
 
 val make : Toolchain.t -> (t, string) result Promise.t
+
+val toolchain : t -> Toolchain.t
+
+val language_client : t -> LanguageClient.t
+
+val ocaml_lsp : t -> Ocaml_lsp.t
 
 val update_on_new_toolchain :
   t -> Toolchain.t -> (unit, string) result Promise.t
 
 val start_language_server :
   Toolchain.t -> (LanguageClient.t * Ocaml_lsp.t, string) result Promise.t
+
+val restart_language_server : t -> (unit, string) result Promise.t
 
 val open_terminal : Toolchain.t -> unit
 

--- a/src/import.ml
+++ b/src/import.ml
@@ -50,3 +50,5 @@ let log_json msg (fields : (string * Jsonoo.t) list) =
   let json = Jsonoo.Encode.object_ fields |> Jsonoo.stringify ~spaces:2 in
   let (lazy output_channel) = Output.extension_output_channel in
   OutputChannel.appendLine output_channel ~value:(msg ^ " " ^ json ^ "\n")
+
+let select_sandbox_command_id = "ocaml.select-sandbox"

--- a/src/import.ml
+++ b/src/import.ml
@@ -28,7 +28,7 @@ module Or_error = struct
   type 'a t = ('a, string) result
 end
 
-let message kind fmt =
+let show_message kind fmt =
   let k message =
     match kind with
     | `Warn -> Window.showWarningMessage ~message ()
@@ -37,7 +37,7 @@ let message kind fmt =
   in
   Printf.ksprintf
     (fun x ->
-      let (_ : _ option Promise.t) = k x in
+      let (_ : unit option Promise.t) = k x in
       ())
     fmt
 

--- a/src/import.ml
+++ b/src/import.ml
@@ -50,5 +50,3 @@ let log_json msg (fields : (string * Jsonoo.t) list) =
   let json = Jsonoo.Encode.object_ fields |> Jsonoo.stringify ~spaces:2 in
   let (lazy output_channel) = Output.extension_output_channel in
   OutputChannel.appendLine output_channel ~value:(msg ^ " " ^ json ^ "\n")
-
-let select_sandbox_command_id = "ocaml.select-sandbox"

--- a/src/ocaml_lsp.ml
+++ b/src/ocaml_lsp.ml
@@ -24,7 +24,7 @@ let of_json (json : Jsonoo.t) =
     in
     { interfaceSpecificLangId; handleSwitchImplIntf }
   with Jsonoo.Decode_error _ ->
-    message `Warn
+    show_message `Warn
       "unexpected experimental capabilities from lsp server. Some features \
        might be missing";
     default

--- a/src/opam.ml
+++ b/src/opam.ml
@@ -50,7 +50,7 @@ let switch_list t =
   let+ output = Cmd.output (Spawn command) in
   match output with
   | Error _ ->
-    message `Warn "Unable to read the list of switches.";
+    show_message `Warn "Unable to read the list of switches.";
     []
   | Ok out -> parse_switch_list out
 

--- a/src/opam.ml
+++ b/src/opam.ml
@@ -63,3 +63,5 @@ let exists t ~switch =
   let open Promise.Syntax in
   let+ switches = switch_list t in
   List.exists switches ~f:(Switch.equal switch)
+
+let equal o1 o2 = Cmd.equal_spawn o1 o2

--- a/src/opam.mli
+++ b/src/opam.mli
@@ -6,6 +6,8 @@ module Switch : sig
   val make : string -> t
 
   val name : t -> string
+
+  val equal : t -> t -> bool
 end
 
 type t

--- a/src/opam.mli
+++ b/src/opam.mli
@@ -19,3 +19,5 @@ val switch_list : t -> Switch.t list Promise.t
 val exec : t -> switch:Switch.t -> args:string list -> Cmd.t
 
 val exists : t -> switch:Switch.t -> bool Promise.t
+
+val equal : t -> t -> bool

--- a/src/settings.ml
+++ b/src/settings.ml
@@ -17,7 +17,7 @@ let get ?section t =
     match t.of_json v with
     | s -> Some s
     | exception Jsonoo.Decode_error msg ->
-      message `Error "Setting %s is invalid: %s" t.key msg;
+      show_message `Error "Setting %s is invalid: %s" t.key msg;
       None )
 
 let set ?section t v =

--- a/src/terminal_sandbox.mli
+++ b/src/terminal_sandbox.mli
@@ -1,6 +1,6 @@
 type t
 
-val create : Toolchain.resources -> t option
+val create : Toolchain.t -> t option
 
 val dispose : t -> unit
 

--- a/src/toolchain.ml
+++ b/src/toolchain.ml
@@ -159,7 +159,7 @@ let of_settings () : Package_manager.t option Promise.t =
       | `Esy -> "esy"
       | `Opam -> "opam"
     in
-    message `Warn
+    show_message `Warn
       "This workspace is configured to use an %s sandbox, but %s isn't \
        available"
       this_ this_
@@ -188,7 +188,7 @@ let of_settings () : Package_manager.t option Promise.t =
       if exists then
         Some (Package_manager.Opam (opam, switch))
       else (
-        message `Warn
+        show_message `Warn
           "Workspace is configured to use the switch %s. This switch does not \
            exist."
           (Opam.Switch.name switch);
@@ -333,7 +333,7 @@ let select () =
   | { status; package_manager } -> (
     match status with
     | Error s ->
-      message `Warn "This toolchain is invalid. Error: %s" s;
+      show_message `Warn "This toolchain is invalid. Error: %s" s;
       Promise.return None
     | Ok () -> Promise.Option.return package_manager )
 

--- a/src/toolchain.ml
+++ b/src/toolchain.ml
@@ -112,9 +112,10 @@ module Package_manager = struct
 
   let equal pm1 pm2 =
     match (pm1, pm2) with
-    | Opam (_, s1), Opam (_, s2) -> Opam.Switch.equal s1 s2
-    | Esy (_, p1), Esy (_, p2) -> Path.equal p1 p2
     | Global, Global -> true
+    | Esy (e1, p1), Esy (e2, p2) -> Path.equal p1 p2 && Esy.equal e1 e2
+    | Opam (o1, s1), Opam (o2, s2) ->
+      Opam.Switch.equal s1 s2 && Opam.equal o1 o2
     | Custom s1, Custom s2 -> String.equal s1 s2
     | _, _ -> false
 

--- a/src/toolchain.ml
+++ b/src/toolchain.ml
@@ -306,7 +306,7 @@ let setup_toolchain (kind : Package_manager.t) =
   | Custom _ ->
     Promise.Result.return ()
 
-let select () =
+let select_sandbox () =
   let open Promise.Syntax in
   let workspace_folders = Workspace.workspaceFolders () in
   let* candidates = sandbox_candidates ~workspace_folders in
@@ -337,9 +337,9 @@ let select () =
       Promise.return None
     | Ok () -> Promise.Option.return package_manager )
 
-let select_and_save () =
+let select_sandbox_and_save () =
   let open Promise.Option.Syntax in
-  let* package_manager = select () in
+  let* package_manager = select_sandbox () in
   let open Promise.Syntax in
   let+ () = to_settings package_manager in
   Some package_manager

--- a/src/toolchain.ml
+++ b/src/toolchain.ml
@@ -382,4 +382,6 @@ let run_setup t =
   match output with
   | Ok _ -> Ok ()
   | Error msg ->
+    (* TODO: if ocamllsp not found, suggest to install it on press of a button;
+       consider checking and suggesting installation for other tools: formatter, etc. *)
     Error (Printf.sprintf "Toolchain initialisation failed: %s" msg)

--- a/src/toolchain.ml
+++ b/src/toolchain.ml
@@ -146,13 +146,13 @@ module Package_manager = struct
     | Custom _ -> "Custom OCaml"
 end
 
-type t = { package_manager : Package_manager.t }
+type t = Package_manager.t
 
-let make package_manager = { package_manager }
+let make (t : Package_manager.t) : t = t
 
-let package_manager t = t.package_manager
+let package_manager (t : t) : Package_manager.t = t
 
-let equal t1 t2 = Package_manager.equal t1.package_manager t2.package_manager
+let equal t1 t2 = Package_manager.equal t1 t2
 
 let available_package_managers () =
   { Package_manager.Kind.Hmap.opam = Opam.make ()
@@ -209,7 +209,7 @@ let of_settings () : Package_manager.t option Promise.t =
   | Some (Custom template) ->
     Promise.return (Some (Package_manager.Custom template))
 
-let save_to_settings { package_manager } =
+let save_to_settings package_manager =
   Settings.set ~section:"ocaml" Package_manager.Setting.t
     (Package_manager.to_setting package_manager)
 
@@ -352,11 +352,11 @@ let select_sandbox_and_save () =
   let open Promise.Option.Syntax in
   let* package_manager = select_sandbox () in
   let open Promise.Syntax in
-  let+ () = save_to_settings { package_manager } in
+  let+ () = save_to_settings package_manager in
   Some package_manager
 
 let get_command (t : t) bin args : Cmd.t =
-  match t.package_manager with
+  match t with
   | Opam (opam, switch) -> Opam.exec opam ~switch ~args:(bin :: args)
   | Esy (esy, manifest) -> Esy.exec esy ~manifest ~args:(bin :: args)
   | Global -> Spawn { bin = Path.of_string bin; args }
@@ -381,7 +381,7 @@ let get_lsp_command ?(args = []) t : Cmd.t = get_command t "ocamllsp" args
 let get_dune_command t args : Cmd.t = get_command t "dune" args
 
 let run_setup t =
-  let package_manager = t.package_manager in
+  let package_manager = t in
   let open Promise.Syntax in
   let+ output =
     let open Promise.Result.Syntax in

--- a/src/toolchain.mli
+++ b/src/toolchain.mli
@@ -28,13 +28,13 @@ module Package_manager : sig
   val to_pretty_string : t -> string
 end
 
-type resources
+type t
 
 val of_settings : unit -> Package_manager.t option Promise.t
 
-val make_resources : Package_manager.t -> resources
+val make : Package_manager.t -> t
 
-val package_manager : resources -> Package_manager.t
+val package_manager : t -> Package_manager.t
 
 (** [select_and_save] requires the process environment the plugin is being run in
    (ie VSCode's process environment) and the project root and produces a promise
@@ -71,15 +71,15 @@ val select : unit -> Package_manager.t option Promise.t
    like yum/apt/brew or Duniverse), [run_setup] must co-operate and
    detect such installations.
  *)
-val run_setup : resources -> (unit, string) result Promise.t
+val run_setup : t -> (unit, string) result Promise.t
 
 (* Helper utils *)
 
 (** Extract command to run with the toolchain *)
-val get_command : resources -> string -> string list -> Cmd.t
+val get_command : t -> string -> string list -> Cmd.t
 
 (** Extract lsp command and arguments *)
-val get_lsp_command : ?args:string list -> resources -> Cmd.t
+val get_lsp_command : ?args:string list -> t -> Cmd.t
 
 (** Extract a dune command *)
-val get_dune_command : resources -> string list -> Cmd.t
+val get_dune_command : t -> string list -> Cmd.t

--- a/src/toolchain.mli
+++ b/src/toolchain.mli
@@ -36,6 +36,10 @@ val make : Package_manager.t -> t
 
 val package_manager : t -> Package_manager.t
 
+val equal : t -> t -> bool
+
+val save_to_settings : t -> unit Promise.t
+
 (** [select_sandbox_and_save] requires the process environment the plugin is being run in
    (ie VSCode's process environment) and the project root and produces a promise
    of resources available that can later be passed on to [run_setup] that can be

--- a/src/toolchain.mli
+++ b/src/toolchain.mli
@@ -36,14 +36,14 @@ val make : Package_manager.t -> t
 
 val package_manager : t -> Package_manager.t
 
-(** [select_and_save] requires the process environment the plugin is being run in
+(** [select_sandbox_and_save] requires the process environment the plugin is being run in
    (ie VSCode's process environment) and the project root and produces a promise
    of resources available that can later be passed on to [run_setup] that can be
    called to install the toolchain. *)
-val select_and_save : unit -> Package_manager.t option Promise.t
+val select_sandbox_and_save : unit -> Package_manager.t option Promise.t
 
-(** [select] is the same as [select_and_save] but does not save the toolchain configuration *)
-val select : unit -> Package_manager.t option Promise.t
+(** [select_sandbox] is the same as [select_sandbox_and_save] but does not save the toolchain configuration *)
+val select_sandbox : unit -> Package_manager.t option Promise.t
 
 (** [run_setup] is an effectful function that triggers setup instructions
    automatically for the user. At present, this functionality

--- a/src/vscode_ocaml_platform.ml
+++ b/src/vscode_ocaml_platform.ml
@@ -1,154 +1,24 @@
 open Import
 
-let select_sandbox_command_id = "ocaml.select-sandbox"
-
-let client_options () =
-  let documentSelector =
-    LanguageClient.DocumentSelector.
-      [| language "ocaml"
-       ; language "ocaml.interface"
-       ; language "ocaml.ocamllex"
-       ; language "ocaml.menhir"
-       ; language "reason"
-      |]
-  in
-  let (lazy outputChannel) = Output.language_server_output_channel in
-  let revealOutputChannelOn = LanguageClient.RevealOutputChannelOn.Never in
-  LanguageClient.ClientOptions.create ~documentSelector ~outputChannel
-    ~revealOutputChannelOn ()
-
-let server_options toolchain =
-  let command = Toolchain.get_lsp_command toolchain in
-  Cmd.log command;
-  match command with
-  | Shell command ->
-    let options = LanguageClient.ExecutableOptions.create ~shell:true () in
-    LanguageClient.Executable.create ~command ~options ()
-  | Spawn { bin; args } ->
-    let command = Path.to_string bin in
-    let options = LanguageClient.ExecutableOptions.create ~shell:false () in
-    LanguageClient.Executable.create ~command ~args ~options ()
-
-module Instance = struct
-  type t =
-    { mutable toolchain : Toolchain.t option
-    ; mutable client : LanguageClient.t option
-    ; mutable ocaml_lsp_capabilities : Ocaml_lsp.t option
-    ; mutable sandbox_info : StatusBarItem.t option
-    ; dune_formatter : Dune_formatter.t
-    ; dune_task_provider : Dune_task_provider.t
-    }
-
-  let create () =
-    { toolchain = None
-    ; client = None
-    ; ocaml_lsp_capabilities = None
-    ; sandbox_info = None
-    ; dune_formatter = Dune_formatter.create ()
-    ; dune_task_provider = Dune_task_provider.create ()
-    }
-
-  let stop_language_server t =
-    Option.iter t.client ~f:(fun client ->
-        LanguageClient.stop client;
-        t.client <- None)
-
-  let stop t =
-    Dune_formatter.dispose t.dune_formatter;
-    Dune_task_provider.dispose t.dune_task_provider;
-
-    Option.iter t.sandbox_info ~f:(fun status_bar_item ->
-        StatusBarItem.dispose status_bar_item;
-        t.sandbox_info <- None);
-
-    stop_language_server t;
-
-    t.ocaml_lsp_capabilities <- None;
-    t.toolchain <- None
-
-  let start_language_server t toolchain =
-    let open Promise.Result.Syntax in
-    let* () = Toolchain.run_setup toolchain in
-    let serverOptions = server_options toolchain in
-    let clientOptions = client_options () in
-    let client =
-      LanguageClient.make ~id:"ocaml" ~name:"OCaml Language Server"
-        ~serverOptions ~clientOptions ()
-    in
-    t.client <- Some client;
-    LanguageClient.start client;
-
-    let open Promise.Syntax in
-    let+ initialize_result = LanguageClient.readyInitializeResult client in
-    let ocaml_lsp = Ocaml_lsp.of_initialize_result initialize_result in
-    t.ocaml_lsp_capabilities <- Some ocaml_lsp;
-    if
-      (not (Ocaml_lsp.has_interface_specific_lang_id ocaml_lsp))
-      || not (Ocaml_lsp.can_handle_switch_impl_intf ocaml_lsp)
-    then
-      show_message `Warn
-        "The installed version of ocamllsp is out of date. Some features may \
-         be unavailable or degraded in functionality: switching between \
-         implementation and interface files, functionality in mli sources. \
-         Consider updating ocamllsp.";
-    Ok ()
-
-  let make_sandbox_info toolchain =
-    let status_bar_item =
-      Window.createStatusBarItem ~alignment:StatusBarAlignment.Left ()
-    in
-    let package_manager = Toolchain.package_manager toolchain in
-    let status_bar_item_text =
-      let package_icon =
-        "$(package)"
-        (* see https://code.visualstudio.com/api/references/icons-in-labels *)
-      in
-      Printf.sprintf "%s %s" package_icon
-      @@ Toolchain.Package_manager.to_pretty_string package_manager
-    in
-    StatusBarItem.set_text status_bar_item status_bar_item_text;
-    StatusBarItem.set_command status_bar_item
-      (`String select_sandbox_command_id);
-    StatusBarItem.show status_bar_item;
-    status_bar_item
-
-  let start t toolchain =
-    t.toolchain <- Some toolchain;
-    Dune_formatter.register t.dune_formatter toolchain;
-    Dune_task_provider.register t.dune_task_provider toolchain;
-    t.sandbox_info <- Some (make_sandbox_info toolchain);
-    start_language_server t toolchain
-
-  let open_terminal toolchain =
-    match Terminal_sandbox.create toolchain with
-    | Some terminal -> Terminal_sandbox.show terminal
-    | None ->
-      show_message `Error
-        "Could not open a terminal in the current sandbox. The toolchain may \
-         not have loaded yet."
-
-  let disposable t = Disposable.make ~dispose:(fun () -> stop t)
-end
-
 module ExtensionCommands = struct
   type command =
     { id : string
-    ; handler : Instance.t -> unit -> unit
+    ; handler : Extension_instance.t -> unit -> unit
     }
 
   let command id handler = { id; handler }
 
   let select_sandbox =
-    let handler (instance : Instance.t) () =
+    let handler (instance : Extension_instance.t) () =
       let set_toolchain =
         let open Promise.Syntax in
         let* package_manager = Toolchain.select_and_save () in
         match package_manager with
         | None -> Promise.Result.return ()
         | Some pm ->
-          Instance.stop instance;
+          Extension_instance.stop instance;
           let t = Toolchain.make pm in
-          Instance.start instance t
+          Extension_instance.start instance t
       in
       let (_ : unit Promise.t) =
         Promise.Result.iter set_toolchain ~error:(show_message `Error "%s")
@@ -158,7 +28,7 @@ module ExtensionCommands = struct
     command select_sandbox_command_id handler
 
   let restart_instance =
-    let handler (instance : Instance.t) () =
+    let handler (instance : Extension_instance.t) () =
       let (_ : unit Promise.t) =
         let open Promise.Syntax in
         let* package_manager = Toolchain.of_settings () in
@@ -167,8 +37,8 @@ module ExtensionCommands = struct
           select_sandbox.handler instance ();
           Promise.return ()
         | Some pm ->
-          Instance.stop_language_server instance;
-          Instance.start_language_server instance (Toolchain.make pm)
+          Extension_instance.stop_language_server instance;
+          Extension_instance.start_language_server instance (Toolchain.make pm)
           |> Promise.Result.iter ~error:(show_message `Error "%s")
       in
       ()
@@ -181,22 +51,22 @@ module ExtensionCommands = struct
         let open Promise.Option.Syntax in
         let+ pm = Toolchain.select () in
         let toolchain = Toolchain.make pm in
-        Instance.open_terminal toolchain
+        Extension_instance.open_terminal toolchain
       in
       ()
     in
     command "ocaml.open-terminal-select" handler
 
   let open_terminal =
-    let handler (instance : Instance.t) () =
+    let handler (instance : Extension_instance.t) () =
       match instance.toolchain with
       | None -> select_sandbox_and_open_terminal.handler instance ()
-      | Some toolchain -> Instance.open_terminal toolchain
+      | Some toolchain -> Extension_instance.open_terminal toolchain
     in
     command "ocaml.open-terminal" handler
 
   let switch_impl_intf =
-    let handler (instance : Instance.t) () =
+    let handler (instance : Extension_instance.t) () =
       let try_switching () =
         let open Option.O in
         let* editor = Window.activeTextEditor () in
@@ -253,10 +123,10 @@ let activate (extension : ExtensionContext.t) =
   (* this env var update disables ocaml-lsp's logging to a file
      because we use vscode [output] pane for logs *)
   Process.Env.set "OCAML_LSP_SERVER_LOG" "-";
-  let instance = Instance.create () in
+  let instance = Extension_instance.create () in
   ExtensionCommands.register_all_commands extension instance;
   ExtensionContext.subscribe extension
-    ~disposable:(Instance.disposable instance);
+    ~disposable:(Extension_instance.disposable instance);
   let open Promise.Syntax in
   let* toolchain, is_fallback =
     let+ pm = Toolchain.of_settings () in
@@ -269,7 +139,7 @@ let activate (extension : ExtensionContext.t) =
     in
     (Toolchain.make resources, is_fallback)
   in
-  Instance.start instance toolchain
+  Extension_instance.start instance toolchain
   |> Promise.Result.iter ~error:(fun e ->
          if not is_fallback then show_message `Error "%s" e)
   |> Promise.catch ~rejected:(fun e ->

--- a/src/vscode_ocaml_platform.ml
+++ b/src/vscode_ocaml_platform.ml
@@ -10,9 +10,7 @@ let suggest_to_setup_toolchain instance =
       ~choices:[ ("Select package manager", ()) ]
       ()
   in
-  match selection with
-  | None -> ()
-  | Some () -> Extension_commands.select_sandbox.handler instance ()
+  Option.iter selection ~f:(Extension_commands.select_sandbox.handler instance)
 
 let activate (extension : ExtensionContext.t) =
   (* this env var update disables ocaml-lsp's logging to a file

--- a/src/vscode_ocaml_platform.ml
+++ b/src/vscode_ocaml_platform.ml
@@ -1,110 +1,5 @@
 open Import
 
-module ExtensionCommands = struct
-  type command =
-    { id : string
-    ; handler : Extension_instance.t -> unit -> unit
-    }
-
-  let command id handler = { id; handler }
-
-  let select_sandbox =
-    let handler (instance : Extension_instance.t) () =
-      let set_toolchain =
-        let open Promise.Syntax in
-        let* package_manager = Toolchain.select_and_save () in
-        match package_manager with
-        | None -> Promise.Result.return ()
-        | Some pm ->
-          Extension_instance.stop instance;
-          let t = Toolchain.make pm in
-          Extension_instance.start instance t
-      in
-      let (_ : unit Promise.t) =
-        Promise.Result.iter set_toolchain ~error:(show_message `Error "%s")
-      in
-      ()
-    in
-    command select_sandbox_command_id handler
-
-  let restart_instance =
-    let handler (instance : Extension_instance.t) () =
-      let (_ : unit Promise.t) =
-        let open Promise.Syntax in
-        let* package_manager = Toolchain.of_settings () in
-        match package_manager with
-        | None ->
-          select_sandbox.handler instance ();
-          Promise.return ()
-        | Some pm ->
-          Extension_instance.stop_language_server instance;
-          Extension_instance.start_language_server instance (Toolchain.make pm)
-          |> Promise.Result.iter ~error:(show_message `Error "%s")
-      in
-      ()
-    in
-    command "ocaml.server.restart" handler
-
-  let select_sandbox_and_open_terminal =
-    let handler _instance () =
-      let (_ : unit option Promise.t) =
-        let open Promise.Option.Syntax in
-        let+ pm = Toolchain.select () in
-        let toolchain = Toolchain.make pm in
-        Extension_instance.open_terminal toolchain
-      in
-      ()
-    in
-    command "ocaml.open-terminal-select" handler
-
-  let open_terminal =
-    let handler (instance : Extension_instance.t) () =
-      match instance.toolchain with
-      | None -> select_sandbox_and_open_terminal.handler instance ()
-      | Some toolchain -> Extension_instance.open_terminal toolchain
-    in
-    command "ocaml.open-terminal" handler
-
-  let switch_impl_intf =
-    let handler (instance : Extension_instance.t) () =
-      let try_switching () =
-        let open Option.O in
-        let* editor = Window.activeTextEditor () in
-        let document = TextEditor.document editor in
-        let* client = instance.client in
-        (* extension needs to be activated; otherwise, just ignore the switch try *)
-        let+ ocaml_lsp = instance.ocaml_lsp_capabilities in
-        (* same as for instance.client; ignore the try if it's None *)
-        if Ocaml_lsp.can_handle_switch_impl_intf ocaml_lsp then
-          Switch_impl_intf.request_switch client document
-        else
-          (* if, however, ocamllsp doesn't have the capability, recommend updating ocamllsp*)
-          Promise.return
-          @@ show_message `Warn
-               "The installed version of ocamllsp does not support switching \
-                between implementation and interface files. Consider updating \
-                ocamllsp."
-      in
-      let (_ : unit Promise.t option) = try_switching () in
-      ()
-    in
-    command "ocaml.switch-impl-intf" handler
-
-  let register_all_commands extension instance =
-    let register_command { id; handler } =
-      let callback ~args:_ = handler instance () in
-      let disposable = Commands.registerCommand ~command:id ~callback in
-      ExtensionContext.subscribe extension ~disposable
-    in
-    List.iter ~f:register_command
-      [ select_sandbox
-      ; restart_instance
-      ; open_terminal
-      ; select_sandbox_and_open_terminal
-      ; switch_impl_intf
-      ]
-end
-
 let suggest_to_setup_toolchain instance =
   let open Promise.Syntax in
   let+ selection =
@@ -117,14 +12,14 @@ let suggest_to_setup_toolchain instance =
   in
   match selection with
   | None -> ()
-  | Some () -> ExtensionCommands.select_sandbox.handler instance ()
+  | Some () -> Extension_commands.select_sandbox.handler instance ()
 
 let activate (extension : ExtensionContext.t) =
   (* this env var update disables ocaml-lsp's logging to a file
      because we use vscode [output] pane for logs *)
   Process.Env.set "OCAML_LSP_SERVER_LOG" "-";
   let instance = Extension_instance.create () in
-  ExtensionCommands.register_all_commands extension instance;
+  Extension_commands.register_all_commands extension instance;
   ExtensionContext.subscribe extension
     ~disposable:(Extension_instance.disposable instance);
   let open Promise.Syntax in

--- a/src/vscode_ocaml_platform.ml
+++ b/src/vscode_ocaml_platform.ml
@@ -86,7 +86,7 @@ module Instance = struct
       (not (Ocaml_lsp.has_interface_specific_lang_id ocaml_lsp))
       || not (Ocaml_lsp.can_handle_switch_impl_intf ocaml_lsp)
     then
-      message `Warn
+      show_message `Warn
         "The installed version of ocamllsp is out of date. Some features may \
          be unavailable or degraded in functionality: switching between \
          implementation and interface files, functionality in mli sources. \
@@ -123,7 +123,7 @@ module Instance = struct
     match Terminal_sandbox.create toolchain with
     | Some terminal -> Terminal_sandbox.show terminal
     | None ->
-      message `Error
+      show_message `Error
         "Could not open a terminal in the current sandbox. The toolchain may \
          not have loaded yet."
 
@@ -151,7 +151,7 @@ module ExtensionCommands = struct
           Instance.start instance t
       in
       let (_ : unit Promise.t) =
-        Promise.Result.iter set_toolchain ~error:(message `Error "%s")
+        Promise.Result.iter set_toolchain ~error:(show_message `Error "%s")
       in
       ()
     in
@@ -169,7 +169,7 @@ module ExtensionCommands = struct
         | Some pm ->
           Instance.stop_language_server instance;
           Instance.start_language_server instance (Toolchain.make pm)
-          |> Promise.Result.iter ~error:(message `Error "%s")
+          |> Promise.Result.iter ~error:(show_message `Error "%s")
       in
       ()
     in
@@ -210,7 +210,7 @@ module ExtensionCommands = struct
         else
           (* if, however, ocamllsp doesn't have the capability, recommend updating ocamllsp*)
           Promise.return
-          @@ message `Warn
+          @@ show_message `Warn
                "The installed version of ocamllsp does not support switching \
                 between implementation and interface files. Consider updating \
                 ocamllsp."
@@ -271,10 +271,10 @@ let activate (extension : ExtensionContext.t) =
   in
   Instance.start instance toolchain
   |> Promise.Result.iter ~error:(fun e ->
-         if not is_fallback then message `Error "%s" e)
+         if not is_fallback then show_message `Error "%s" e)
   |> Promise.catch ~rejected:(fun e ->
          let error_message = Node.JsError.message e in
-         message `Error "Error: %s" error_message;
+         show_message `Error "Error: %s" error_message;
          Promise.return ())
 
 let () =

--- a/src/vscode_ocaml_platform.ml
+++ b/src/vscode_ocaml_platform.ml
@@ -1,13 +1,15 @@
 open Import
 
-let suggest_to_setup_toolchain instance =
+let suggest_to_pick_sandbox instance =
   let open Promise.Syntax in
+  let select_pm_button_text = "Select package manager and sandbox" in
   let+ selection =
     Window.showInformationMessage
       ~message:
-        "Extension is unable to find ocamllsp automatically. Please select \
-         package manager you used to install ocamllsp for this project."
-      ~choices:[ ("Select package manager", ()) ]
+        "OCaml Platform is using the package manager and sandbox available in \
+         the environment. Pick a particular package manager and sandbox by \
+         clicking the button below"
+      ~choices:[ (select_pm_button_text, ()) ]
       ()
   in
   Option.iter selection ~f:(Extension_commands.select_sandbox.handler instance)
@@ -16,25 +18,27 @@ let activate (extension : ExtensionContext.t) =
   (* this env var update disables ocaml-lsp's logging to a file
      because we use vscode [output] pane for logs *)
   Process.Env.set "OCAML_LSP_SERVER_LOG" "-";
-  let instance = Extension_instance.create () in
-  Extension_commands.register_all_commands extension instance;
-  ExtensionContext.subscribe extension
-    ~disposable:(Extension_instance.disposable instance);
   let open Promise.Syntax in
-  let* toolchain, is_fallback =
-    let+ pm = Toolchain.of_settings () in
-    let resources, is_fallback =
-      match pm with
-      | Some pm -> (pm, false)
-      | None ->
-        let (_ : unit Promise.t) = suggest_to_setup_toolchain instance in
-        (Toolchain.Package_manager.Global, true)
-    in
-    (Toolchain.make resources, is_fallback)
+  let* package_manager =
+    Toolchain.of_settings ()
+    (* TODO: implement [Toolchain.from_settings_or_detect] that would
+       either get the sandbox from the settings or detect in a smart way (not simply Global) *)
   in
-  Extension_instance.start instance toolchain
+  let is_fallback = Option.is_empty package_manager in
+  let package_manager =
+    Option.value package_manager ~default:Toolchain.Package_manager.Global
+  in
+  Extension_instance.make (Toolchain.make package_manager)
   |> Promise.Result.iter
-       ~ok:(fun () ->
+       ~ok:(fun instance ->
+         (* register things with vscode, making sure to register their disposables *)
+         let _register_extension_commands : unit =
+           Extension_commands.register_all_commands extension instance
+         in
+         let _register_extension_instance : unit =
+           ExtensionContext.subscribe extension
+             ~disposable:(Extension_instance.disposable instance)
+         in
          let _register_dune_formatter : unit =
            Dune_formatter.register instance
            |> List.iter ~f:(fun disposable ->
@@ -44,8 +48,19 @@ let activate (extension : ExtensionContext.t) =
            let disposable = Dune_task_provider.register instance in
            ExtensionContext.subscribe extension ~disposable
          in
-         ())
-       ~error:(fun e -> if not is_fallback then show_message `Error "%s" e)
+         if
+           is_fallback
+           (* if the toolchain we just set up is a fallback sandbox,
+              we create a pop-up message to offer the user to pick a sandbox they want;
+              note: if the user picks another sandbox in the pop-up,
+                we redo part of work we have just done;
+                this is the case because we can't wait or rely on user to pick a sandbox:
+                they may ignore the pop-up leaving the extension hanging, so we use fallback;
+                w/ a proper detection mechanism, we would redo work in rare cases *)
+         then
+           let (_ : unit Promise.t) = suggest_to_pick_sandbox instance in
+           ())
+       ~error:(fun e -> show_message `Error "%s" e)
   |> Promise.catch ~rejected:(fun e ->
          let error_message = Node.JsError.message e in
          show_message `Error "Error: %s" error_message;

--- a/src/vscode_ocaml_platform.ml
+++ b/src/vscode_ocaml_platform.ml
@@ -40,6 +40,10 @@ let activate (extension : ExtensionContext.t) =
            |> List.iter ~f:(fun disposable ->
                   ExtensionContext.subscribe extension ~disposable)
          in
+         let _register_dune_task_provider : unit =
+           let disposable = Dune_task_provider.register instance in
+           ExtensionContext.subscribe extension ~disposable
+         in
          ())
        ~error:(fun e -> if not is_fallback then show_message `Error "%s" e)
   |> Promise.catch ~rejected:(fun e ->

--- a/src/vscode_ocaml_platform.ml
+++ b/src/vscode_ocaml_platform.ml
@@ -43,8 +43,7 @@ let activate (extension : ExtensionContext.t) =
            Dune_formatter.register extension instance
          in
          let _register_dune_task_provider : unit =
-           let disposable = Dune_task_provider.register instance in
-           ExtensionContext.subscribe extension ~disposable
+           Dune_task_provider.register extension instance
          in
          if
            is_fallback

--- a/src/vscode_ocaml_platform.ml
+++ b/src/vscode_ocaml_platform.ml
@@ -33,8 +33,15 @@ let activate (extension : ExtensionContext.t) =
     (Toolchain.make resources, is_fallback)
   in
   Extension_instance.start instance toolchain
-  |> Promise.Result.iter ~error:(fun e ->
-         if not is_fallback then show_message `Error "%s" e)
+  |> Promise.Result.iter
+       ~ok:(fun () ->
+         let _register_dune_formatter : unit =
+           Dune_formatter.register instance
+           |> List.iter ~f:(fun disposable ->
+                  ExtensionContext.subscribe extension ~disposable)
+         in
+         ())
+       ~error:(fun e -> if not is_fallback then show_message `Error "%s" e)
   |> Promise.catch ~rejected:(fun e ->
          let error_message = Node.JsError.message e in
          show_message `Error "Error: %s" error_message;

--- a/src/vscode_ocaml_platform.ml
+++ b/src/vscode_ocaml_platform.ml
@@ -32,19 +32,11 @@ let activate (extension : ExtensionContext.t) =
   |> Promise.Result.iter
        ~ok:(fun instance ->
          (* register things with vscode, making sure to register their disposables *)
-         let _register_extension_commands : unit =
-           Extension_commands.register_all_commands extension instance
-         in
-         let _register_extension_instance : unit =
-           ExtensionContext.subscribe extension
-             ~disposable:(Extension_instance.disposable instance)
-         in
-         let _register_dune_formatter : unit =
-           Dune_formatter.register extension instance
-         in
-         let _register_dune_task_provider : unit =
-           Dune_task_provider.register extension instance
-         in
+         ExtensionContext.subscribe extension
+           ~disposable:(Extension_instance.disposable instance);
+         Extension_commands.register_all_commands extension instance;
+         Dune_formatter.register extension instance;
+         Dune_task_provider.register extension instance;
          if
            is_fallback
            (* if the toolchain we just set up is a fallback sandbox,

--- a/src/vscode_ocaml_platform.ml
+++ b/src/vscode_ocaml_platform.ml
@@ -40,9 +40,7 @@ let activate (extension : ExtensionContext.t) =
              ~disposable:(Extension_instance.disposable instance)
          in
          let _register_dune_formatter : unit =
-           Dune_formatter.register instance
-           |> List.iter ~f:(fun disposable ->
-                  ExtensionContext.subscribe extension ~disposable)
+           Dune_formatter.register extension instance
          in
          let _register_dune_task_provider : unit =
            let disposable = Dune_task_provider.register instance in

--- a/src/vscode_ocaml_platform.mli
+++ b/src/vscode_ocaml_platform.mli
@@ -1,3 +1,4 @@
 (** Entry point *)
 
+(* see {{:https://code.visualstudio.com/api/references/vscode-api#Extension} activate() *)
 val activate : Vscode.ExtensionContext.t -> unit Promise.t

--- a/vscode/vscode/vscode.ml
+++ b/vscode/vscode/vscode.ml
@@ -1983,3 +1983,8 @@ end
 module Env = struct
   val shell : unit -> string [@@js.get "vscode.env.shell"]
 end
+
+(* see https://code.visualstudio.com/api/references/icons-in-labels *)
+module LabelIcons = struct
+  let package = "$(package)"
+end

--- a/vscode/vscode/vscode.mli
+++ b/vscode/vscode/vscode.mli
@@ -1923,3 +1923,7 @@ end
 module Env : sig
   val shell : unit -> string
 end
+
+module LabelIcons : sig
+  val package : string
+end


### PR DESCRIPTION
This is a slightly large change to how to store and manage extension state (was called `Instance` and is called`Extension_instance` now). It removes some mutable state, avoids restarting the instance when we can just update it, and does several other small things. 

For reviewing: I would recommend to go commit by commit from oldest to youngest, and the code should make sense.