### PR TITLE
Initialize extension correctly

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 - Improve highlighting of type parameters and `module type of` (#461)
 - Fix highlighting of escaped character literals (#467)
 - Fix highlighting of comments that contain strings with escaped quotes (#469)
+- Initialize extension even if language server fails to start (#471)
 
 ## 1.5.0
 

--- a/src/extension_commands.ml
+++ b/src/extension_commands.ml
@@ -74,20 +74,20 @@ let switch_impl_intf =
       let open Option.O in
       let+ editor = Window.activeTextEditor () in
       let document = TextEditor.document editor in
-      let client = Extension_instance.language_client instance in
-      (* extension needs to be activated; otherwise, just ignore the switch try *)
-      let ocaml_lsp = Extension_instance.ocaml_lsp instance in
-      (* same as for instance.client; ignore the try if it's None *)
-      if Ocaml_lsp.can_handle_switch_impl_intf ocaml_lsp then
-        Switch_impl_intf.request_switch client document
-      else
-        (* if, however, ocamllsp doesn't have the capability, recommend updating
-           ocamllsp*)
-        Promise.return
-        @@ show_message `Warn
-             "The installed version of ocamllsp does not support switching \
-              between implementation and interface files. Consider updating \
-              ocamllsp."
+      match Extension_instance.lsp_client instance with
+      | None -> Promise.return (show_message `Warn "ocamllsp is not running.")
+      | Some (client, ocaml_lsp) ->
+        (* same as for instance.client; ignore the try if it's None *)
+        if Ocaml_lsp.can_handle_switch_impl_intf ocaml_lsp then
+          Switch_impl_intf.request_switch client document
+        else
+          (* if, however, ocamllsp doesn't have the capability, recommend
+             updating ocamllsp*)
+          Promise.return
+          @@ show_message `Warn
+               "The installed version of ocamllsp does not support switching \
+                between implementation and interface files. Consider updating \
+                ocamllsp."
     in
     let (_ : unit Promise.t option) = try_switching () in
     ()

--- a/src/extension_instance.mli
+++ b/src/extension_instance.mli
@@ -2,9 +2,11 @@ open Import
 
 type t
 
-val make : Sandbox.t -> t Promise.t
+val make : unit -> t
 
 val sandbox : t -> Sandbox.t
+
+val set_sandbox : t -> Sandbox.t -> unit
 
 val language_client : t -> LanguageClient.t option
 
@@ -12,12 +14,7 @@ val ocaml_lsp : t -> Ocaml_lsp.t option
 
 val lsp_client : t -> (LanguageClient.t * Ocaml_lsp.t) option
 
-val update_on_new_sandbox : t -> Sandbox.t -> (unit, string) result Promise.t
-
-val start_language_server :
-  Sandbox.t -> (LanguageClient.t * Ocaml_lsp.t, string) result Promise.t
-
-val restart_language_server : t -> (unit, string) result Promise.t
+val start_language_server : t -> unit Promise.t
 
 val open_terminal : Sandbox.t -> unit
 

--- a/src/extension_instance.mli
+++ b/src/extension_instance.mli
@@ -2,13 +2,15 @@ open Import
 
 type t
 
-val make : Sandbox.t -> (t, string) result Promise.t
+val make : Sandbox.t -> t Promise.t
 
 val sandbox : t -> Sandbox.t
 
-val language_client : t -> LanguageClient.t
+val language_client : t -> LanguageClient.t option
 
-val ocaml_lsp : t -> Ocaml_lsp.t
+val ocaml_lsp : t -> Ocaml_lsp.t option
+
+val lsp_client : t -> (LanguageClient.t * Ocaml_lsp.t) option
 
 val update_on_new_sandbox : t -> Sandbox.t -> (unit, string) result Promise.t
 

--- a/src/vscode_ocaml_platform.ml
+++ b/src/vscode_ocaml_platform.ml
@@ -19,29 +19,41 @@ let activate (extension : ExtensionContext.t) =
      vscode [output] pane for logs *)
   Process.Env.set "OCAML_LSP_SERVER_LOG" "-";
   let open Promise.Syntax in
-  let* sandbox = Sandbox.of_settings_or_detect () in
-  let is_fallback = Option.is_empty sandbox in
-  let sandbox = Option.value sandbox ~default:Sandbox.Global in
-  let+ instance = Extension_instance.make sandbox in
-  (* register things with vscode, making sure to register their disposables *)
+  let instance = Extension_instance.make () in
   ExtensionContext.subscribe extension
     ~disposable:(Extension_instance.disposable instance);
   Extension_commands.register_all_commands extension instance;
   Dune_formatter.register extension instance;
   Dune_task_provider.register extension instance;
-  if
-    is_fallback
-    (* if the sandbox we just set up is a fallback sandbox, we create a pop-up
-       message to offer the user to pick a sandbox they want; note: if the user
-       picks another sandbox in the pop-up, we redo part of work we have just
-       done; this is the case because we can't wait or rely on user to pick a
-       sandbox: they may ignore the pop-up leaving the extension hanging, so we
-       use fallback; w/ a proper detection mechanism, we would redo work in rare
-       cases *)
-  then
-    let (_ : unit Promise.t) = suggest_to_pick_sandbox instance in
+  let sandbox = Sandbox.of_settings_or_detect () in
+  let (_ : unit Promise.t) =
+    let* sandbox = sandbox in
+    let is_fallback = Option.is_empty sandbox in
+    if
+      is_fallback
+      (* if the sandbox we just set up is a fallback sandbox, we create a pop-up
+         message to offer the user to pick a sandbox they want; note: if the
+         user picks another sandbox in the pop-up, we redo part of work we have
+         just done; this is the case because we can't wait or rely on user to
+         pick a sandbox: they may ignore the pop-up leaving the extension
+         hanging, so we use fallback; w/ a proper detection mechanism, we would
+         redo work in rare cases *)
+    then
+      suggest_to_pick_sandbox instance
+    else
+      Promise.return ()
+  in
+  let (_ : unit Promise.t) =
+    let* sandbox = sandbox in
+    let sandbox = Option.value sandbox ~default:Sandbox.Global in
+    Extension_instance.set_sandbox instance sandbox;
+    let+ () = Extension_instance.start_language_server instance in
     ()
+  in
+  Promise.return ()
 
+(* see {{:https://code.visualstudio.com/api/references/vscode-api#Extension}
+   activate() *)
 let () =
   let open Js_of_ocaml.Js in
   export "activate" (wrap_callback activate)

--- a/src/vscode_ocaml_platform.mli
+++ b/src/vscode_ocaml_platform.mli
@@ -1,5 +1,1 @@
 (** Entry point *)
-
-(* see {{:https://code.visualstudio.com/api/references/vscode-api#Extension}
-   activate() *)
-val activate : Vscode.ExtensionContext.t -> unit Promise.t


### PR DESCRIPTION
We should initialize the extension and register all commands even if the
language server fails to load.