### PR TITLE
Highlight format indication characters in OCaml strings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Change Log
 
+# Unreleased
+
+- Highlight `@` format indication characters in OCaml strings (#462)
+
 ## 1.5.0
 
 - Highlight `rec` keyword in OCaml mli files for recursive modules (#434)

--- a/syntaxes/ocaml.json
+++ b/syntaxes/ocaml.json
@@ -221,9 +221,21 @@
               "match": "\\\\u\\{[[:xdigit:]]{1,6}\\}"
             },
             {
-              "comment": "printf format string",
+              "comment": "printf string",
               "name": "constant.character.printf.ocaml",
               "match": "%[-0+ #]*([[:digit:]]+|\\*)?(.([[:digit:]]+|\\*))?[lLn]?[diunlLNxXosScCfFeEgGhHBbat!%@,]"
+            },
+            {
+              "comment": "format string",
+              "name": "keyword.other.format.ocaml",
+              "begin": "@[\\[;{]?<",
+              "end": ">",
+              "patterns": [{ "include": "$self" }]
+            },
+            {
+              "comment": "format string",
+              "name": "keyword.other.format.ocaml",
+              "match": "@([\\[\\], ;.{}?]|\\\\n)"
             },
             {
               "comment": "unknown escape sequence",


### PR DESCRIPTION
Highlights indication characters that begin with `@` (https://ocaml.org/releases/4.11/htmlman/libref/Format.html#fpp).

Example: 

![image](https://user-images.githubusercontent.com/25037249/100776640-a1b6a500-33b9-11eb-95d2-3819baccd414.png)
