### PR TITLE
Update promise_jsoo and jsonoo dependencies

### DIFF
--- a/dune-project
+++ b/dune-project
@@ -35,9 +35,9 @@
   (core_kernel
    (>= v0.14.0))
   (promise_jsoo
-   (>= 0.3.0))
+   (>= 0.3.1))
   (jsonoo
-   (>= 0.2.0))))
+   (>= 0.2.1))))
 
 (package
  (name vscode)
@@ -50,6 +50,6 @@
   (gen_js_api
    (>= 1.0.6))
   (promise_jsoo
-   (>= 0.3.0))
+   (>= 0.3.1))
   (jsonoo
-   (>= 0.2.0))))
+   (>= 0.2.1))))

--- a/esy.json
+++ b/esy.json
@@ -4,8 +4,8 @@
     "@opam/js_of_ocaml": "3.7.1",
     "@opam/gen_js_api": "1.0.6",
     "@opam/core_kernel": "v0.14.0",
-    "@opam/promise_jsoo": "0.2.0",
-    "@opam/jsonoo": "0.2.0"
+    "@opam/promise_jsoo": "0.3.1",
+    "@opam/jsonoo": "0.2.1"
   },
   "devDependencies": {
     "@opam/dune": "2.7.1",

--- a/vscode-ocaml-platform.opam
+++ b/vscode-ocaml-platform.opam
@@ -22,8 +22,8 @@ depends: [
   "js_of_ocaml" {>= "3.7.0"}
   "gen_js_api" {>= "1.0.6"}
   "core_kernel" {>= "v0.14.0"}
-  "promise_jsoo" {>= "0.3.0"}
-  "jsonoo" {>= "0.2.0"}
+  "promise_jsoo" {>= "0.3.1"}
+  "jsonoo" {>= "0.2.1"}
   "odoc" {with-doc}
 ]
 build: [

--- a/vscode.opam
+++ b/vscode.opam
@@ -20,8 +20,8 @@ depends: [
   "ocaml" {>= "4.11"}
   "js_of_ocaml" {>= "3.7.0"}
   "gen_js_api" {>= "1.0.6"}
-  "promise_jsoo" {>= "0.3.0"}
-  "jsonoo" {>= "0.2.0"}
+  "promise_jsoo" {>= "0.3.1"}
+  "jsonoo" {>= "0.2.1"}
   "odoc" {with-doc}
 ]
 build: [


### PR DESCRIPTION
Updates to the latest version of `promise_jsoo` and `jsonoo`, which stop unnecessarily linking to the `js_of_ocaml-ppx` library. 

The size of the generated JS file decreases to about 9 MB and the VSIX file decreases to about 2 MB.