### PR TITLE
Register provider and commands in treeview modules

### DIFF
--- a/package.json
+++ b/package.json
@@ -100,7 +100,8 @@
       },
       {
         "command": "ocaml.refresh-switches",
-        "title": "Refresh",
+        "category": "OCaml",
+        "title": "Refresh Switches",
         "icon": {
           "light": "assets/refresh-light.svg",
           "dark": "assets/refresh-dark.svg"
@@ -108,7 +109,8 @@
       },
       {
         "command": "ocaml.remove-switch",
-        "title": "Remove",
+        "category": "OCaml",
+        "title": "Remove Switch",
         "icon": {
           "light": "assets/x-light.svg",
           "dark": "assets/x-dark.svg"
@@ -116,6 +118,7 @@
       },
       {
         "command": "ocaml.open-documentation",
+        "category": "OCaml",
         "title": "Open Documentation",
         "icon": {
           "light": "assets/document-search-light.svg",
@@ -149,24 +152,31 @@
     "menus": {
       "commandPalette": [
         {
-          "command": "ocaml.select-sandbox",
-          "when": "ocaml-platform:enabled"
+          "command": "ocaml.select-sandbox"
         },
         {
-          "command": "ocaml.server.restart",
-          "when": "ocaml-platform:enabled"
+          "command": "ocaml.server.restart"
         },
         {
-          "command": "ocaml.open-terminal",
-          "when": "ocaml-platform:enabled"
+          "command": "ocaml.open-terminal"
         },
         {
-          "command": "ocaml.open-terminal-select",
-          "when": "ocaml-platform:enabled"
+          "command": "ocaml.open-terminal-select"
         },
         {
-          "command": "ocaml.switch-impl-intf",
-          "when": "ocaml-platform:enabled"
+          "command": "ocaml.switch-impl-intf"
+        },
+        {
+          "command": "ocaml.refresh-switches",
+          "when": "false"
+        },
+        {
+          "command": "ocaml.remove-switch",
+          "when": "false"
+        },
+        {
+          "command": "ocaml.open-documentation",
+          "when": "false"
         }
       ],
       "editor/title": [

--- a/src/extension_commands.mli
+++ b/src/extension_commands.mli
@@ -1,11 +1,3 @@
-type command = private
-  { id : string
-  ; handler : Extension_instance.t -> args:Ojs.t list -> unit
-  }
-
-val make_command :
-  string -> (Extension_instance.t -> args:Ojs.t list -> unit) -> command
-
 (** Module to manage commands[1] across the extension.
 
     Module does not have public API for command creation on purpose. One should
@@ -17,6 +9,11 @@ val make_command :
 
     [1] https://code.visualstudio.com/api/references/vscode-api#commands *)
 
+type command = private
+  { id : string
+  ; handler : Extension_instance.t -> args:Ojs.t list -> unit
+  }
+
 val select_sandbox : command
 
 val restart_language_server : command
@@ -26,10 +23,6 @@ val select_sandbox_and_open_terminal : command
 val open_terminal : command
 
 val switch_impl_intf : command
-
-val remove_switch : command
-
-val open_documentation : command
 
 (** Registers commands with vscode. Should be called in
     [Vscode_ocaml_platform.activate]. It subscribes the disposables to the

--- a/src/opam.ml
+++ b/src/opam.ml
@@ -220,7 +220,7 @@ let get_switch_compiler t switch =
 
 let remove_switch t switch =
   let name = Switch.name switch in
-  Cmd.Spawn (Cmd.append t [ "-y"; "switch"; "remove"; name ])
+  Cmd.Spawn (Cmd.append t [ "switch"; "remove"; name; "-y";  ])
 
 let uninstall_package t ~switch ~package =
   exec t ~switch ~args:[ "uninstall"; Package.name package ]

--- a/src/treeview_commands.ml
+++ b/src/treeview_commands.ml
@@ -46,7 +46,7 @@ let getChildren ~extension_path ~element =
   | None -> `Value (Some (items ~extension_path))
   | Some _ -> `Value (Some [])
 
-let register extension (_ : Extension_instance.t) =
+let register extension =
   let extension_path = Vscode.ExtensionContext.extensionPath extension in
   let treeDataProvider =
     Vscode.TreeDataProvider.create

--- a/src/treeview_commands.ml
+++ b/src/treeview_commands.ml
@@ -47,20 +47,15 @@ let getChildren ~extension_path ~element =
   | Some _ -> `Value (Some [])
 
 let register extension (_ : Extension_instance.t) =
-  let (_ : unit Promise.t) =
-    Promise.make @@ fun ~resolve ~reject:_ ->
-    let extension_path = Vscode.ExtensionContext.extensionPath extension in
-    let treeDataProvider =
-      Vscode.TreeDataProvider.create
-        ~getTreeItem:(getTreeItem ~extension_path)
-        ~getChildren:(getChildren ~extension_path)
-        ()
-    in
-    let disposable =
-      Vscode.Window.registerTreeDataProvider ~viewId:"ocaml-commands"
-        ~treeDataProvider
-    in
-    Vscode.ExtensionContext.subscribe extension ~disposable;
-    resolve ()
+  let extension_path = Vscode.ExtensionContext.extensionPath extension in
+  let treeDataProvider =
+    Vscode.TreeDataProvider.create
+      ~getTreeItem:(getTreeItem ~extension_path)
+      ~getChildren:(getChildren ~extension_path)
+      ()
   in
-  ()
+  let disposable =
+    Vscode.Window.registerTreeDataProvider ~viewId:"ocaml-commands"
+      ~treeDataProvider
+  in
+  Vscode.ExtensionContext.subscribe extension ~disposable

--- a/src/treeview_commands.ml
+++ b/src/treeview_commands.ml
@@ -46,16 +46,21 @@ let getChildren ~extension_path ~element =
   | None -> `Value (Some (items ~extension_path))
   | Some _ -> `Value (Some [])
 
-let register extension =
-  let extension_path = Vscode.ExtensionContext.extensionPath extension in
-  let treeDataProvider =
-    Vscode.TreeDataProvider.create
-      ~getTreeItem:(getTreeItem ~extension_path)
-      ~getChildren:(getChildren ~extension_path)
-      ()
+let register extension (_ : Extension_instance.t) =
+  let (_ : unit Promise.t) =
+    Promise.make @@ fun ~resolve ~reject:_ ->
+    let extension_path = Vscode.ExtensionContext.extensionPath extension in
+    let treeDataProvider =
+      Vscode.TreeDataProvider.create
+        ~getTreeItem:(getTreeItem ~extension_path)
+        ~getChildren:(getChildren ~extension_path)
+        ()
+    in
+    let disposable =
+      Vscode.Window.registerTreeDataProvider ~viewId:"ocaml-commands"
+        ~treeDataProvider
+    in
+    Vscode.ExtensionContext.subscribe extension ~disposable;
+    resolve ()
   in
-  let disposable =
-    Vscode.Window.registerTreeDataProvider ~viewId:"ocaml-commands"
-      ~treeDataProvider
-  in
-  Promise.return disposable
+  ()

--- a/src/treeview_commands.mli
+++ b/src/treeview_commands.mli
@@ -1,3 +1,2 @@
-(** Register the ocaml-commands tree view and returns the provider as a
-    disposable. *)
-val register : Vscode.ExtensionContext.t -> Vscode.Disposable.t Promise.t
+(** Register the ocaml-commands tree view. *)
+val register : Vscode.ExtensionContext.t -> Extension_instance.t -> unit

--- a/src/treeview_commands.mli
+++ b/src/treeview_commands.mli
@@ -1,2 +1,2 @@
 (** Register the ocaml-commands tree view. *)
-val register : Vscode.ExtensionContext.t -> Extension_instance.t -> unit
+val register : Vscode.ExtensionContext.t -> unit

--- a/src/treeview_help.ml
+++ b/src/treeview_help.ml
@@ -78,16 +78,21 @@ let getChildren ~extension_path ~element =
   | None -> `Value (Some (items ~extension_path))
   | Some _ -> `Value (Some [])
 
-let register extension =
-  let extension_path = Vscode.ExtensionContext.extensionPath extension in
-  let treeDataProvider =
-    Vscode.TreeDataProvider.create
-      ~getTreeItem:(getTreeItem ~extension_path)
-      ~getChildren:(getChildren ~extension_path)
-      ()
+let register extension (_ : Extension_instance.t) =
+  let (_ : unit Promise.t) =
+    Promise.make @@ fun ~resolve ~reject:_ ->
+    let extension_path = Vscode.ExtensionContext.extensionPath extension in
+    let treeDataProvider =
+      Vscode.TreeDataProvider.create
+        ~getTreeItem:(getTreeItem ~extension_path)
+        ~getChildren:(getChildren ~extension_path)
+        ()
+    in
+    let disposable =
+      Vscode.Window.registerTreeDataProvider ~viewId:"ocaml-help"
+        ~treeDataProvider
+    in
+    Vscode.ExtensionContext.subscribe extension ~disposable;
+    resolve ()
   in
-  let disposable =
-    Vscode.Window.registerTreeDataProvider ~viewId:"ocaml-help"
-      ~treeDataProvider
-  in
-  Promise.return disposable
+  ()

--- a/src/treeview_help.ml
+++ b/src/treeview_help.ml
@@ -79,20 +79,15 @@ let getChildren ~extension_path ~element =
   | Some _ -> `Value (Some [])
 
 let register extension (_ : Extension_instance.t) =
-  let (_ : unit Promise.t) =
-    Promise.make @@ fun ~resolve ~reject:_ ->
-    let extension_path = Vscode.ExtensionContext.extensionPath extension in
-    let treeDataProvider =
-      Vscode.TreeDataProvider.create
-        ~getTreeItem:(getTreeItem ~extension_path)
-        ~getChildren:(getChildren ~extension_path)
-        ()
-    in
-    let disposable =
-      Vscode.Window.registerTreeDataProvider ~viewId:"ocaml-help"
-        ~treeDataProvider
-    in
-    Vscode.ExtensionContext.subscribe extension ~disposable;
-    resolve ()
+  let extension_path = Vscode.ExtensionContext.extensionPath extension in
+  let treeDataProvider =
+    Vscode.TreeDataProvider.create
+      ~getTreeItem:(getTreeItem ~extension_path)
+      ~getChildren:(getChildren ~extension_path)
+      ()
   in
-  ()
+  let disposable =
+    Vscode.Window.registerTreeDataProvider ~viewId:"ocaml-help"
+      ~treeDataProvider
+  in
+  Vscode.ExtensionContext.subscribe extension ~disposable

--- a/src/treeview_help.ml
+++ b/src/treeview_help.ml
@@ -78,7 +78,7 @@ let getChildren ~extension_path ~element =
   | None -> `Value (Some (items ~extension_path))
   | Some _ -> `Value (Some [])
 
-let register extension (_ : Extension_instance.t) =
+let register extension =
   let extension_path = Vscode.ExtensionContext.extensionPath extension in
   let treeDataProvider =
     Vscode.TreeDataProvider.create

--- a/src/treeview_help.mli
+++ b/src/treeview_help.mli
@@ -1,2 +1,2 @@
-(** Register the ocaml-help tree view and returns the provider as a disposable. *)
-val register : Vscode.ExtensionContext.t -> Vscode.Disposable.t Promise.t
+(** Register the ocaml-help tree view. *)
+val register : Vscode.ExtensionContext.t -> unit

--- a/src/treeview_switches.ml
+++ b/src/treeview_switches.ml
@@ -212,7 +212,7 @@ let get_dependencies ~opam ~extension_path element =
     let deps = get_dependency_dependencies dependency in
     dependencies_opt_to_tree_items deps
 
-let register extension (_ : Extension_instance.t) =
+let register extension =
   let (_ : unit Promise.t) =
     let open Promise.Syntax in
     let extension_path = Vscode.ExtensionContext.extensionPath extension in

--- a/src/treeview_switches.mli
+++ b/src/treeview_switches.mli
@@ -24,7 +24,5 @@ module Dependency : sig
   val collapsible_state : t -> Vscode.TreeItemCollapsibleState.t
 end
 
-(** Register the ocaml-switches tree view and returns the provider as a
-    disposable, with a callback to refresh the view. *)
-val register :
-  Vscode.ExtensionContext.t -> (Vscode.Disposable.t * (unit -> unit)) Promise.t
+(** Register the ocaml-switches tree view *)
+val register : Vscode.ExtensionContext.t -> Extension_instance.t -> unit

--- a/src/treeview_switches.mli
+++ b/src/treeview_switches.mli
@@ -1,28 +1,2 @@
-module Dependency : sig
-  type t =
-    | Switch of Opam.Switch.t
-    | Dependency of (Opam.Package.t * t option)
-
-  val sexp_of_t : t -> Sexplib0.Sexp.t
-
-  val t_of_sexp : Sexplib0.Sexp.t -> t
-
-  val to_string : t -> string
-
-  val of_string : string -> t
-
-  val label : t -> string
-
-  val description : opam:Opam.t -> t -> string option Promise.t
-
-  val tooltip : t -> string option
-
-  val context_value : t -> string
-
-  val icon : extension_path:string -> t -> Vscode.TreeItem.LightDarkIcon.t
-
-  val collapsible_state : t -> Vscode.TreeItemCollapsibleState.t
-end
-
 (** Register the ocaml-switches tree view *)
-val register : Vscode.ExtensionContext.t -> Extension_instance.t -> unit
+val register : Vscode.ExtensionContext.t -> unit

--- a/src/vscode_ocaml_platform.ml
+++ b/src/vscode_ocaml_platform.ml
@@ -26,9 +26,9 @@ let activate (extension : ExtensionContext.t) =
   Dune_formatter.register extension instance;
   Dune_task_provider.register extension instance;
   Extension_commands.register_all_commands extension instance;
-  Treeview_switches.register extension instance;
-  Treeview_commands.register extension instance;
-  Treeview_help.register extension instance;
+  Treeview_switches.register extension;
+  Treeview_commands.register extension;
+  Treeview_help.register extension;
   let sandbox = Sandbox.of_settings_or_detect () in
   let (_ : unit Promise.t) =
     let* sandbox = sandbox in

--- a/src/vscode_ocaml_platform.ml
+++ b/src/vscode_ocaml_platform.ml
@@ -23,29 +23,13 @@ let activate (extension : ExtensionContext.t) =
   let instance = Extension_instance.make () in
   ExtensionContext.subscribe extension
     ~disposable:(Extension_instance.disposable instance);
-  Extension_commands.register_all_commands extension instance;
   Dune_formatter.register extension instance;
   Dune_task_provider.register extension instance;
+  Extension_commands.register_all_commands extension instance;
+  Treeview_switches.register extension instance;
+  Treeview_commands.register extension instance;
+  Treeview_help.register extension instance;
   let sandbox = Sandbox.of_settings_or_detect () in
-  let* refresh =
-    let+ disposable, command = Treeview_switches.register extension in
-    ExtensionContext.subscribe extension ~disposable;
-    command
-  in
-  let () =
-    let handler (_ : Extension_instance.t) ~args:_ = refresh () in
-    Extension_commands.make_command Extension_consts.Commands.refresh_switches
-      handler
-    |> Extension_commands.register extension instance
-  in
-  let (_ : unit Promise.t) =
-    let+ disposable = Treeview_commands.register extension in
-    ExtensionContext.subscribe extension ~disposable
-  in
-  let (_ : unit Promise.t) =
-    let+ disposable = Treeview_help.register extension in
-    ExtensionContext.subscribe extension ~disposable
-  in
   let (_ : unit Promise.t) =
     let* sandbox = sandbox in
     let is_fallback = Option.is_empty sandbox in


### PR DESCRIPTION
This PR improves the registration of tree view providers:

- The registrations are now async and don't depend on each other
- The tree view modules register their own command, so the `Extension_commands` can stay isolated.

cc @ulugbekna 