### PR TITLE
Support token aliases in associativity declarations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Change Log
 
+# Unreleased
+
+- Highlight token aliases in Menhir associativity declarations (#473)
+
 ## 1.5.1
 
 - Improve highlighting of type parameters and `module type of` (#461)
@@ -7,7 +11,10 @@
 - Fix highlighting of comments that contain strings with escaped quotes (#469)
 - Initialize extension even if language server fails to start (#471)
 - Detection of local Opam and Esy sandboxes (#445)
-  The detection will prioritize Opam local switches, then Esy sandboxes (that are detected with the directory `_esy`), and will fallback to the global environment sandbox if none of these are found.
+
+  The detection will prioritize Opam local switches, then Esy sandboxes (that
+  are detected with the directory `_esy`), and will fallback to the global
+  environment sandbox if none of these are found.
 
 ## 1.5.0
 

--- a/syntaxes/menhir.json
+++ b/syntaxes/menhir.json
@@ -70,6 +70,8 @@
           "patterns": [
             { "include": "#token-name" },
             { "include": "#production-name" },
+            { "include": "source.ocaml#strings" },
+            { "include": "source.ocaml#attributes" },
             { "include": "#comments" }
           ]
         },
@@ -81,6 +83,8 @@
           "patterns": [
             { "include": "#type-annotation" },
             { "include": "#production-name" },
+            { "include": "source.ocaml#strings" },
+            { "include": "source.ocaml#attributes" },
             { "include": "#comments" }
           ]
         },


### PR DESCRIPTION
Why did it not even occur to me that these existed...