### PR TITLE
Drastically improve Menhir syntax highlighting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 - Highlight `cram` stanza in dune-project files (#441)
 - Fix reason highlighting of let extensions (#447)
 - Improve highlighting of Menhir new syntax (#450)
+- Improve Menhir syntax highlighting (#455)
 
 ## 1.4.0
 

--- a/package.json
+++ b/package.json
@@ -489,9 +489,19 @@
         "path": "./syntaxes/ocamllex.json"
       },
       {
+        "scopeName": "source.action.menhir",
+        "path": "./syntaxes/menhir-action.json",
+        "injectTo": [
+          "source.ocaml"
+        ]
+      },
+      {
         "language": "ocaml.menhir",
         "scopeName": "source.ocaml.menhir",
-        "path": "./syntaxes/menhir.json"
+        "path": "./syntaxes/menhir.json",
+        "embeddedLanguages": {
+          "source.embedded-action.menhir": "source.action.menhir"
+        }
       },
       {
         "language": "ocaml.opam",

--- a/syntaxes/menhir-action.json
+++ b/syntaxes/menhir-action.json
@@ -1,0 +1,29 @@
+{
+  "scopeName": "source.action.menhir",
+  "injectionSelector": "L:source.embedded-action.menhir",
+  "patterns": [
+    {
+      "begin": "(\\$(?:startpos|endpos|startofs|endofs|loc))[[:space:]]*\\(",
+      "beginCaptures": {
+        "1": { "name": "keyword.other.menhir" }
+      },
+      "end": "\\)",
+      "patterns": [
+        { "include": "#~anon-capture" },
+        { "include": "#token-name" },
+        { "include": "#production-name" }
+      ]
+    },
+    {
+      "match": "\\$(?:startpos|endpos|symbolstartpos|startofs|endofs|symbolstartofs|loc|sloc)\\b",
+      "name": "keyword.other.menhir"
+    },
+    { "include": "#~anon-capture" }
+  ],
+  "repository": {
+    "~anon-capture": {
+      "match": "\\$[[:digit:]]+\\b",
+      "name": "keyword.other.menhir"
+    }
+  }
+}

--- a/syntaxes/menhir-action.json
+++ b/syntaxes/menhir-action.json
@@ -9,7 +9,7 @@
       },
       "end": "\\)",
       "patterns": [
-        { "include": "#~anon-capture" },
+        { "include": "#anon-capture" },
         { "include": "#token-name" },
         { "include": "#production-name" }
       ]
@@ -18,10 +18,10 @@
       "match": "\\$(?:startpos|endpos|symbolstartpos|startofs|endofs|symbolstartofs|loc|sloc)\\b",
       "name": "keyword.other.menhir"
     },
-    { "include": "#~anon-capture" }
+    { "include": "#anon-capture" }
   ],
   "repository": {
-    "~anon-capture": {
+    "anon-capture": {
       "match": "\\$[[:digit:]]+\\b",
       "name": "keyword.other.menhir"
     }

--- a/syntaxes/menhir-action.json
+++ b/syntaxes/menhir-action.json
@@ -10,8 +10,8 @@
       "end": "\\)",
       "patterns": [
         { "include": "#anon-capture" },
-        { "include": "#token-name" },
-        { "include": "#production-name" }
+        { "include": "source.ocaml.menhir#token-name" },
+        { "include": "source.ocaml.menhir#production-name" }
       ]
     },
     {

--- a/syntaxes/menhir.json
+++ b/syntaxes/menhir.json
@@ -58,6 +58,7 @@
             { "include": "#type-annotation" },
             { "include": "#token-name" },
             { "include": "source.ocaml#strings" },
+            { "include": "source.ocaml#attributes" },
             { "include": "#comments" }
           ]
         },
@@ -90,7 +91,7 @@
         },
         {
           "comment": "attribute declaration",
-          "begin": "%(?:attribute\\b)?",
+          "begin": "%(?:attribute\\b|(?=\\[))",
           "beginCaptures": [{ "name": "keyword.other.menhir" }],
           "end": "(?=%)",
           "patterns": [

--- a/syntaxes/menhir.json
+++ b/syntaxes/menhir.json
@@ -123,6 +123,11 @@
           "comment": "declaration for public or inline rule",
           "name": "keyword.other.directive.menhir",
           "match": "%(?:public|inline)\\b"
+        },
+        {
+          "comment": "reserved keywords/operators for new syntax",
+          "name": "keyword.other.menhir",
+          "match": "\\blet\\b|:=|=="
         }
       ]
     },

--- a/syntaxes/menhir.json
+++ b/syntaxes/menhir.json
@@ -21,6 +21,24 @@
     { "include": "source.ocaml" }
   ],
   "repository": {
+    "comments": {
+      "patterns": [
+        { "include": "source.ocaml#comments" },
+        {
+          "comment": "c-style block comment",
+          "name": "comment.block.menhir",
+          "begin": "/\\*",
+          "end": "\\*/"
+        },
+        {
+          "comment": "c-style line comment",
+          "name": "comment.line.menhir",
+          "begin": "//",
+          "end": "$"
+        }
+      ]
+    },
+
     "declarations": {
       "patterns": [
         {
@@ -96,33 +114,98 @@
         }
       }
     },
-    "prec": {
-      "match": "%prec\\b",
-      "name": "keyword.other.menhir"
-    },
+
     "rules": {
       "patterns": [
+        { "include": "#old-rules" },
+        { "include": "#new-rules" },
         {
-          "comment": "new rule syntax with optional parameter list",
-          "begin": "(let)[[:space:]]+([[:lower:]_][[:word:]]*)[[:space:]]*(?:\\(([^)]+)\\)[[:space:]]*)?(:=|==)",
-          "end": "(?=let\\b|[[:lower:]_][[:word:]]*[[:space:]]*(?:\\([^)]+\\)[[:space:]]*)?:|%(?!prec\\b))",
-          "beginCaptures": {
-            "1": { "name": "keyword.other.menhir" },
-            "2": {
-              "comment": "rule name",
-              "name": "entity.name.function.rule.menhir"
-            },
-            "3": {
-              "patterns": [
-                {
-                  "comment": "rule parameter",
-                  "name": "variable.parameter.rule.menhir",
-                  "match": "[[:alpha:]_][[:word:]]*"
-                }
-              ]
-            },
-            "4": { "name": "keyword.other.menhir" }
-          },
+          "comment": "declaration for public or inline rule",
+          "name": "keyword.other.directive.menhir",
+          "match": "%(?:public|inline)\\b"
+        }
+      ]
+    },
+    "old-rules": {
+      "comment": "rule name with optional parameter list",
+      "begin": "([[:lower:]_][[:word:]]*)[[:space:]]*(?:\\(([^)]+)\\))?(?=[[:space:]]*:)",
+      "beginCaptures": {
+        "1": {
+          "comment": "rule name",
+          "name": "entity.name.function.rule.menhir"
+        },
+        "2": {
+          "patterns": [
+            {
+              "comment": "rule parameter",
+              "name": "variable.parameter.rule.menhir",
+              "match": "[[:alpha:]_][[:word:]]*"
+            }
+          ]
+        }
+      },
+      "end": "(?=let\\b|[[:lower:]_][[:word:]]*[[:space:]]*(?:\\([^)]+\\)[[:space:]]*)?:|%(?!prec\\b))",
+      "patterns": [
+        { "include": "#comments" },
+        { "include": "#old-variables" },
+        { "include": "#references" },
+        { "include": "#prec" },
+        { "include": "#operators" },
+        { "include": "source.ocaml#strings" },
+        { "include": "source.ocaml#attributes" },
+        { "include": "#old-actions" },
+        {
+          "comment": "production",
+          "begin": "[:|]",
+          "beginCaptures": [{ "name": "keyword.other.menhir" }],
+          "end": "(?=[{<|]|let\\b|[[:lower:]_][[:word:]]*[[:space:]]*(?:\\([^)]+\\)[[:space:]]*)?:|%(?!prec\\b))",
+          "patterns": [
+            { "include": "#comments" },
+            { "include": "#old-variables" },
+            { "include": "#references" },
+            { "include": "#prec" },
+            { "include": "#operators" },
+            { "include": "source.ocaml#strings" },
+            { "include": "source.ocaml#attributes" }
+          ]
+        }
+      ]
+    },
+    "new-rules": {
+      "comment": "new rule syntax with optional parameter list",
+      "begin": "(let)[[:space:]]+([[:lower:]_][[:word:]]*)[[:space:]]*(?:\\(([^)]+)\\)[[:space:]]*)?(:=|==)",
+      "end": "(?=let\\b|[[:lower:]_][[:word:]]*[[:space:]]*(?:\\([^)]+\\)[[:space:]]*)?:|%(?!prec\\b))",
+      "beginCaptures": {
+        "1": { "name": "keyword.other.menhir" },
+        "2": {
+          "comment": "rule name",
+          "name": "entity.name.function.rule.menhir"
+        },
+        "3": {
+          "patterns": [
+            {
+              "comment": "rule parameter",
+              "name": "variable.parameter.rule.menhir",
+              "match": "[[:alpha:]_][[:word:]]*"
+            }
+          ]
+        },
+        "4": { "name": "keyword.other.menhir" }
+      },
+      "patterns": [
+        { "include": "#comments" },
+        { "include": "#new-variables" },
+        { "include": "#references" },
+        { "include": "#prec" },
+        { "include": "#operators" },
+        { "include": "source.ocaml#strings" },
+        { "include": "source.ocaml#attributes" },
+        { "include": "#new-actions" },
+        {
+          "comment": "production",
+          "begin": "[:|]",
+          "beginCaptures": [{ "name": "keyword.other.menhir" }],
+          "end": "(?=[{<|]|let\\b|[[:lower:]_][[:word:]]*[[:space:]]*(?:\\([^)]+\\)[[:space:]]*)?:|%(?!prec\\b))",
           "patterns": [
             { "include": "#comments" },
             { "include": "#new-variables" },
@@ -130,78 +213,18 @@
             { "include": "#prec" },
             { "include": "#operators" },
             { "include": "source.ocaml#strings" },
-            { "include": "source.ocaml#attributes" },
-            { "include": "#new-actions" },
-            {
-              "comment": "production",
-              "begin": "[:|]",
-              "beginCaptures": [{ "name": "keyword.other.menhir" }],
-              "end": "(?=[{<|]|let\\b|[[:lower:]_][[:word:]]*[[:space:]]*(?:\\([^)]+\\)[[:space:]]*)?:|%(?!prec\\b))",
-              "patterns": [
-                { "include": "#comments" },
-                { "include": "#new-variables" },
-                { "include": "#references" },
-                { "include": "#prec" },
-                { "include": "#operators" },
-                { "include": "source.ocaml#strings" },
-                { "include": "source.ocaml#attributes" }
-              ]
-            }
+            { "include": "source.ocaml#attributes" }
           ]
-        },
-        {
-          "comment": "rule name with optional parameter list",
-          "begin": "([[:lower:]_][[:word:]]*)[[:space:]]*(?:\\(([^)]+)\\))?(?=[[:space:]]*:)",
-          "beginCaptures": {
-            "1": {
-              "comment": "rule name",
-              "name": "entity.name.function.rule.menhir"
-            },
-            "2": {
-              "patterns": [
-                {
-                  "comment": "rule parameter",
-                  "name": "variable.parameter.rule.menhir",
-                  "match": "[[:alpha:]_][[:word:]]*"
-                }
-              ]
-            }
-          },
-          "end": "(?=let\\b|[[:lower:]_][[:word:]]*[[:space:]]*(?:\\([^)]+\\)[[:space:]]*)?:|%(?!prec\\b))",
-          "patterns": [
-            { "include": "#comments" },
-            { "include": "#variables" },
-            { "include": "#references" },
-            { "include": "#prec" },
-            { "include": "#operators" },
-            { "include": "source.ocaml#strings" },
-            { "include": "source.ocaml#attributes" },
-            { "include": "#actions" },
-            {
-              "comment": "production",
-              "begin": "[:|]",
-              "beginCaptures": [{ "name": "keyword.other.menhir" }],
-              "end": "(?=[{<|]|let\\b|[[:lower:]_][[:word:]]*[[:space:]]*(?:\\([^)]+\\)[[:space:]]*)?:|%(?!prec\\b))",
-              "patterns": [
-                { "include": "#comments" },
-                { "include": "#variables" },
-                { "include": "#references" },
-                { "include": "#prec" },
-                { "include": "#operators" },
-                { "include": "source.ocaml#strings" },
-                { "include": "source.ocaml#attributes" }
-              ]
-            }
-          ]
-        },
-        {
-          "comment": "declaration for public or inline rule; precedence annotation",
-          "name": "keyword.other.directive.menhir",
-          "match": "%(?:public|inline|prec)\\b"
         }
       ]
     },
-    "actions": {
+
+    "prec": {
+      "match": "%prec\\b",
+      "name": "keyword.other.menhir"
+    },
+
+    "old-actions": {
       "comment": "ocaml semantic action",
       "contentName": "source.embedded-action.menhir",
       "begin": "{",
@@ -212,7 +235,7 @@
     },
     "new-actions": {
       "patterns": [
-        { "include": "#actions" },
+        { "include": "#old-actions" },
         {
           "comment": "point-free ocaml semantic action",
           "begin": "<",
@@ -223,24 +246,8 @@
         }
       ]
     },
-    "comments": {
-      "patterns": [
-        { "include": "source.ocaml#comments" },
-        {
-          "comment": "c-style block comment",
-          "name": "comment.block.menhir",
-          "begin": "/\\*",
-          "end": "\\*/"
-        },
-        {
-          "comment": "c-style line comment",
-          "name": "comment.line.menhir",
-          "begin": "//",
-          "end": "$"
-        }
-      ]
-    },
-    "variables": {
+
+    "old-variables": {
       "comment": "labeled semantic value identifier",
       "match": "([[:lower:]_][[:word:]]*)[[:space:]]*(=)",
       "captures": {
@@ -251,7 +258,7 @@
     },
     "new-variables": {
       "patterns": [
-        { "include": "#variables" },
+        { "include": "#old-variables" },
         {
           "comment": "punned semantic value capture",
           "match": "(~)[[:space:]]*(=)",
@@ -286,6 +293,7 @@
         }
       }
     },
+
     "token-name": {
       "comment": "reference to a token",
       "name": "constant.other.token.menhir",
@@ -307,6 +315,7 @@
         { "include": "#production-name" }
       ]
     },
+
     "operators": {
       "patterns": [
         {

--- a/syntaxes/menhir.json
+++ b/syntaxes/menhir.json
@@ -8,10 +8,7 @@
       "comment": "sequence of declarations",
       "begin": "(?=%[^%])",
       "end": "(?=%%)",
-      "patterns": [
-        { "include": "#comments" },
-        { "include": "#declarations" }
-      ]
+      "patterns": [{ "include": "#comments" }, { "include": "#declarations" }]
     },
     {
       "comment": "sequence of rules",
@@ -19,10 +16,7 @@
       "beginCaptures": [{ "name": "keyword.other.menhir" }],
       "end": "%%",
       "endCaptures": [{ "name": "keyword.other.menhir" }],
-      "patterns": [
-        { "include": "#comments" },
-        { "include": "#rules" }
-      ]
+      "patterns": [{ "include": "#comments" }, { "include": "#rules" }]
     },
     { "include": "source.ocaml" }
   ],

--- a/syntaxes/menhir.json
+++ b/syntaxes/menhir.json
@@ -43,7 +43,7 @@
           "beginCaptures": [{ "name": "keyword.other.menhir" }],
           "end": "(?=%)",
           "patterns": [
-            { "include": "#~type-annotation" },
+            { "include": "#type-annotation" },
             { "include": "#token-name" },
             { "include": "source.ocaml#strings" },
             { "include": "#comments" }
@@ -66,7 +66,7 @@
           "beginCaptures": [{ "name": "keyword.other.menhir" }],
           "end": "(?=%)",
           "patterns": [
-            { "include": "#~type-annotation" },
+            { "include": "#type-annotation" },
             { "include": "#production-name" },
             { "include": "#comments" }
           ]
@@ -76,11 +76,11 @@
           "name": "keyword.other.menhir",
           "match": "%(?:parameter|attribute)\\b"
         },
-        { "include": "#~type-annotation" },
+        { "include": "#type-annotation" },
         { "include": "source.ocaml#strings" }
       ],
       "repository": {
-        "~type-annotation": {
+        "type-annotation": {
           "comment": "ocaml type annotation for token",
           "begin": "<",
           "end": ">",
@@ -257,11 +257,11 @@
           "endCaptures": {
             "1": { "name": "keyword.other.menhir" }
           },
-          "patterns": [{ "include": "#~pattern" }]
+          "patterns": [{ "include": "#pattern" }]
         }
       ],
       "repository": {
-        "~pattern": {
+        "pattern": {
           "patterns": [
             {
               "match": "[[:lower:]_][[:word:]]*|~",
@@ -270,7 +270,7 @@
             {
               "begin": "\\(",
               "end": "\\)",
-              "patterns": [{ "include": "#~pattern" }]
+              "patterns": [{ "include": "#pattern" }]
             }
           ]
         }

--- a/syntaxes/menhir.json
+++ b/syntaxes/menhir.json
@@ -8,7 +8,10 @@
       "comment": "sequence of declarations",
       "begin": "(?=%[^%])",
       "end": "(?=%%)",
-      "patterns": [{ "include": "#comments" }, { "include": "#declarations" }]
+      "patterns": [
+        { "include": "#comments" },
+        { "include": "#declarations" }
+      ]
     },
     {
       "comment": "sequence of rules",
@@ -16,7 +19,10 @@
       "beginCaptures": [{ "name": "keyword.other.menhir" }],
       "end": "%%",
       "endCaptures": [{ "name": "keyword.other.menhir" }],
-      "patterns": [{ "include": "#comments" }, { "include": "#rules" }]
+      "patterns": [
+        { "include": "#comments" },
+        { "include": "#rules" }
+      ]
     },
     { "include": "source.ocaml" }
   ],
@@ -32,32 +38,70 @@
           "patterns": [{ "include": "source.ocaml" }]
         },
         {
-          "comment": "builtin declaration",
-          "name": "keyword.other.menhir",
-          "match": "(%parameter|%token|%nonassoc|%left|%right|%type|%start|%attribute|%on_error_reduce)\\b"
+          "comment": "token declaration",
+          "begin": "%token\\b",
+          "beginCaptures": [{ "name": "keyword.other.menhir" }],
+          "end": "(?=%)",
+          "patterns": [
+            { "include": "#~type-annotation" },
+            { "include": "#token-name" },
+            { "include": "source.ocaml#strings" },
+            { "include": "#comments" }
+          ]
         },
         {
+          "comment": "associativity declaration",
+          "begin": "%(?:nonassoc|left|right)\\b",
+          "beginCaptures": [{ "name": "keyword.other.menhir" }],
+          "end": "(?=%)",
+          "patterns": [
+            { "include": "#token-name" },
+            { "include": "#production-name" },
+            { "include": "#comments" }
+          ]
+        },
+        {
+          "comment": "type/start/on_error_reduce declaration",
+          "begin": "%(?:type|start|on_error_reduce)\\b",
+          "beginCaptures": [{ "name": "keyword.other.menhir" }],
+          "end": "(?=%)",
+          "patterns": [
+            { "include": "#~type-annotation" },
+            { "include": "#production-name" },
+            { "include": "#comments" }
+          ]
+        },
+        {
+          "comment": "builtin declaration",
+          "name": "keyword.other.menhir",
+          "match": "%(?:parameter|attribute)\\b"
+        },
+        { "include": "#~type-annotation" },
+        { "include": "source.ocaml#strings" }
+      ],
+      "repository": {
+        "~type-annotation": {
           "comment": "ocaml type annotation for token",
           "begin": "<",
           "end": ">",
           "beginCaptures": [{ "name": "keyword.other.menhir" }],
           "endCaptures": [{ "name": "keyword.other.menhir" }],
           "patterns": [{ "include": "source.ocaml" }]
-        },
-        { "include": "source.ocaml#strings" }
-      ]
+        }
+      }
     },
-
+    "prec": {
+      "match": "%prec\\b",
+      "name": "keyword.other.menhir"
+    },
     "rules": {
       "patterns": [
         {
           "comment": "new rule syntax with optional parameter list",
-          "begin": "(let)[[:space:]]*([[:lower:]][[:word:]]*)[[:space:]]*(?:\\(([^)]+)\\))?[[:space:]]*(:=|==)",
-          "end": "$",
+          "begin": "(let)[[:space:]]+([[:lower:]_][[:word:]]*)[[:space:]]*(?:\\(([^)]+)\\)[[:space:]]*)?(:=|==)",
+          "end": "(?=let\\b|[[:lower:]_][[:word:]]*[[:space:]]*(?:\\([^)]+\\)[[:space:]]*)?:|%(?!prec\\b))",
           "beginCaptures": {
-            "1": {
-              "name": "keyword.other.menhir"
-            },
+            "1": { "name": "keyword.other.menhir" },
             "2": {
               "comment": "rule name",
               "name": "entity.name.function.rule.menhir"
@@ -67,28 +111,40 @@
                 {
                   "comment": "rule parameter",
                   "name": "variable.parameter.rule.menhir",
-                  "match": "[[:alpha:]][[:word:]]*"
+                  "match": "[[:alpha:]_][[:word:]]*"
                 }
               ]
             },
-            "4": {
-              "name": "keyword.other.menhir"
-            }
+            "4": { "name": "keyword.other.menhir" }
           },
           "patterns": [
             { "include": "#comments" },
-            { "include": "#variables" },
+            { "include": "#new-variables" },
             { "include": "#references" },
+            { "include": "#prec" },
             { "include": "#operators" },
             { "include": "source.ocaml#strings" },
-            { "include": "#actions" }
+            { "include": "#new-actions" },
+            {
+              "comment": "production",
+              "begin": "[:|]",
+              "beginCaptures": [{ "name": "keyword.other.menhir" }],
+              "end": "(?=[{<|]|let\\b|[[:lower:]_][[:word:]]*[[:space:]]*(?:\\([^)]+\\)[[:space:]]*)?:|%(?!prec\\b))",
+              "patterns": [
+                { "include": "#comments" },
+                { "include": "#new-variables" },
+                { "include": "#references" },
+                { "include": "#prec" },
+                { "include": "#operators" },
+                { "include": "source.ocaml#strings" }
+              ]
+            }
           ]
         },
-
         {
           "comment": "rule name with optional parameter list",
-          "match": "([[:lower:]][[:word:]]*)[[:space:]]*(?:\\(([^)]+)\\))?(?=[[:space:]]*:)",
-          "captures": {
+          "begin": "([[:lower:]_][[:word:]]*)[[:space:]]*(?:\\(([^)]+)\\))?(?=[[:space:]]*:)",
+          "beginCaptures": {
             "1": {
               "comment": "rule name",
               "name": "entity.name.function.rule.menhir"
@@ -98,45 +154,55 @@
                 {
                   "comment": "rule parameter",
                   "name": "variable.parameter.rule.menhir",
-                  "match": "[[:alpha:]][[:word:]]*"
+                  "match": "[[:alpha:]_][[:word:]]*"
                 }
               ]
             }
-          }
-        },
-        {
-          "comment": "declaration for public or inline rule; precedence annotation",
-          "name": "keyword.other.directive.menhir",
-          "match": "%public|%inline|%prec"
-        },
-        {
-          "comment": "production",
-          "begin": ":|\\|",
-          "beginCaptures": [{ "name": "keyword.other.menhir" }],
-          "end": "$",
+          },
+          "end": "(?=let\\b|[[:lower:]_][[:word:]]*[[:space:]]*(?:\\([^)]+\\)[[:space:]]*)?:|%(?!prec\\b))",
           "patterns": [
             { "include": "#comments" },
             { "include": "#variables" },
             { "include": "#references" },
+            { "include": "#prec" },
             { "include": "#operators" },
             { "include": "source.ocaml#strings" },
-            { "include": "#actions" }
+            { "include": "#actions" },
+            {
+              "comment": "production",
+              "begin": "[:|]",
+              "beginCaptures": [{ "name": "keyword.other.menhir" }],
+              "end": "(?=[{<|]|let\\b|[[:lower:]_][[:word:]]*[[:space:]]*(?:\\([^)]+\\)[[:space:]]*)?:|%(?!prec\\b))",
+              "patterns": [
+                { "include": "#comments" },
+                { "include": "#variables" },
+                { "include": "#references" },
+                { "include": "#prec" },
+                { "include": "#operators" },
+                { "include": "source.ocaml#strings" }
+              ]
+            }
           ]
         },
-        { "include": "#actions" }
+        {
+          "comment": "declaration for public or inline rule; precedence annotation",
+          "name": "keyword.other.directive.menhir",
+          "match": "%(?:public|inline|prec)\\b"
+        }
       ]
     },
-
     "actions": {
+      "comment": "ocaml semantic action",
+      "contentName": "source.embedded-action.menhir",
+      "begin": "{",
+      "beginCaptures": [{ "name": "keyword.other.menhir" }],
+      "end": "}",
+      "endCaptures": [{ "name": "keyword.other.menhir" }],
+      "patterns": [{ "include": "source.ocaml" }]
+    },
+    "new-actions": {
       "patterns": [
-        {
-          "comment": "ocaml semantic action",
-          "begin": "{",
-          "beginCaptures": [{ "name": "keyword.other.menhir" }],
-          "end": "}",
-          "endCaptures": [{ "name": "keyword.other.menhir" }],
-          "patterns": [{ "include": "source.ocaml" }]
-        },
+        { "include": "#actions" },
         {
           "comment": "point-free ocaml semantic action",
           "begin": "<",
@@ -147,7 +213,6 @@
         }
       ]
     },
-
     "comments": {
       "patterns": [
         { "include": "source.ocaml#comments" },
@@ -165,17 +230,62 @@
         }
       ]
     },
-
     "variables": {
       "comment": "labeled semantic value identifier",
-      "match": "([[:lower:]_][[:word:]']*|~)[[:space:]]*(=)",
+      "match": "([[:lower:]_][[:word:]]*)[[:space:]]*(=)",
       "captures": {
         "1": { "name": "variable.parameter.value.menhir" },
         "2": { "name": "keyword.other.menhir" }
       },
       "patterns": [{ "include": "#references" }]
     },
-
+    "new-variables": {
+      "patterns": [
+        { "include": "#variables" },
+        {
+          "comment": "punned semantic value capture",
+          "match": "(~)[[:space:]]*(=)",
+          "captures": {
+            "1": { "name": "variable.parameter.value.menhir" },
+            "2": { "name": "keyword.other.menhir" }
+          }
+        },
+        {
+          "comment": "destructured semantic value capture",
+          "begin": "(?<![[:word:]][[:space:]]*)\\(",
+          "end": "\\)[[:space:]]*(=)",
+          "endCaptures": {
+            "1": { "name": "keyword.other.menhir" }
+          },
+          "patterns": [{ "include": "#~pattern" }]
+        }
+      ],
+      "repository": {
+        "~pattern": {
+          "patterns": [
+            {
+              "match": "[[:lower:]_][[:word:]]*|~",
+              "name": "variable.parameter.value.menhir"
+            },
+            {
+              "begin": "\\(",
+              "end": "\\)",
+              "patterns": [{ "include": "#~pattern" }]
+            }
+          ]
+        }
+      }
+    },
+    "token-name": {
+      "comment": "reference to a token",
+      "name": "constant.other.token.menhir",
+      "match": "[[:upper:]][[:word:]]*"
+    },
+    "production-name": {
+      "comment": "reference to a production",
+      "name": "entity.name.function.rule.menhir",
+      "match": "[[:lower:]_][[:word:]]*"
+    },
     "references": {
       "patterns": [
         {
@@ -183,19 +293,10 @@
           "name": "support.function.rule.menhir",
           "match": "\\b(endrule|midrule|option|ioption|boption|loption|pair|separated_pair|preceded|terminated|delimited|list|nonempty_list|separated_list|separated_nonempty_list|rev|flatten|append)\\b"
         },
-        {
-          "comment": "reference to a token",
-          "name": "entity.name.token.menhir",
-          "match": "[[:upper:]][[:word:]]*"
-        },
-        {
-          "comment": "reference to a production",
-          "name": "entity.name.function.rule.menhir",
-          "match": "[[:lower:]][[:word:]]*"
-        }
+        { "include": "#token-name" },
+        { "include": "#production-name" }
       ]
     },
-
     "operators": {
       "patterns": [
         {

--- a/syntaxes/menhir.json
+++ b/syntaxes/menhir.json
@@ -66,9 +66,21 @@
           ]
         },
         {
-          "comment": "builtin declaration",
+          "comment": "parameter declaration",
           "name": "keyword.other.menhir",
-          "match": "%(?:parameter|attribute)\\b"
+          "match": "%parameter\\b"
+        },
+        {
+          "comment": "attribute declaration",
+          "begin": "%(?:attribute\\b)?",
+          "beginCaptures": [{ "name": "keyword.other.menhir" }],
+          "end": "(?=%)",
+          "patterns": [
+            { "include": "source.ocaml#attributes" },
+            { "include": "#token-name" },
+            { "include": "#production-name" },
+            { "include": "#comments" }
+          ]
         },
         { "include": "#type-annotation" },
         { "include": "source.ocaml#strings" }

--- a/syntaxes/menhir.json
+++ b/syntaxes/menhir.json
@@ -130,6 +130,7 @@
             { "include": "#prec" },
             { "include": "#operators" },
             { "include": "source.ocaml#strings" },
+            { "include": "source.ocaml#attributes" },
             { "include": "#new-actions" },
             {
               "comment": "production",
@@ -142,7 +143,8 @@
                 { "include": "#references" },
                 { "include": "#prec" },
                 { "include": "#operators" },
-                { "include": "source.ocaml#strings" }
+                { "include": "source.ocaml#strings" },
+                { "include": "source.ocaml#attributes" }
               ]
             }
           ]
@@ -173,6 +175,7 @@
             { "include": "#prec" },
             { "include": "#operators" },
             { "include": "source.ocaml#strings" },
+            { "include": "source.ocaml#attributes" },
             { "include": "#actions" },
             {
               "comment": "production",
@@ -185,7 +188,8 @@
                 { "include": "#references" },
                 { "include": "#prec" },
                 { "include": "#operators" },
-                { "include": "source.ocaml#strings" }
+                { "include": "source.ocaml#strings" },
+                { "include": "source.ocaml#attributes" }
               ]
             }
           ]

--- a/syntaxes/ocaml.json
+++ b/syntaxes/ocaml.json
@@ -577,6 +577,12 @@
           "begin": "\\[",
           "end": "]",
           "patterns": [{ "include": "$self" }]
+        },
+        {
+          "comment": "braces",
+          "begin": "\\{",
+          "end": "\\}",
+          "patterns": [{ "include": "$self" }]
         }
       ]
     },


### PR DESCRIPTION
Menhir's syntax highlighting was bad so I decided to fix it.

Possible future improvements:
1) Fix highlighting for attributes (not possible without `#2` below).
2) Generate grammars using OCaml because JSON is terrible.

A lengthy example:
![image](https://user-images.githubusercontent.com/16247881/100388483-bb8e6b80-2ff8-11eb-867f-6823763e694a.png)

Another example (new merlin syntax):
![image](https://user-images.githubusercontent.com/16247881/100388622-19bb4e80-2ff9-11eb-9de3-5794dbb645f9.png)
