### PR TITLE
Fix Menhir production highlighting in new syntax

### DIFF
--- a/syntaxes/menhir.json
+++ b/syntaxes/menhir.json
@@ -113,13 +113,14 @@
           "comment": "production",
           "begin": ":|\\|",
           "beginCaptures": [{ "name": "keyword.other.menhir" }],
-          "end": "(?={|<)",
+          "end": "$",
           "patterns": [
             { "include": "#comments" },
             { "include": "#variables" },
             { "include": "#references" },
             { "include": "#operators" },
-            { "include": "source.ocaml#strings" }
+            { "include": "source.ocaml#strings" },
+            { "include": "#actions" }
           ]
         },
         { "include": "#actions" }
@@ -167,7 +168,7 @@
 
     "variables": {
       "comment": "labeled semantic value identifier",
-      "match": "([[:lower:]][[:word:]]*|~)[[:space:]]*(=)",
+      "match": "([[:lower:]_][[:word:]']*|~)[[:space:]]*(=)",
       "captures": {
         "1": { "name": "variable.parameter.value.menhir" },
         "2": { "name": "keyword.other.menhir" }
@@ -196,9 +197,23 @@
     },
 
     "operators": {
-      "comment": "rule modifier (?, +, *, |, or ;)",
-      "match": "[?+*|;]",
-      "name": "keyword.operator.menhir"
+      "patterns": [
+        {
+          "comment": "rule modifier (?, +, *)",
+          "match": "[?+*]",
+          "name": "keyword.operator.menhir"
+        },
+        {
+          "comment": "vertical bar",
+          "match": "\\|",
+          "name": "keyword.other.menhir"
+        },
+        {
+          "comment": "semicolon",
+          "match": ";",
+          "name": "keyword.other.menhir punctuation.separator.terminator punctuation.separator.semicolon"
+        }
+      ]
     }
   }
 }


### PR DESCRIPTION
@ALANVF pointed out some lingering issues with the syntax highlighting of Menhir's new syntax:

| Before | After |
| - | - |
| ![before](https://user-images.githubusercontent.com/25037249/100265621-6291db00-2f05-11eb-8f74-9066dc25a5f7.png) | ![after](https://user-images.githubusercontent.com/25037249/100265625-658ccb80-2f05-11eb-84e0-01f0784b2035.png) |

