### PR TITLE
Automatic installation of missing binaries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,11 @@
   is located in the same folder as the open file or creates the dune file in a
   draft mode (not yet saved on the disk). (#499)
 
+- Install OCaml Platform tools automatically (#463)
+
+  The platform tools (a.k.a toolchain) are installed in a private opam switch
+  that should only be used by `vscode-ocaml-platform`.
+
 ## 1.5.1
 
 - Improve highlighting of type parameters and `module type of` (#461)

--- a/README.md
+++ b/README.md
@@ -8,15 +8,13 @@ _Please report any bugs you encounter._
 
 ## Quick start
 
-1. Install this extension from
+1. [Install Opam](https://opam.ocaml.org/doc/Install.html)
+2. Install this extension from
    [the VSCode Marketplace](https://marketplace.visualstudio.com/items?itemName=ocamllabs.ocaml-platform)
    (or by entering `ext install ocamllabs.ocaml-platform` at the command palette
    <kbd>Ctrl</kbd>+<kbd>Shift</kbd>+<kbd>P</kbd>
    (<kbd>Cmd</kbd>+<kbd>Shift</kbd>+<kbd>P</kbd> on MacOS)
-2. Open a OCaml/ReasonML project (`File > Add Folder to Workspace...`)
-3. Install [OCaml-LSP](https://github.com/ocaml/ocaml-lsp) with
-   [opam](https://github.com/ocaml/opam) or [esy](https://github.com/esy/esy).
-   E.g. `opam install ocaml-lsp-server`
+3. Open a OCaml/ReasonML project (`File > Add Folder to Workspace...`)
 
 ### Windows
 
@@ -142,4 +140,4 @@ MacOS).
 
 ## Requirements
 
-- [ocaml/ocaml-lsp](https://github.com/ocaml/ocaml-lsp)
+- [opam](https://opam.ocaml.org/)

--- a/src/bindings/node/node.ml
+++ b/src/bindings/node/node.ml
@@ -40,6 +40,10 @@ module Process = struct
   end
 end
 
+module Os = struct
+  val homedir : unit -> string [@@js.global "os.homedir"]
+end
+
 module JsError = struct
   let message (error : Promise.error) =
     let js_error = [%js.of: Promise.error] error in

--- a/src/bindings/node/node.mli
+++ b/src/bindings/node/node.mli
@@ -74,6 +74,10 @@ module Path : sig
   val join : string list -> string
 end
 
+module Os : sig
+  val homedir : unit -> string
+end
+
 module Fs : sig
   val readDir : string -> (string list, string) result Promise.t
 

--- a/src/bindings/node/node_stub.js
+++ b/src/bindings/node/node_stub.js
@@ -10,3 +10,5 @@ joo_global_object.fs = {
 joo_global_object.child_process = require("child_process");
 
 joo_global_object.path = require("path");
+
+joo_global_object.os = require("os");

--- a/src/cmd.ml
+++ b/src/cmd.ml
@@ -98,10 +98,13 @@ let log ?(result : ChildProcess.return option) (t : t) =
       :: message
     | Shell command_line -> ("shell", string command_line) :: message
   in
-  log_json "external command" message
+  match result with
+  | None -> log_json "external command" message
+  | Some _ -> log_json "external command (finished)" message
 
 let output ?cwd ?env ?stdin (t : t) =
   let open Promise.Syntax in
+  log t;
   let+ (result : ChildProcess.return) = run ?stdin ?cwd ?env t in
   log ~result t;
   if result.exitCode = 0 then

--- a/src/dune_formatter.ml
+++ b/src/dune_formatter.ml
@@ -11,25 +11,26 @@ let get_formatter instance ~document ~options:_ ~token:_ =
   in
   (* text of entire document *)
   let document_text = TextDocument.getText document ~range () in
-  let command =
-    let sandbox = Extension_instance.sandbox instance in
-    Sandbox.get_dune_command sandbox [ "format-dune-file" ]
-  in
-  let output =
-    let open Promise.Result.Syntax in
-    let* command = Cmd.check command in
-    Cmd.output ~stdin:document_text command
-  in
-  let promise =
-    let open Promise.Syntax in
-    let+ output = output in
-    match output with
-    | Ok newText -> Some [ TextEdit.replace ~range ~newText ]
-    | Error msg ->
-      show_message `Error "Dune formatting failed: %s" msg;
-      Some []
-  in
-  `Promise promise
+  match Extension_instance.toolchain instance with
+  | None -> `Value None
+  | Some toolchain ->
+    let promise =
+      let open Promise.Syntax in
+      let* command =
+        Toolchain.get_dune_command toolchain ~args:[ "format-dune-file" ]
+      in
+      let+ output =
+        let open Promise.Result.Syntax in
+        let* command = Cmd.check command in
+        Cmd.output ~stdin:document_text command
+      in
+      match output with
+      | Ok newText -> Some [ TextEdit.replace ~range ~newText ]
+      | Error msg ->
+        show_message `Error "Dune formatting failed: %s" msg;
+        Some []
+    in
+    `Promise promise
 
 let register extension instance =
   [ "dune"; "dune-project"; "dune-workspace" ]

--- a/src/esy.ml
+++ b/src/esy.ml
@@ -113,6 +113,10 @@ let discover = Discover.run
 let exec t manifest ~args =
   Cmd.Spawn (Cmd.append t ("-P" :: Path.to_string manifest :: args))
 
+let install t manifest ~packages =
+  Cmd.Spawn
+    (Cmd.append t ("-P" :: Path.to_string manifest :: "add" :: packages))
+
 module State = struct
   type t =
     | Ready

--- a/src/esy.mli
+++ b/src/esy.mli
@@ -60,6 +60,9 @@ val packages : t -> Manifest.t -> (Package.t list, string) result Promise.t
     to packages that have been installed as a dependency of another package. *)
 val root_packages : t -> Manifest.t -> (Package.t list, string) result Promise.t
 
+(** Install a package in the Esy sandbox. *)
+val install : t -> Manifest.t -> packages:string list -> Cmd.t
+
 (** {4 General utilities} *)
 
 (** Execute an esy sub-command with in the given sandbox. *)

--- a/src/extension_commands.ml
+++ b/src/extension_commands.ml
@@ -46,7 +46,11 @@ let _select_sandbox =
       match sandbox with
       | None (* sandbox selection cancelled *) -> Promise.return ()
       | Some new_sandbox ->
+        let* toolchain = Toolchain.setup ~project_sandbox:new_sandbox () in
         Extension_instance.set_sandbox instance new_sandbox;
+        ( match toolchain with
+        | Error _ -> ()
+        | Ok t -> Extension_instance.set_toolchain instance t );
         let (_ : unit Promise.t) = Sandbox.save_to_settings new_sandbox in
         Extension_instance.start_language_server instance
     in

--- a/src/extension_instance.mli
+++ b/src/extension_instance.mli
@@ -4,7 +4,11 @@ type t
 
 val make : unit -> t
 
+val toolchain : t -> Toolchain.t option
+
 val sandbox : t -> Sandbox.t
+
+val set_toolchain : t -> Toolchain.t -> unit
 
 val set_sandbox : t -> Sandbox.t -> unit
 

--- a/src/ocaml_windows.ml
+++ b/src/ocaml_windows.ml
@@ -1,0 +1,31 @@
+open Import
+
+let ocaml_env_binary = Path.of_string "ocaml-env"
+
+let ocaml_env_setting =
+  Settings.create ~scope:Global ~key:"ocaml.useOcamlEnv"
+    ~of_json:Jsonoo.Decode.bool ~to_json:Jsonoo.Encode.bool
+
+let use_ocaml_env () =
+  match (Platform.t, Settings.get ocaml_env_setting) with
+  | Win32, Some true -> true
+  | _ -> false
+
+let spawn_ocaml_env args =
+  { Cmd.bin = ocaml_env_binary; args = "exec" :: "--" :: args }
+
+let cygwin_home () =
+  let open Promise.Syntax in
+  let spawn = spawn_ocaml_env [ "cygpath"; "--windows"; "~" ] in
+  let+ output = Cmd.output (Cmd.Spawn spawn) in
+  match output with
+  | Error _ as e -> e
+  | Ok output -> (
+    let lines = String.split_on_chars ~on:[ '\n' ] output in
+    match lines with
+    | home :: _ -> Ok home
+    | _ ->
+      let msg =
+        Printf.sprintf "Unexpected output for Cygin home directory: %s" output
+      in
+      Error msg )

--- a/src/ocaml_windows.mli
+++ b/src/ocaml_windows.mli
@@ -1,0 +1,8 @@
+(* Whether to use ocaml-env for opam on Windows *)
+val use_ocaml_env : unit -> bool
+
+(* Spawn command from OCaml for Windows using ocaml-env *)
+val spawn_ocaml_env : string list -> Cmd.spawn
+
+(* Path to home directory from OCaml for Windows *)
+val cygwin_home : unit -> (string, string) result Promise.t

--- a/src/opam.mli
+++ b/src/opam.mli
@@ -43,13 +43,13 @@ end
 
 type t
 
-val make : unit -> t option Promise.t
+val make : ?root:Path.t -> unit -> t option Promise.t
 
 (** Install new packages in a switch *)
-val install : t -> Switch.t -> string list -> Cmd.t
+val install : t -> Switch.t -> packages:string list -> Cmd.t
 
 (** Update the opam repository *)
-val update : t -> Cmd.t
+val update : t -> Switch.t -> Cmd.t
 
 (** Upgrade packages in a switch *)
 val upgrade : t -> Switch.t -> Cmd.t
@@ -57,13 +57,19 @@ val upgrade : t -> Switch.t -> Cmd.t
 (* Remove a list of packages from a switch *)
 val remove : t -> Switch.t -> string list -> Cmd.t
 
+(* Initialize a new Opam environment. *)
+val init : t -> Cmd.t
+
 (** {4 Working with switches} *)
 
 (** Path of the switch on the filesystem.
 
     If the switch is a local switch, the path is [switch_path ^ _opam],
     otherwise it is the result of [opam var root]. *)
-val switch_path : t -> Switch.t -> (Path.t, string) result Promise.t
+val switch_path : t -> Switch.t -> Path.t
+
+(** Create a new switch. *)
+val switch_create : t -> name:string -> args:string list -> Cmd.t
 
 (** List the opam switches available on the system. *)
 val switch_list : t -> Switch.t list Promise.t

--- a/src/sandbox.mli
+++ b/src/sandbox.mli
@@ -60,16 +60,9 @@ val select_sandbox_and_save : unit -> t option Promise.t
     the sandbox configuration *)
 val select_sandbox : unit -> t option Promise.t
 
-(** [run_setup] is an effectful function that triggers setup instructions
-    automatically for the user.
-
-    A hard requirement for [run_setup] is to not get in the way to existing
-    setups. If users already have working sandboxes installed via some other
-    sandbox/package manager (Nix, system wide managers like yum/apt/brew or
-    Duniverse), [run_setup] must co-operate and detect such installations. *)
-val run_setup : t -> (unit, string) result Promise.t
-
 (* Helper utils *)
+
+val has_command : t -> string -> bool Promise.t
 
 (** Extract command to run with the sandbox *)
 val get_command : t -> string -> string list -> Cmd.t
@@ -79,6 +72,12 @@ val get_lsp_command : ?args:string list -> t -> Cmd.t
 
 (** Extract a dune command *)
 val get_dune_command : t -> string list -> Cmd.t
+
+(** Command to install dependencies in the sandbox *)
+val get_install_command : t -> string list -> Cmd.t option
+
+(** Command to exec a process in the sandbox *)
+val get_exec_command : t -> string list -> Cmd.t option
 
 (** The packages installed in the sandbox *)
 val packages : t -> (Package.t list, string) result Promise.t
@@ -94,3 +93,7 @@ val install_packages : t -> string list -> unit Promise.t
 
 (** Upgrade packages in the sandbox *)
 val upgrade_packages : t -> unit Promise.t
+
+(** [ocaml_version] returns the version of the ocaml compiler installed in given
+    sandbox. *)
+val ocaml_version : t -> (string, string) result Promise.t

--- a/src/toolchain.ml
+++ b/src/toolchain.ml
@@ -1,0 +1,244 @@
+open Import
+
+let get_opamroot () =
+  let open Promise.Syntax in
+  let+ home =
+    if not (Ocaml_windows.use_ocaml_env ()) then
+      Promise.return @@ Node.Os.homedir ()
+    else
+      let+ output = Ocaml_windows.cygwin_home () in
+      match output with
+      | Ok cygwin_home -> cygwin_home
+      | Error e ->
+        show_message `Warn
+          "Could not determine Cygwin home directory, defaulting to Windows \
+           home directory: %s"
+          e;
+        Node.Os.homedir ()
+  in
+  Path.(of_string home / ".vscode-ocaml" / "opam")
+
+type t =
+  { project_sandbox : Sandbox.t option
+  ; opam : Opam.t * Opam.Switch.t
+  ; version : string
+  ; is_new : bool
+  }
+
+module Tool = struct
+  type t =
+    { opam_package : string
+    ; cmd : Cmd.t
+    }
+
+  let opam_package t = t.opam_package
+
+  let cmd t = t.cmd
+
+  let make ?(args = []) ~opam_package
+      { opam = opam, switch; project_sandbox; _ } bin =
+    match project_sandbox with
+    | Some sandbox ->
+      let open Promise.Syntax in
+      let+ has_command = Sandbox.has_command sandbox bin in
+      if has_command then
+        { opam_package; cmd = Sandbox.get_command sandbox bin args }
+      else
+        { opam_package; cmd = Opam.exec opam switch ~args:(bin :: args) }
+    | _ ->
+      Promise.return
+        { opam_package; cmd = Opam.exec opam switch ~args:(bin :: args) }
+
+  let lsp ?args toolchain =
+    make ~opam_package:"ocaml-lsp-server" toolchain "ocamllsp" ?args
+
+  let dune ?args toolchain = make ~opam_package:"dune" toolchain "dune" ?args
+
+  let ocamlformat ?args toolchain =
+    make ~opam_package:"ocamlformat" toolchain "ocamlformat" ?args
+
+  let all toolchain =
+    Promise.all_list
+      [ lsp toolchain ~args:[ "--version" ]
+      ; ocamlformat toolchain ~args:[ "--version" ]
+      ]
+
+  let detect_missing toolchain =
+    let open Promise.Syntax in
+    let missing_command_opt t =
+      let cmd = t.cmd in
+      let+ output =
+        let open Promise.Result.Syntax in
+        let* command = Cmd.check cmd in
+        Cmd.output command
+      in
+      match output with
+      | Ok _ -> None
+      | Error _ -> Some t
+    in
+    let* all = all toolchain in
+    Promise.List.filter_map missing_command_opt all
+end
+
+let compiler_of_version v =
+  match (Platform.t, Platform.arch) with
+  | Win32, X32 -> "ocaml-variants." ^ v ^ "+mingw32c"
+  | Win32, _ -> "ocaml-variants." ^ v ^ "+mingw64c"
+  | _ -> "ocaml-base-compiler." ^ v
+
+let switch_of_version v = "vscode-ocaml-toolchain." ^ v
+
+let compiler_version project_sandbox =
+  let default = "4.11.1" in
+  match project_sandbox with
+  | None -> Promise.return default
+  | Some sandbox -> (
+    let open Promise.Syntax in
+    let+ result = Sandbox.ocaml_version sandbox in
+    match result with
+    | Error _ -> default
+    | Ok version -> version )
+
+let is_sandbox_installed opam switch =
+  let open Promise.Syntax in
+  let cmd = Opam.exec opam switch ~args:[ "true" ] in
+  let+ result = Cmd.output cmd in
+  match result with
+  | Ok _ -> true
+  | Error _ -> false
+
+let setup_toolchain_sandbox project_sandbox opamroot =
+  let open Promise.Syntax in
+  let* opam_opt = Opam.make ~root:opamroot () in
+  match opam_opt with
+  | None -> Promise.return (Error "Opam is not available")
+  | Some opam ->
+    let* compiler_version = compiler_version project_sandbox in
+    let compiler_name = compiler_of_version compiler_version in
+    let sandbox_name = switch_of_version compiler_version in
+    let open Promise.Result.Syntax in
+    let+ _ =
+      Opam.switch_create opam ~name:sandbox_name ~args:[ compiler_name ]
+      |> Cmd.output
+    in
+    ()
+
+let get_install_command { opam = opam, switch; _ } tools =
+  let opam_packages = List.map tools ~f:Tool.opam_package in
+  Opam.install opam switch ~packages:opam_packages
+
+let with_progress ~msg f =
+  let open Promise.Syntax in
+  let progress_options =
+    ProgressOptions.create ~location:(`ProgressLocation Window) ~title:msg
+      ~cancellable:false ()
+  in
+  let task ~progress:_ ~token:_ =
+    let+ result = f () in
+    match result with
+    | Ok _ -> Ok ()
+    | Error err ->
+      show_message `Error "%s" err;
+      Error err
+  in
+  Window.withProgress
+    Interop.Js.((module Result (Unit) (String)))
+    ~options:progress_options ~task
+
+let opam_init opam opamroot =
+  let open Promise.Syntax in
+  let* exists = Fs.exists (opamroot |> Path.to_string) in
+  if exists then
+    Promise.Result.return ()
+  else
+    with_progress
+      ~msg:"Initializing Platform Tools (this might take a few minutes)"
+      (fun () ->
+        let+ result = Opam.init opam |> Cmd.output in
+        Result.map_error result ~f:(fun err ->
+            Printf.sprintf
+              "The creation of the toolchain Opam switch failed: %s" err))
+
+let install_missing_tools t tools opamroot =
+  let open Promise.Syntax in
+  match tools with
+  | [] -> Promise.Result.return ()
+  | tools ->
+    with_progress
+      ~msg:"Installing Platform Tools (this might take a few minutes)"
+      (fun () ->
+        let opam, switch = t.opam in
+        let* is_installed = is_sandbox_installed opam switch in
+        let* _ =
+          match is_installed with
+          | false -> setup_toolchain_sandbox t.project_sandbox opamroot
+          | true -> Promise.Result.return ()
+        in
+        let cmd = get_install_command t tools in
+        let+ result = Cmd.output cmd in
+        Result.map_error result ~f:(fun err ->
+            Printf.sprintf "The installation of the Platform tools failed: %s"
+              err))
+
+let upgrade t =
+  if t.is_new then (
+    log "Is new, won't upgrade";
+    Promise.Result.return ()
+  ) else
+    let opam, switch = t.opam in
+    with_progress ~msg:"Checking for Platform Tools updates" (fun () ->
+        let open Promise.Syntax in
+        let* _ = Opam.update opam switch |> Cmd.output in
+        let+ result = Opam.upgrade opam switch |> Cmd.output in
+        Result.map_error result ~f:(fun err ->
+            Printf.sprintf "The upgrade of the Platform tools failed: %s" err))
+
+let setup ?project_sandbox () =
+  let open Promise.Syntax in
+  let* compiler_version = compiler_version project_sandbox in
+  let sandbox_name = switch_of_version compiler_version in
+  let* opamroot = get_opamroot () in
+  let* opam_opt =
+    let open Promise.Option.Syntax in
+    let* opam = Opam.make ~root:opamroot () in
+    let+ switch = Opam.Switch.of_string sandbox_name |> Promise.return in
+    (opam, switch)
+  in
+  match opam_opt with
+  | None ->
+    let msg =
+      "Opam is required to install the toolchain. Install it manually to use \
+       the extension."
+    in
+    show_message `Error "%s" msg;
+    Promise.return (Error msg)
+  | Some ((opam, switch) as opam_switch) ->
+    let open Promise.Result.Syntax in
+    let* () = opam_init opam opamroot in
+    let open Promise.Syntax in
+    let* is_installed = is_sandbox_installed opam switch in
+    let t =
+      { opam = opam_switch
+      ; project_sandbox
+      ; version = compiler_version
+      ; is_new = not is_installed
+      }
+    in
+    let* missing_tools =
+      if is_installed then
+        Tool.detect_missing t
+      else
+        Tool.all t
+    in
+    let open Promise.Result.Syntax in
+    let+ () = install_missing_tools t missing_tools opamroot in
+    t
+
+let to_pretty_string { version; _ } = "OCaml " ^ version
+
+let get_lsp_command ?args t = Tool.lsp ?args t |> Promise.map Tool.cmd
+
+let get_dune_command ?args t = Tool.dune ?args t |> Promise.map Tool.cmd
+
+let get_ocamlformat_command ?args t =
+  Tool.ocamlformat ?args t |> Promise.map Tool.cmd

--- a/src/toolchain.mli
+++ b/src/toolchain.mli
@@ -1,0 +1,26 @@
+(** Manages OCaml Platform toolchain
+
+    The toolchain is installed in a private sandbox, managed by VSCode only,
+    where the tools we depend on are installed automatically.
+
+    The sandbox uses Opam, but it does not conflict with users who use Esy as
+    their package managers, since the tools are separated from the project. *)
+
+type t
+
+val setup : ?project_sandbox:Sandbox.t -> unit -> (t, string) result Promise.t
+
+val upgrade : t -> (unit, string) result Promise.t
+
+(* Helper utils *)
+
+(** Extract lsp command and arguments *)
+val get_lsp_command : ?args:string list -> t -> Cmd.t Promise.t
+
+(** Extract a dune command *)
+val get_dune_command : ?args:string list -> t -> Cmd.t Promise.t
+
+(** Extract a ocamlformat command and arguments *)
+val get_ocamlformat_command : ?args:string list -> t -> Cmd.t Promise.t
+
+val to_pretty_string : t -> string

--- a/vscode/interop/interop.mli
+++ b/vscode/interop/interop.mli
@@ -52,6 +52,8 @@ module Js : sig
 
   module Any : T with type t = Ojs.t
 
+  module Unit : T with type t = unit
+
   module Bool : T with type t = bool
 
   module Int : T with type t = int
@@ -59,6 +61,8 @@ module Js : sig
   module String : T with type t = string
 
   module Option (T : T) : T with type t = T.t option
+
+  module Result (Ok : T) (Error : T) : T with type t = (Ok.t, Error.t) result
 
   module Or_undefined (T : T) : T with type t = T.t or_undefined
 

--- a/vscode/vscode/vscode.ml
+++ b/vscode/vscode/vscode.ml
@@ -2471,8 +2471,3 @@ end
 module Env = struct
   val shell : unit -> string [@@js.get "vscode.env.shell"]
 end
-
-(* see https://code.visualstudio.com/api/references/icons-in-labels *)
-module LabelIcons = struct
-  let package = "$(package)"
-end

--- a/vscode/vscode/vscode.mli
+++ b/vscode/vscode/vscode.mli
@@ -1946,7 +1946,3 @@ end
 module Env : sig
   val shell : unit -> string
 end
-
-module LabelIcons : sig
-  val package : string
-end


### PR DESCRIPTION
This PR adds a popup to install missing tools (`ocamllsp` and `ocamlformat` for now) when they are not found in the user's sandbox.

It installs the tools from source for now, which is time-consuming, so we'll want to use something like `opam-tools`, but I figured it was good enough for a first version, and we most likely want to use it as a fallback anyways.

Not ready for review yet, but I wanted to get some early feedback on the approach.

**TODO**

- [ ] ~~Cancellation~~
- [X] Display errors
- [ ] ~~What to do when the install command wants to upgrade/downgrade some dependencies? Should we use "-y"?~~
- [X] Do not try to run ocamllsp if missing (and avoid the won't restart error)
- [x] Use the toolchain corresponding to the sandboxe's ocaml compiler version
- [ ] What to do if the user does not have Opam? Can we install it for them (🙈)?
- [ ] What to do if the user does not have Opam but has Esy? Should we create a private sandbox with it?
- [x] Should we use the tools in the user's sandbox when they are available?

Fixes #294
Fixes #361
Fixes #353