### PR TITLE
Fix terminal creation when using default shell and arguments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
   project marker files. (#482)
 - Add `ocaml.useOcamlEnv` setting to determine whether to use `ocaml-env` for
   opam commands from OCaml for Windows (#481)
+- Fix terminal creation when using default shell and arguments (#484)
 
 ## 1.5.1
 

--- a/package.json
+++ b/package.json
@@ -148,7 +148,8 @@
           "type": [
             "string",
             "null"
-          ]
+          ],
+          "default": null
         },
         "ocaml.terminal.shell.windows": {
           "description": "The path of the shell that the sandbox terminal uses on Windows",

--- a/src/extension_instance.ml
+++ b/src/extension_instance.ml
@@ -121,12 +121,8 @@ let set_sandbox t new_sandbox =
   t.sandbox <- new_sandbox
 
 let open_terminal sandbox =
-  match Terminal_sandbox.create sandbox with
-  | Some terminal -> Terminal_sandbox.show terminal
-  | None ->
-    show_message `Error
-      "Could not open a terminal in the current sandbox. The sandbox may not \
-       have loaded yet."
+  let terminal = Terminal_sandbox.create sandbox in
+  Terminal_sandbox.show terminal
 
 let disposable t =
   Disposable.make ~dispose:(fun () ->

--- a/src/terminal_sandbox.mli
+++ b/src/terminal_sandbox.mli
@@ -1,6 +1,6 @@
 type t
 
-val create : Sandbox.t -> t option
+val create : Sandbox.t -> t
 
 val dispose : t -> unit
 


### PR DESCRIPTION
Fixes issue mentioned in https://github.com/ocaml/ocaml-lsp/issues/346#issuecomment-743359650

Once the extension sandbox is set up, creating a terminal should never fail. The previous behavior would not create a terminal if `ocaml.terminal.shell.*` was unset.