### PR TITLE
Add keyboard shortcut for infer interface code action

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 - Fix reason highlighting of let extensions (#447)
 - Improve highlighting of Menhir new syntax (#450)
 - Improve Menhir syntax highlighting (#455)
+- Add `Alt + P` keyboard shortcut for infer interface code action (#448)
 
 ## 1.4.0
 

--- a/package.json
+++ b/package.json
@@ -79,6 +79,14 @@
           "kind": "destruct"
         },
         "when": "editorLangId  == ocaml || editorLangId == reason"
+      },
+      {
+        "command": "editor.action.codeAction",
+        "key": "Alt+P",
+        "args": {
+          "kind": "inferred_intf"
+        },
+        "when": "editorLangId  == ocaml.interface || editorLangId == reason"
       }
     ],
     "menus": {


### PR DESCRIPTION
Adds an `Alt+P` keybinding to fill a file with an inferred interface.

The workflow is quite smooth from my testing:
- `Alt+O` to switch to  new .mli file.
- `CTRL+S`/ `CMD+S` to save the .mli file.
- `Alt+P` to fill the .mli file with an inferred interface.