### PR TITLE
Improve syntax highlighting of type parameters and module type of

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Change Log
 
+## Unreleased
+
+- Improve highlighting of type parameters and `module type of` (#461)
+
 ## 1.5.0
 
 - Highlight `rec` keyword in OCaml mli files for recursive modules (#434)

--- a/syntaxes/ocaml.interface.json
+++ b/syntaxes/ocaml.interface.json
@@ -28,15 +28,6 @@
           "match": "~([[:lower:]_][[:word:]']*)?"
         },
         {
-          "comment": "module type of",
-          "match": "\\b(module)[[:space:]]+(type)[[:space:]]+(of)\\b",
-          "captures": {
-            "1": { "name": "keyword.ocaml" },
-            "2": { "name": "keyword.ocaml" },
-            "3": { "name": "keyword.ocaml" }
-          }
-        },
-        {
           "comment": "type declaration",
           "match": "\\b(type)[[:space:]]+(nonrec[[:space:]]+)?(_[[:space:]]+|[+-]?'[[:alpha:]][[:word:]']*[[:space:]]+|\\(.*\\)[[:space:]]+)?([[:lower:]_][[:word:]']*)",
           "captures": {
@@ -142,6 +133,17 @@
             "1": { "name": "keyword.ocaml" },
             "2": { "name": "entity.name.function.binding.ocaml" }
           }
+        },
+        {
+          "comment": "module type of",
+          "begin": "\\b(module)[[:space:]]+(type)[[:space:]]+(of)\\b",
+          "beginCaptures": {
+            "1": { "name": "keyword.ocaml" },
+            "2": { "name": "keyword.ocaml" },
+            "3": { "name": "keyword.ocaml" }
+          },
+          "end": "(?=val|external|type|exception|class|module|open|include|=)",
+          "patterns": [{ "include": "source.ocaml" }]
         }
       ]
     },

--- a/syntaxes/ocaml.json
+++ b/syntaxes/ocaml.json
@@ -9,7 +9,7 @@
     { "include": "#characters" },
     { "include": "#attributes" },
     { "include": "#extensions" },
-    { "include": "#signatures" },
+    { "include": "#modules" },
     { "include": "#bindings" },
     { "include": "#operators" },
     { "include": "#keywords" },
@@ -319,12 +319,23 @@
       "patterns": [{ "include": "$self" }]
     },
 
-    "signatures": {
-      "begin": "\\b(sig)\\b",
-      "end": "\\b(end)\\b",
-      "beginCaptures": [{ "name": "keyword.other.ocaml" }],
-      "endCaptures": [{ "name": "keyword.other.ocaml" }],
-      "patterns": [{ "include": "source.ocaml.interface" }]
+    "modules": {
+      "patterns": [
+        {
+          "begin": "\\b(sig)\\b",
+          "end": "\\b(end)\\b",
+          "beginCaptures": [{ "name": "keyword.other.ocaml" }],
+          "endCaptures": [{ "name": "keyword.other.ocaml" }],
+          "patterns": [{ "include": "source.ocaml.interface" }]
+        },
+        {
+          "begin": "\\b(struct)\\b",
+          "end": "\\b(end)\\b",
+          "beginCaptures": [{ "name": "keyword.other.ocaml" }],
+          "endCaptures": [{ "name": "keyword.other.ocaml" }],
+          "patterns": [{ "include": "$self" }]
+        }
+      ]
     },
 
     "bindings": {
@@ -489,12 +500,6 @@
     "literals": {
       "patterns": [
         {
-          "comment": "wildcard underscore",
-          "name": "constant.language.ocaml",
-          "match": "\\b_\\b"
-        },
-
-        {
           "comment": "boolean literal",
           "name": "constant.language.boolean.ocaml",
           "match": "\\b(true|false)\\b"
@@ -592,7 +597,12 @@
         {
           "comment": "type parameter",
           "name": "storage.type.ocaml",
-          "match": "'[[:alpha:]][[:word:]']*\\b"
+          "match": "'[[:alpha:]][[:word:]']*\\b|'_\\b"
+        },
+        {
+          "comment": "weak type parameter",
+          "name": "storage.type.weak.ocaml",
+          "match": "'_[[:alpha:]][[:word:]']*\\b"
         },
         {
           "comment": "builtin type",
@@ -604,6 +614,11 @@
 
     "identifiers": {
       "patterns": [
+        {
+          "comment": "wildcard underscore",
+          "name": "constant.language.ocaml",
+          "match": "\\b_\\b"
+        },
         {
           "comment": "capital identifier for constructor, exception, or module",
           "name": "constant.language.capital-identifier.ocaml",


### PR DESCRIPTION
Weak type parameters (`'_weak1`) don't appear in source code, but they do appear in hover type information, so they should be highlighted:

![image](https://user-images.githubusercontent.com/25037249/100773578-ec362280-33b5-11eb-83d7-e74158e9b3ca.png)




`module type of`:
| Before | After |
| - | - |
| ![image](https://user-images.githubusercontent.com/25037249/100773282-834eaa80-33b5-11eb-9618-89d59414d75d.png) | ![image](https://user-images.githubusercontent.com/25037249/100773314-8cd81280-33b5-11eb-9342-d06c544a088d.png) |

