### PR TITLE
Fix reason highlighting of let extensions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - Highlight `rec` keyword in OCaml mli files for recursive modules (#434)
 - Highlight `cram` stanza in dune-project files (#441)
+- Fix reason highlighting of let extensions (#447)
 
 ## 1.4.0
 

--- a/syntaxes/reason.json
+++ b/syntaxes/reason.json
@@ -595,7 +595,6 @@
       "patterns": [{ "include": "#value-expression" }]
     },
     "module-item-let-value-bind-name-or-pattern": {
-      "begin": "(?<=[^[:word:]]and|^and|[^[:word:]]external|^external|[^[:word:]]let|^let|[^[:word:]]method|^method|[^[:word:]]rec|^rec)[[:space:]]*",
       "end": "(?<=[^[:space:]])|(?=[[:space:]]|[;:}=]|\\b(and|as|class|constraint|exception|external|for|include|inherit|let|method|module|nonrec|open|private|rec|switch|try|type|val|while|with)\\b)",
       "patterns": [
         { "include": "#comment" },
@@ -611,33 +610,8 @@
       ]
     },
     "module-item-let-value-bind-name-params-type-body": {
-      "begin": "(?<=[^[:word:]]and|^and|[^[:word:]]external|^external|[^[:word:]]let|^let|[^[:word:]]method|^method|[^[:word:]]rec|^rec)",
       "end": "(?=[;}]|\\b(and|class|constraint|exception|external|include|inherit|let|method|module|nonrec|open|private|rec|type|val|with)\\b)",
       "patterns": [
-        {
-          "comment": "FIXME; hack for punned arguments",
-          "begin": "(::)",
-          "end": "(?<=[[:space:]])",
-          "beginCaptures": {
-            "1": { "name": "keyword.control" }
-          },
-          "patterns": [
-            { "include": "#pattern" },
-            {
-              "begin": "(=)",
-              "end": "(\\?)|(?<=[^[:space:]=][[:space:]])(?=[[:space:]]*+[^\\.])",
-              "beginCaptures": {
-                "1": {
-                  "name": "markup.inserted keyword.control.less message.error"
-                }
-              },
-              "endCaptures": {
-                "1": { "name": "storage.type" }
-              },
-              "patterns": [{ "include": "#value-expression-atomic-with-paths" }]
-            }
-          ]
-        },
         { "include": "#module-item-let-value-bind-name-or-pattern" },
         { "include": "#module-item-let-value-bind-params-type" },
         { "include": "#module-item-let-value-bind-type" },


### PR DESCRIPTION
Closes #380

This PR updates parts of the reason syntax to [reason-language-server's version](https://github.com/jaredly/reason-language-server/blob/master/editor-extensions/vscode/reason.json) to fix highlighting bugs.