### PR TITLE
Fix highlighting of escaped character literals

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Unreleased
 
 - Improve highlighting of type parameters and `module type of` (#461)
+- Fix highlighting of escaped character literals (#467)
 
 ## 1.5.0
 

--- a/syntaxes/ocaml.json
+++ b/syntaxes/ocaml.json
@@ -239,37 +239,37 @@
       "patterns": [
         {
           "comment": "character literal from escaped backslash",
-          "name": "string.quoted.other.ocaml constant.character.ocaml",
+          "name": "string.quoted.single.ocaml",
           "match": "'(\\\\\\\\)'",
           "captures": { "1": { "name": "constant.character.escape.ocaml" } }
         },
         {
           "comment": "character literal from escaped quote or whitespace",
-          "name": "string.quoted.other.ocaml constant.character.ocaml",
+          "name": "string.quoted.single.ocaml",
           "match": "'(\\\\[\"'ntbr ])'",
           "captures": { "1": { "name": "constant.character.escape.ocaml" } }
         },
         {
           "comment": "character literal from decimal ASCII code",
-          "name": "string.quoted.other.ocaml constant.character.ocaml",
+          "name": "string.quoted.single.ocaml",
           "match": "'(\\\\[[:digit:]]{3})'",
           "captures": { "1": { "name": "constant.character.escape.ocaml" } }
         },
         {
           "comment": "character literal from hexadecimal ASCII code",
-          "name": "string.quoted.other.ocaml constant.character.ocaml",
+          "name": "string.quoted.single.ocaml",
           "match": "'(\\\\x[[:xdigit:]]{2})'",
           "captures": { "1": { "name": "constant.character.escape.ocaml" } }
         },
         {
           "comment": "character literal from octal ASCII code",
-          "name": "string.quoted.other.ocaml constant.character.ocaml",
+          "name": "string.quoted.single.ocaml",
           "match": "'(\\\\o[0-3][0-7]{2})'",
           "captures": { "1": { "name": "constant.character.escape.ocaml" } }
         },
         {
           "comment": "character literal from unknown escape sequence",
-          "name": "string.quoted.other.ocaml constant.character.ocaml",
+          "name": "string.quoted.single.ocaml",
           "match": "'(\\\\.)'",
           "captures": {
             "1": { "name": "invalid.illegal.unknown-escape.ocaml" }


### PR DESCRIPTION
Character literals with an escaped character inside of them should have the same token name as normal character literals (`string.quoted.single.ocaml`). Otherwise, the surrounding single quotes may be a different color from normal character literals.