### PR TITLE
Use ocaml-env for opam commands on windows

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@
 - Highlight token aliases in Menhir associativity declarations (#473)
 - Activate the extension when workspace contains OCaml, Reason sources or
   project marker files. (#482)
+- Add `ocaml.useOcamlEnv` setting to determine whether to use `ocaml-env` for
+  opam commands from OCaml for Windows (#481)
 
 ## 1.5.1
 

--- a/README.md
+++ b/README.md
@@ -20,23 +20,9 @@ _Please report any bugs you encounter._
 
 ### Windows
 
-If you are on Windows, there are two ways to use this extension:
-
-1. Launch VSCode from Cygwin. This will let you choose a global or opam sandbox.
-
-2. Use a custom sandbox with
-   [ocaml-env](https://fdopen.github.io/opam-repository-mingw/ocaml-env/). If it
-   is on your PATH you can input `ocaml-env exec -- $prog $args` for the custom
-   command template, or manually edit the `ocaml.sandbox` setting so it is
-
-```json
-"ocaml.sandbox": {
-  "kind": "custom",
-  "template": "ocaml-env exec -- $prog $args"
-}
-```
-
-We find the first option more reliable.
+Install [OCaml for Windows](https://fdopen.github.io/opam-repository-mingw/) and
+make sure the `ocaml-env` program is accessible on the PATH (`ocaml-env` is in
+the `usr/local/bin` folder relative to the installation directory).
 
 ### BuckleScript
 
@@ -103,6 +89,7 @@ the settings under `File > Preferences > Settings`.
 | `ocaml.sandbox`                    | Determines where to find the sandbox for a given project                                                | `null`  |
 | `ocaml.dune.autoDetect`            | Controls whether dune tasks should be automatically detected.                                           | `true`  |
 | `ocaml.trace.server`               | Controls the logging output of the language server. Valid settings are `off`, `messages`, or `verbose`. | `off`   |
+| `ocaml.useOcamlEnv`                | Controls whether to use ocaml-env for opam commands from OCaml for Windows.                             | `true`  |
 | `ocaml.terminal.shell.linux`       | The path of the shell that the sandbox terminal uses on Linux                                           | `null`  |
 | `ocaml.terminal.shell.osx`         | The path of the shell that the sandbox terminal uses on macOS                                           | `null`  |
 | `ocaml.terminal.shell.windows`     | The path of the shell that the sandbox terminal uses on Windows                                         | `null`  |

--- a/package.json
+++ b/package.json
@@ -133,7 +133,7 @@
         "ocaml.useOcamlEnv": {
           "type": "boolean",
           "default": true,
-          "description": "Whether to use ocaml-env for opam commands from OCaml for Windows."
+          "description": "Controls whether to use ocaml-env for opam commands from OCaml for Windows."
         },
         "ocaml.terminal.shell.linux": {
           "description": "The path of the shell that the sandbox terminal uses on Linux",

--- a/package.json
+++ b/package.json
@@ -130,6 +130,11 @@
           ],
           "default": "off"
         },
+        "ocaml.useOcamlEnv": {
+          "type": "boolean",
+          "default": true,
+          "description": "Whether to use ocaml-env for opam commands from OCaml for Windows."
+        },
         "ocaml.terminal.shell.linux": {
           "description": "The path of the shell that the sandbox terminal uses on Linux",
           "type": [


### PR DESCRIPTION
This PR makes the extension execute `ocaml-env exec -- opam` for any opam commands on Windows. Previously, VSCode would have to be opened from cygwin to have a proper opam environment. Now, VSCode can be opened normally and the extension handles the environment.

I made the `ocaml.useOcamlEnv` setting default to true because this should be the smoothest way to use the extension on Windows now. Having the option lets users continue to use the old workflow by accessing `opam` directly.

@tmattio: I think this should (partially) help implement #463 on Windows.