### PR TITLE
Fix highlighting of comments that contain strings with escaped quotes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - Improve highlighting of type parameters and `module type of` (#461)
 - Fix highlighting of escaped character literals (#467)
+- Fix highlighting of comments that contain strings with escaped quotes (#469)
 
 ## 1.5.0
 

--- a/syntaxes/ocaml.json
+++ b/syntaxes/ocaml.json
@@ -158,7 +158,8 @@
         {
           "comment": "string literal",
           "begin": "\"",
-          "end": "\""
+          "end": "\"",
+          "patterns": [{ "match": "\\\\\\\\" }, { "match": "\\\\\"" }]
         },
         {
           "comment": "quoted string literal",


### PR DESCRIPTION
Closes #468 

| Before | After |
| - | - |
| <img width="190" alt="image" src="https://user-images.githubusercontent.com/25037249/100966619-39afae00-34e2-11eb-85bf-ac7d2dc37380.png"> | <img width="190" alt="image" src="https://user-images.githubusercontent.com/25037249/100966702-6663c580-34e2-11eb-9f6e-35351edc2e40.png"> |

