### PR TITLE
Unify toolchain and package manager types

### DIFF
--- a/src/extension_commands.ml
+++ b/src/extension_commands.ml
@@ -20,11 +20,10 @@ let select_sandbox =
     let open Promise.Syntax in
     let current_toolchain = Extension_instance.toolchain instance in
     let (_ : unit Promise.t) =
-      let* package_manager = Toolchain.select_sandbox () in
-      match package_manager with
+      let* toolchain = Toolchain.select_toolchain () in
+      match toolchain with
       | None (* sandbox selection cancelled *) -> Promise.return ()
-      | Some pm ->
-        let new_toolchain = Toolchain.make pm in
+      | Some new_toolchain ->
         if Toolchain.equal current_toolchain new_toolchain then
           (* TODO: or should we relaunch so that user wishes to "restart" their toolchain *)
           Promise.return ()
@@ -54,8 +53,7 @@ let select_sandbox_and_open_terminal =
   let handler _instance () =
     let (_ : unit option Promise.t) =
       let open Promise.Option.Syntax in
-      let+ pm = Toolchain.select_sandbox () in
-      let toolchain = Toolchain.make pm in
+      let+ toolchain = Toolchain.select_toolchain () in
       Extension_instance.open_terminal toolchain
     in
     ()

--- a/src/extension_instance.ml
+++ b/src/extension_instance.ml
@@ -83,17 +83,15 @@ module Sandbox_info : sig
 
   val update : StatusBarItem.t -> new_toolchain:Toolchain.t -> unit
 end = struct
-  let make_status_bar_item_text package_manager =
+  let make_status_bar_item_text toolchain =
     Printf.sprintf "%s %s" LabelIcons.package
-    @@ Toolchain.Package_manager.to_pretty_string package_manager
+    @@ Toolchain.to_pretty_string toolchain
 
   let make toolchain =
     let status_bar_item =
       Window.createStatusBarItem ~alignment:StatusBarAlignment.Left ()
     in
-    let status_bar_item_text =
-      make_status_bar_item_text @@ Toolchain.package_manager toolchain
-    in
+    let status_bar_item_text = make_status_bar_item_text toolchain in
     StatusBarItem.set_text status_bar_item status_bar_item_text;
     StatusBarItem.set_command status_bar_item
       (`String Extension_consts.Commands.select_sandbox);
@@ -101,9 +99,7 @@ end = struct
     status_bar_item
 
   let update sandbox_info ~new_toolchain =
-    let status_bar_item_text =
-      make_status_bar_item_text @@ Toolchain.package_manager new_toolchain
-    in
+    let status_bar_item_text = make_status_bar_item_text new_toolchain in
     StatusBarItem.set_text sandbox_info status_bar_item_text
 end
 

--- a/src/terminal_sandbox.ml
+++ b/src/terminal_sandbox.ml
@@ -76,8 +76,7 @@ let create toolchain =
       | PowerShell bin -> { bin; args = [ "-c"; "& " ^ command_line ] } )
   in
   Cmd.log (Spawn command);
-  let package_manager = Toolchain.package_manager toolchain in
-  let name = Toolchain.Package_manager.to_pretty_string package_manager in
+  let name = Toolchain.to_pretty_string toolchain in
   let shellPath = Path.to_string bin in
   let shellArgs = `Strings args in
   Window.createTerminal ~name ~shellPath ~shellArgs ()

--- a/src/toolchain.ml
+++ b/src/toolchain.ml
@@ -1,8 +1,8 @@
 open Import
 
 (* Terminology:
-   - Package_manager: represents supported package managers
-     with Global as the fallback
+   - Toolchain: represents supported toolchains with Global as
+     the fallback
    - project_root is different from Package_manager root (Eg. Opam
      (Path.of_string "/foo/bar")). Project root
      is the directory where manifest file (opam/esy.json/package.json)
@@ -14,156 +14,135 @@ open Import
    - Manifest: abstracts functions handling manifest files
      of the supported package managers *)
 
-module Package_manager = struct
-  module Kind = struct
-    type t =
-      | Opam
-      | Esy
-      | Global
-      | Custom
+type t =
+  | Opam of Opam.t * Opam.Switch.t
+  | Esy of Esy.t * Path.t
+  | Global
+  | Custom of string
 
-    module Hmap = struct
-      type ('opam, 'esy, 'global, 'custom) t =
-        { opam : 'opam
-        ; esy : 'esy
-        ; global : 'global
-        ; custom : 'custom
-        }
-    end
+let equal t1 t2 =
+  match (t1, t2) with
+  | Global, Global -> true
+  | Esy (e1, p1), Esy (e2, p2) -> Path.equal p1 p2 && Esy.equal e1 e2
+  | Opam (o1, s1), Opam (o2, s2) -> Opam.Switch.equal s1 s2 && Opam.equal o1 o2
+  | Custom s1, Custom s2 -> String.equal s1 s2
+  | _, _ -> false
 
-    let of_string = function
-      | "opam" -> Some Opam
-      | "esy" -> Some Esy
-      | "global" -> Some Global
-      | "custom" -> Some Custom
-      | _ -> None
+let to_string = function
+  | Esy (_, root) -> Printf.sprintf "esy(%s)" (Path.to_string root)
+  | Opam (_, switch) -> Printf.sprintf "opam(%s)" (Opam.Switch.name switch)
+  | Global -> "global"
+  | Custom _ -> "custom"
 
-    let of_json json =
-      let open Jsonoo.Decode in
-      match of_string (string json) with
-      | Some s -> s
-      | None ->
-        raise
-          (Jsonoo.Decode_error
-             "opam | esy | global | custom are the only valid values")
+let to_pretty_string t =
+  let print_opam = Printf.sprintf "opam(%s)" in
+  let print_esy = Printf.sprintf "esy(%s)" in
+  match t with
+  | Esy (_, root) ->
+    let project_name = Path.basename root in
+    print_esy project_name
+  | Opam (_, Named name) -> print_opam name
+  | Opam (_, Local path) ->
+    let project_name = Path.basename path in
+    print_opam project_name
+  | Global -> "Global OCaml"
+  | Custom _ -> "Custom OCaml"
 
-    let to_string = function
-      | Opam -> "opam"
-      | Esy -> "esy"
-      | Global -> "global"
-      | Custom -> "custom"
+module Kind = struct
+  type t =
+    | Opam
+    | Esy
+    | Global
+    | Custom
 
-    let to_json s = Jsonoo.Encode.string (to_string s)
+  module Hmap = struct
+    type ('opam, 'esy, 'global, 'custom) t =
+      { opam : 'opam
+      ; esy : 'esy
+      ; global : 'global
+      ; custom : 'custom
+      }
   end
 
+  let of_string = function
+    | "opam" -> Some Opam
+    | "esy" -> Some Esy
+    | "global" -> Some Global
+    | "custom" -> Some Custom
+    | _ -> None
+
+  let of_json json =
+    let open Jsonoo.Decode in
+    match of_string (string json) with
+    | Some s -> s
+    | None ->
+      raise
+        (Jsonoo.Decode_error
+           "opam | esy | global | custom are the only valid values")
+
+  let to_string = function
+    | Opam -> "opam"
+    | Esy -> "esy"
+    | Global -> "global"
+    | Custom -> "custom"
+
+  let to_json s = Jsonoo.Encode.string (to_string s)
+end
+
+module Setting = struct
   type t =
-    | Opam of Opam.t * Opam.Switch.t
-    | Esy of Esy.t * Path.t
+    | Opam of Opam.Switch.t
+    | Esy of Path.t
     | Global
     | Custom of string
 
-  module Setting = struct
-    type t =
-      | Opam of Opam.Switch.t
-      | Esy of Path.t
-      | Global
-      | Custom of string
+  let kind : t -> Kind.t = function
+    | Opam _ -> Opam
+    | Esy _ -> Esy
+    | Global -> Global
+    | Custom _ -> Custom
 
-    let kind : t -> Kind.t = function
-      | Opam _ -> Opam
-      | Esy _ -> Esy
-      | Global -> Global
-      | Custom _ -> Custom
+  let of_json json =
+    let open Jsonoo.Decode in
+    let decode_vars json = Settings.resolve_workspace_vars (string json) in
+    let kind = field "kind" Kind.of_json json in
+    match (kind : Kind.t) with
+    | Global -> Global
+    | Esy ->
+      let manifest =
+        field "root" (fun js -> Path.of_string (decode_vars js)) json
+      in
+      Esy manifest
+    | Opam ->
+      let switch =
+        field "switch" (fun js -> Opam.Switch.make (decode_vars js)) json
+      in
+      Opam switch
+    | Custom ->
+      let template = field "template" decode_vars json in
+      Custom template
 
-    let of_json json =
-      let open Jsonoo.Decode in
-      let decode_vars json = Settings.resolve_workspace_vars (string json) in
-      let kind = field "kind" Kind.of_json json in
-      match (kind : Kind.t) with
-      | Global -> Global
-      | Esy ->
-        let manifest =
-          field "root" (fun js -> Path.of_string (decode_vars js)) json
-        in
-        Esy manifest
-      | Opam ->
-        let switch =
-          field "switch" (fun js -> Opam.Switch.make (decode_vars js)) json
-        in
-        Opam switch
-      | Custom ->
-        let template = field "template" decode_vars json in
-        Custom template
-
-    let to_json (t : t) =
-      let open Jsonoo.Encode in
-      let encode_vars str = string (Settings.substitute_workspace_vars str) in
-      let kind = ("kind", Kind.to_json (kind t)) in
-      match t with
-      | Global -> Jsonoo.Encode.object_ [ kind ]
-      | Esy manifest ->
-        object_ [ kind; ("root", encode_vars @@ Path.to_string manifest) ]
-      | Opam switch ->
-        object_ [ kind; ("switch", encode_vars @@ Opam.Switch.name switch) ]
-      | Custom template -> object_ [ kind; ("template", string template) ]
-
-    let t = Settings.create ~scope:Workspace ~key:"sandbox" ~of_json ~to_json
-  end
-
-  let equal pm1 pm2 =
-    match (pm1, pm2) with
-    | Global, Global -> true
-    | Esy (e1, p1), Esy (e2, p2) -> Path.equal p1 p2 && Esy.equal e1 e2
-    | Opam (o1, s1), Opam (o2, s2) ->
-      Opam.Switch.equal s1 s2 && Opam.equal o1 o2
-    | Custom s1, Custom s2 -> String.equal s1 s2
-    | _, _ -> false
-
-  let to_setting = function
-    | Esy (_, root) -> Setting.Esy root
-    | Opam (_, switch) -> Setting.Opam switch
-    | Global -> Setting.Global
-    | Custom template -> Setting.Custom template
-
-  let to_string = function
-    | Esy (_, root) -> Printf.sprintf "esy(%s)" (Path.to_string root)
-    | Opam (_, switch) -> Printf.sprintf "opam(%s)" (Opam.Switch.name switch)
-    | Global -> "global"
-    | Custom _ -> "custom"
-
-  let to_pretty_string t =
-    let print_opam = Printf.sprintf "opam(%s)" in
-    let print_esy = Printf.sprintf "esy(%s)" in
+  let to_json (t : t) =
+    let open Jsonoo.Encode in
+    let encode_vars str = string (Settings.substitute_workspace_vars str) in
+    let kind = ("kind", Kind.to_json (kind t)) in
     match t with
-    | Esy (_, root) ->
-      let project_name = Path.basename root in
-      print_esy project_name
-    | Opam (_, Named name) -> print_opam name
-    | Opam (_, Local path) ->
-      let project_name = Path.basename path in
-      print_opam project_name
-    | Global -> "Global OCaml"
-    | Custom _ -> "Custom OCaml"
+    | Global -> Jsonoo.Encode.object_ [ kind ]
+    | Esy manifest ->
+      object_ [ kind; ("root", encode_vars @@ Path.to_string manifest) ]
+    | Opam switch ->
+      object_ [ kind; ("switch", encode_vars @@ Opam.Switch.name switch) ]
+    | Custom template -> object_ [ kind; ("template", string template) ]
+
+  let t = Settings.create ~scope:Workspace ~key:"sandbox" ~of_json ~to_json
 end
 
-type t = Package_manager.t
+let available_toolchains () =
+  { Kind.Hmap.opam = Opam.make (); esy = Esy.make (); global = (); custom = () }
 
-let make (t : Package_manager.t) : t = t
-
-let package_manager (t : t) : Package_manager.t = t
-
-let equal t1 t2 = Package_manager.equal t1 t2
-
-let available_package_managers () =
-  { Package_manager.Kind.Hmap.opam = Opam.make ()
-  ; esy = Esy.make ()
-  ; global = ()
-  ; custom = ()
-  }
-
-let of_settings () : Package_manager.t option Promise.t =
+let of_settings () : t option Promise.t =
   let open Promise.Syntax in
-  let available = available_package_managers () in
+  let available = available_toolchains () in
   let not_available kind =
     let this_ =
       match kind with
@@ -175,10 +154,7 @@ let of_settings () : Package_manager.t option Promise.t =
        available"
       this_ this_
   in
-  match
-    ( Settings.get ~section:"ocaml" Package_manager.Setting.t
-      : Package_manager.Setting.t option )
-  with
+  match (Settings.get ~section:"ocaml" Setting.t : Setting.t option) with
   | None -> Promise.return None
   | Some (Esy manifest) -> (
     let+ esy = available.esy in
@@ -186,7 +162,7 @@ let of_settings () : Package_manager.t option Promise.t =
     | None ->
       not_available `Esy;
       None
-    | Some esy -> Some (Package_manager.Esy (esy, manifest)) )
+    | Some esy -> Some (Esy (esy, manifest)) )
   | Some (Opam switch) -> (
     let open Promise.Syntax in
     let* opam = available.opam in
@@ -197,7 +173,7 @@ let of_settings () : Package_manager.t option Promise.t =
     | Some opam ->
       let+ exists = Opam.exists opam ~switch in
       if exists then
-        Some (Package_manager.Opam (opam, switch))
+        Some (Opam (opam, switch))
       else (
         show_message `Warn
           "Workspace is configured to use the switch %s. This switch does not \
@@ -205,34 +181,38 @@ let of_settings () : Package_manager.t option Promise.t =
           (Opam.Switch.name switch);
         None
       ) )
-  | Some Global -> Promise.return (Some Package_manager.Global)
-  | Some (Custom template) ->
-    Promise.return (Some (Package_manager.Custom template))
+  | Some Global -> Promise.return (Some Global)
+  | Some (Custom template) -> Promise.return (Some (Custom template))
 
-let save_to_settings package_manager =
-  Settings.set ~section:"ocaml" Package_manager.Setting.t
-    (Package_manager.to_setting package_manager)
+let save_to_settings toolchain =
+  let to_setting = function
+    | Esy (_, root) -> Setting.Esy root
+    | Opam (_, switch) -> Setting.Opam switch
+    | Global -> Setting.Global
+    | Custom template -> Setting.Custom template
+  in
+  Settings.set ~section:"ocaml" Setting.t (to_setting toolchain)
 
 module Candidate = struct
-  type t =
-    { package_manager : Package_manager.t
+  type nonrec t =
+    { toolchain : t
     ; status : (unit, string) result
     }
 
-  let to_quick_pick { package_manager; status } =
+  let to_quick_pick { toolchain; status } =
     let create = QuickPickItem.create in
     let description =
       match status with
       | Error s -> Some (Printf.sprintf "Invalid sandbox: %s" s)
       | Ok () -> (
-        match package_manager with
+        match toolchain with
         | Opam (_, Local _) -> Some "Local switch"
         | Opam (_, Named _) -> Some "Global switch"
         | Esy _ -> Some "Esy"
         | _ -> None )
     in
-    match package_manager with
-    | Package_manager.Opam (_, Named name) -> create ~label:name ?description ()
+    match toolchain with
+    | Opam (_, Named name) -> create ~label:name ?description ()
     | Opam (_, Local path) ->
       let project_name = Path.basename path in
       let project_path = Path.to_string path in
@@ -248,26 +228,26 @@ module Candidate = struct
       create ?description ~label:"Custom"
         ~detail:"Custom toolchain using a command template" ()
 
-  let ok package_manager = { package_manager; status = Ok () }
+  let ok toolchain = { toolchain; status = Ok () }
 end
 
-let select_package_manager (choices : Candidate.t list) =
+let select_toolchain (choices : Candidate.t list) =
   let placeHolder =
     "Which package manager would you like to manage the toolchain?"
   in
   let choices =
     List.map
-      ~f:(fun (pm : Candidate.t) ->
-        let quick_pick = Candidate.to_quick_pick pm in
-        (quick_pick, pm))
+      ~f:(fun (toolchain : Candidate.t) ->
+        let quick_pick = Candidate.to_quick_pick toolchain in
+        (quick_pick, toolchain))
       choices
   in
   let options = QuickPickOptions.create ~canPickMany:false ~placeHolder () in
   Window.showQuickPickItems ~choices ~options ()
 
-let sandbox_candidates ~workspace_folders =
+let toolchain_candidates ~workspace_folders =
   let open Promise.Syntax in
-  let available = available_package_managers () in
+  let available = available_toolchains () in
   let esy =
     let* esy = available.esy in
     match esy with
@@ -284,8 +264,7 @@ let sandbox_candidates ~workspace_folders =
       in
       List.concat esys
       |> List.map ~f:(fun (manifest : Esy.discover) ->
-             { Candidate.package_manager =
-                 Package_manager.Esy (esy, manifest.file)
+             { Candidate.toolchain = Esy (esy, manifest.file)
              ; status = manifest.status
              })
   in
@@ -296,12 +275,12 @@ let sandbox_candidates ~workspace_folders =
     | Some opam ->
       let+ switches = Opam.switch_list opam in
       List.map switches ~f:(fun sw ->
-          let package_manager = Package_manager.Opam (opam, sw) in
-          { Candidate.package_manager; status = Ok () })
+          let toolchain = Opam (opam, sw) in
+          { Candidate.toolchain; status = Ok () })
   in
-  let global = Candidate.ok Package_manager.Global in
+  let global = Candidate.ok Global in
   let custom =
-    Candidate.ok (Package_manager.Custom "$prog $args")
+    Candidate.ok (Custom "$prog $args")
     (* doesn't matter what the custom fields are set to here
        user will input custom commands in [select] *)
   in
@@ -309,7 +288,7 @@ let sandbox_candidates ~workspace_folders =
   let+ esy, opam = Promise.all2 (esy, opam) in
   (global :: custom :: esy) @ opam
 
-let setup_toolchain (kind : Package_manager.t) =
+let setup_toolchain (kind : t) =
   match kind with
   | Esy (esy, manifest) -> Esy.setup_toolchain esy ~manifest
   | Opam _
@@ -317,14 +296,14 @@ let setup_toolchain (kind : Package_manager.t) =
   | Custom _ ->
     Promise.Result.return ()
 
-let select_sandbox () =
+let select_toolchain () =
   let open Promise.Syntax in
   let workspace_folders = Workspace.workspaceFolders () in
-  let* candidates = sandbox_candidates ~workspace_folders in
+  let* candidates = toolchain_candidates ~workspace_folders in
   let open Promise.Option.Syntax in
-  let* candidate = select_package_manager candidates in
+  let* candidate = select_toolchain candidates in
   match candidate with
-  | { status = Ok (); package_manager = Custom _ } ->
+  | { status = Ok (); toolchain = Custom _ } ->
     let validateInput ~value =
       if
         String.is_substring value ~substring:"$prog"
@@ -340,23 +319,23 @@ let select_sandbox () =
     in
     let* input = Window.showInputBox ~options () in
     let template = String.strip input in
-    Promise.Option.return @@ Package_manager.Custom template
-  | { status; package_manager } -> (
+    Promise.Option.return @@ Custom template
+  | { status; toolchain } -> (
     match status with
     | Error s ->
       show_message `Warn "This toolchain is invalid. Error: %s" s;
       Promise.return None
-    | Ok () -> Promise.Option.return package_manager )
+    | Ok () -> Promise.Option.return toolchain )
 
-let select_sandbox_and_save () =
+let select_toolchain_and_save () =
   let open Promise.Option.Syntax in
-  let* package_manager = select_sandbox () in
+  let* toolchain = select_toolchain () in
   let open Promise.Syntax in
-  let+ () = save_to_settings package_manager in
-  Some package_manager
+  let+ () = save_to_settings toolchain in
+  Some toolchain
 
-let get_command (t : t) bin args : Cmd.t =
-  match t with
+let get_command toolchain bin args : Cmd.t =
+  match toolchain with
   | Opam (opam, switch) -> Opam.exec opam ~switch ~args:(bin :: args)
   | Esy (esy, manifest) -> Esy.exec esy ~manifest ~args:(bin :: args)
   | Global -> Spawn { bin = Path.of_string bin; args }
@@ -376,18 +355,18 @@ let get_command (t : t) bin args : Cmd.t =
     in
     Shell command
 
-let get_lsp_command ?(args = []) t : Cmd.t = get_command t "ocamllsp" args
+let get_lsp_command ?(args = []) toolchain : Cmd.t =
+  get_command toolchain "ocamllsp" args
 
-let get_dune_command t args : Cmd.t = get_command t "dune" args
+let get_dune_command toolchain args : Cmd.t = get_command toolchain "dune" args
 
-let run_setup t =
-  let package_manager = t in
+let run_setup toolchain =
   let open Promise.Syntax in
   let+ output =
     let open Promise.Result.Syntax in
-    let* () = setup_toolchain package_manager in
+    let* () = setup_toolchain toolchain in
     let args = [ "--version" ] in
-    let* command = Cmd.check (get_lsp_command t ~args) in
+    let* command = Cmd.check (get_lsp_command toolchain ~args) in
     Cmd.output command
   in
   match output with

--- a/src/toolchain.mli
+++ b/src/toolchain.mli
@@ -16,38 +16,30 @@
    user to install missing tools etc). Having a single [Toolchain.make()], for
    instance, would not make it this flexible. *)
 
-module Package_manager : sig
-  type t =
-    | Opam of Opam.t * Opam.Switch.t
-    | Esy of Esy.t * Path.t
-    | Global
-    | Custom of string
-
-  val to_string : t -> string
-
-  val to_pretty_string : t -> string
-end
-
-type t
-
-val of_settings : unit -> Package_manager.t option Promise.t
-
-val make : Package_manager.t -> t
-
-val package_manager : t -> Package_manager.t
+type t =
+  | Opam of Opam.t * Opam.Switch.t
+  | Esy of Esy.t * Path.t
+  | Global
+  | Custom of string
 
 val equal : t -> t -> bool
 
+val to_string : t -> string
+
+val to_pretty_string : t -> string
+
+val of_settings : unit -> t option Promise.t
+
 val save_to_settings : t -> unit Promise.t
 
-(** [select_sandbox_and_save] requires the process environment the plugin is being run in
+(** [select_toolchain_and_save] requires the process environment the plugin is being run in
    (ie VSCode's process environment) and the project root and produces a promise
    of resources available that can later be passed on to [run_setup] that can be
    called to install the toolchain. *)
-val select_sandbox_and_save : unit -> Package_manager.t option Promise.t
+val select_toolchain_and_save : unit -> t option Promise.t
 
-(** [select_sandbox] is the same as [select_sandbox_and_save] but does not save the toolchain configuration *)
-val select_sandbox : unit -> Package_manager.t option Promise.t
+(** [select_toolchain] is the same as [select_toolchain_and_save] but does not save the toolchain configuration *)
+val select_toolchain : unit -> t option Promise.t
 
 (** [run_setup] is an effectful function that triggers setup instructions
    automatically for the user. At present, this functionality

--- a/src/vscode_ocaml_platform.ml
+++ b/src/vscode_ocaml_platform.ml
@@ -19,16 +19,14 @@ let activate (extension : ExtensionContext.t) =
      because we use vscode [output] pane for logs *)
   Process.Env.set "OCAML_LSP_SERVER_LOG" "-";
   let open Promise.Syntax in
-  let* package_manager =
+  let* toolchain =
     Toolchain.of_settings ()
     (* TODO: implement [Toolchain.from_settings_or_detect] that would
        either get the sandbox from the settings or detect in a smart way (not simply Global) *)
   in
-  let is_fallback = Option.is_empty package_manager in
-  let package_manager =
-    Option.value package_manager ~default:Toolchain.Package_manager.Global
-  in
-  Extension_instance.make (Toolchain.make package_manager)
+  let is_fallback = Option.is_empty toolchain in
+  let toolchain = Option.value toolchain ~default:Toolchain.Global in
+  Extension_instance.make toolchain
   |> Promise.Result.iter
        ~ok:(fun instance ->
          (* register things with vscode, making sure to register their disposables *)


### PR DESCRIPTION
This PR removes the `Package_manager` module and directly integrates its components in the `Toolchain` module.

The separate types (`Toolchain.t` and `Package_manager.t`) have only caused unnecessary conversions between each other, without providing additional functionality.

This PR also cleans up the use of language internally to refer to "toolchains", not "package managers" or "sandboxes". The previous language didn't make sense because only the `Opam`/`Esy` variants could be considered "package managers" and the `Custom`/`Global` variants aren't necessarily sandboxed. 

I didn't change any exposed names, so the commands and settings are still the same (`ocaml.select-sandbox` and `ocaml.sandbox`).