### PR TITLE
Add a sandbox tree view

### DIFF
--- a/assets/arrow-circle-up-dark.svg
+++ b/assets/arrow-circle-up-dark.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="#C5C5C5">
+  <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 11l3-3m0 0l3 3m-3-3v8m0-13a9 9 0 110 18 9 9 0 010-18z" />
+</svg>

--- a/assets/arrow-circle-up-light.svg
+++ b/assets/arrow-circle-up-light.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="#424242">
+  <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 11l3-3m0 0l3 3m-3-3v8m0-13a9 9 0 110 18 9 9 0 010-18z" />
+</svg>

--- a/assets/plus-dark.svg
+++ b/assets/plus-dark.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="#C5C5C5">
+  <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 6v6m0 0v6m0-6h6m-6 0H6" />
+</svg>

--- a/assets/plus-light.svg
+++ b/assets/plus-light.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="#424242">
+  <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 6v6m0 0v6m0-6h6m-6 0H6" />
+</svg>

--- a/package.json
+++ b/package.json
@@ -43,6 +43,12 @@
   ],
   "icon": "assets/logo.png",
   "contributes": {
+    "viewsWelcome": [
+      {
+        "view": "ocaml-sandbox",
+        "contents": "In order to manage your sandbox, you can open a folder containing an Opam switch, or select an Opam switch as a sandbox.\n[Open Folder](command:vscode.openFolder)\n[Select Sandbox](command:ocaml.select-sandbox)"
+      }
+    ],
     "viewsContainers": {
       "activitybar": [
         {
@@ -55,8 +61,12 @@
     "views": {
       "ocaml-explorer": [
         {
+          "id": "ocaml-sandbox",
+          "name": "Sandbox"
+        },
+        {
           "id": "ocaml-switches",
-          "name": "Switches"
+          "name": "Opam Switches"
         },
         {
           "id": "ocaml-commands",
@@ -108,6 +118,33 @@
         }
       },
       {
+        "command": "ocaml.refresh-sandbox",
+        "category": "OCaml",
+        "title": "Refresh Sandbox",
+        "icon": {
+          "light": "assets/refresh-light.svg",
+          "dark": "assets/refresh-dark.svg"
+        }
+      },
+      {
+        "command": "ocaml.install-sandbox",
+        "category": "OCaml",
+        "title": "Install Packages",
+        "icon": {
+          "light": "assets/plus-light.svg",
+          "dark": "assets/plus-dark.svg"
+        }
+      },
+      {
+        "command": "ocaml.upgrade-sandbox",
+        "category": "OCaml",
+        "title": "Upgrade Packages",
+        "icon": {
+          "light": "assets/arrow-circle-up-light.svg",
+          "dark": "assets/arrow-circle-up-dark.svg"
+        }
+      },
+      {
         "command": "ocaml.remove-switch",
         "category": "OCaml",
         "title": "Remove Switch",
@@ -117,7 +154,25 @@
         }
       },
       {
-        "command": "ocaml.open-documentation",
+        "command": "ocaml.uninstall-sandbox-package",
+        "category": "OCaml",
+        "title": "Uninstall Package",
+        "icon": {
+          "light": "assets/x-light.svg",
+          "dark": "assets/x-dark.svg"
+        }
+      },
+      {
+        "command": "ocaml.open-switches-documentation",
+        "category": "OCaml",
+        "title": "Open Documentation",
+        "icon": {
+          "light": "assets/document-search-light.svg",
+          "dark": "assets/document-search-dark.svg"
+        }
+      },
+      {
+        "command": "ocaml.open-sandbox-documentation",
         "category": "OCaml",
         "title": "Open Documentation",
         "icon": {
@@ -171,11 +226,31 @@
           "when": "false"
         },
         {
+          "command": "ocaml.refresh-sandbox",
+          "when": "false"
+        },
+        {
+          "command": "ocaml.install-sandbox",
+          "when": "false"
+        },
+        {
+          "command": "ocaml.uninstall-sandbox-package",
+          "when": "false"
+        },
+        {
+          "command": "ocaml.upgrade-sandbox",
+          "when": "false"
+        },
+        {
           "command": "ocaml.remove-switch",
           "when": "false"
         },
         {
-          "command": "ocaml.open-documentation",
+          "command": "ocaml.open-switches-documentation",
+          "when": "false"
+        },
+        {
+          "command": "ocaml.open-sandbox-documentation",
           "when": "false"
         }
       ],
@@ -192,17 +267,42 @@
           "command": "ocaml.refresh-switches",
           "when": "view == ocaml-switches",
           "group": "navigation"
+        },
+        {
+          "command": "ocaml.refresh-sandbox",
+          "when": "view == ocaml-sandbox",
+          "group": "navigation"
+        },
+        {
+          "command": "ocaml.install-sandbox",
+          "when": "view == ocaml-sandbox",
+          "group": "navigation"
+        },
+        {
+          "command": "ocaml.upgrade-sandbox",
+          "when": "view == ocaml-sandbox",
+          "group": "navigation"
         }
       ],
       "view/item/context": [
         {
           "command": "ocaml.remove-switch",
-          "when": "view == ocaml-switches && viewItem == switch",
+          "when": "view == ocaml-switches && viewItem == opam-switch",
           "group": "inline"
         },
         {
-          "command": "ocaml.open-documentation",
+          "command": "ocaml.uninstall-sandbox-package",
+          "when": "view == ocaml-sandbox",
+          "group": "inline"
+        },
+        {
+          "command": "ocaml.open-switches-documentation",
           "when": "view == ocaml-switches && viewItem == package-with-doc",
+          "group": "inline"
+        },
+        {
+          "command": "ocaml.open-sandbox-documentation",
+          "when": "view == ocaml-sandbox && viewItem == package-with-doc",
           "group": "inline"
         }
       ]

--- a/src/bindings/node/dune
+++ b/src/bindings/node/dune
@@ -4,5 +4,5 @@
   (pps gen_js_api.ppx))
  (js_of_ocaml
   (javascript_files node_stub.js))
- (libraries interop promise_jsoo jsonoo gen_js_api)
+ (libraries interop promise_jsoo jsonoo gen_js_api js_of_ocaml)
  (modes byte))

--- a/src/bindings/node/node.ml
+++ b/src/bindings/node/node.ml
@@ -1,5 +1,11 @@
 open Interop
 
+let __filename () =
+  Js_of_ocaml.Js.Unsafe.eval_string "__filename" |> Js_of_ocaml.Js.to_string
+
+let __dirname () =
+  Js_of_ocaml.Js.Unsafe.eval_string "__dirname" |> Js_of_ocaml.Js.to_string
+
 module Process = struct
   val cwd : unit -> string [@@js.global "process.cwd"]
 

--- a/src/bindings/node/node.mli
+++ b/src/bindings/node/node.mli
@@ -1,5 +1,9 @@
 open Interop
 
+val __filename : unit -> string
+
+val __dirname : unit -> string
+
 module Process : sig
   val cwd : unit -> string
 

--- a/src/esy.mli
+++ b/src/esy.mli
@@ -1,20 +1,69 @@
+(** Provide an interface to Esy.
+
+    The functions in this module either use the result of esy commands, or use
+    the filesystem to get the state of esy configurations. *)
+
 open Import
+
+module Manifest : sig
+  type t
+
+  val equal : t -> t -> bool
+
+  val path : t -> Path.t
+
+  val of_path : Path.t -> t
+end
+
+(** A package installed in an Esy sandbox *)
+module Package : sig
+  type t
+
+  (** {4 Properties} *)
+
+  val name : t -> string
+
+  val version : t -> string
+
+  val documentation : t -> string option
+
+  val synopsis : t -> string option
+
+  val has_dependencies : t -> bool
+
+  val dependencies : t -> (t list, string) result Promise.t
+end
 
 type t
 
 val make : unit -> t option Promise.t
 
 type discover =
-  { file : Path.t
+  { manifest : Manifest.t
   ; status : (unit, string) result
   }
 
 val discover : dir:Path.t -> discover list Promise.t
 
-val find_manifest_in_dir : Path.t -> Path.t option Promise.t
+val find_manifest_in_dir : Path.t -> Manifest.t option Promise.t
 
-val exec : t -> manifest:Path.t -> args:string list -> Cmd.t
+val setup_sandbox : t -> Manifest.t -> unit Or_error.t Promise.t
 
-val setup_sandbox : t -> manifest:Path.t -> unit Or_error.t Promise.t
+(** {4 Working with packages} *)
 
+(** Return the list of installed packages in the given opam switch. *)
+val packages : t -> Manifest.t -> (Package.t list, string) result Promise.t
+
+(** Return the list of root packages in the given opam switch.
+
+    Root packages are packages that have been installed by the user, as opposed
+    to packages that have been installed as a dependency of another package. *)
+val root_packages : t -> Manifest.t -> (Package.t list, string) result Promise.t
+
+(** {4 General utilities} *)
+
+(** Execute an esy sub-command with in the given sandbox. *)
+val exec : t -> Manifest.t -> args:string list -> Cmd.t
+
+(** Check that two instances of [Esy] are equal. *)
 val equal : t -> t -> bool

--- a/src/extension_commands.ml
+++ b/src/extension_commands.ml
@@ -91,3 +91,5 @@ let register extension instance { id; handler } =
 
 let register_all_commands extension instance =
   List.iter ~f:(register extension instance) !commands
+
+let register id handler = command id handler |> ignore

--- a/src/extension_commands.ml
+++ b/src/extension_commands.ml
@@ -92,4 +92,6 @@ let register extension instance { id; handler } =
 let register_all_commands extension instance =
   List.iter ~f:(register extension instance) !commands
 
-let register id handler = command id handler |> ignore
+let register ~id handler =
+  let (_ : command) = command id handler in
+  ()

--- a/src/extension_commands.mli
+++ b/src/extension_commands.mli
@@ -31,4 +31,4 @@ val register_all_commands :
   Vscode.ExtensionContext.t -> Extension_instance.t -> unit
 
 val register :
-  Vscode.ExtensionContext.t -> Extension_instance.t -> command -> unit
+  string -> (Extension_instance.t -> args:Ojs.t list -> unit) -> unit

--- a/src/extension_commands.mli
+++ b/src/extension_commands.mli
@@ -31,4 +31,4 @@ val register_all_commands :
   Vscode.ExtensionContext.t -> Extension_instance.t -> unit
 
 val register :
-  string -> (Extension_instance.t -> args:Ojs.t list -> unit) -> unit
+  id:string -> (Extension_instance.t -> args:Ojs.t list -> unit) -> unit

--- a/src/extension_consts.ml
+++ b/src/extension_consts.ml
@@ -15,7 +15,17 @@ module Commands = struct
 
   let refresh_switches = ocaml_prefixed "refresh-switches"
 
-  let open_documentation = ocaml_prefixed "open-documentation"
+  let refresh_sandbox = ocaml_prefixed "refresh-sandbox"
+
+  let upgrade_sandbox = ocaml_prefixed "upgrade-sandbox"
+
+  let install_sandbox = ocaml_prefixed "install-sandbox"
+
+  let uninstall_sandbox_package = ocaml_prefixed "uninstall-sandbox-package"
+
+  let open_switches_documentation = ocaml_prefixed "open-switches-documentation"
+
+  let open_sandbox_documentation = ocaml_prefixed "open-sandbox-documentation"
 end
 
 (* TODO: Refactor the code so that we don't need any "constants" module *)

--- a/src/extension_instance.ml
+++ b/src/extension_instance.ml
@@ -118,7 +118,12 @@ let make () =
 
 let set_sandbox t new_sandbox =
   Sandbox_info.update t.sandbox_info ~new_sandbox;
-  t.sandbox <- new_sandbox
+  t.sandbox <- new_sandbox;
+  let (_ : Ojs.t option Promise.t) =
+    Vscode.Commands.executeCommand
+      ~command:Extension_consts.Commands.refresh_sandbox ~args:[]
+  in
+  ()
 
 let open_terminal sandbox =
   let terminal = Terminal_sandbox.create sandbox in

--- a/src/opam.mli
+++ b/src/opam.mli
@@ -1,17 +1,32 @@
+(** Provide an interface to Opam.
+
+    The functions in this module either use the result of opam commands, or use
+    the filesystem to get the state of opam configurations. *)
+
+(** An Opam switch *)
 module Switch : sig
   type t =
     | Local of Path.t
     | Named of string
 
+  (** {4 Constructors} *)
+
   val of_string : string -> t option
 
+  (** {4 Properties} *)
+
   val name : t -> string
+
+  (** {4 Utilities} *)
 
   val equal : t -> t -> bool
 end
 
+(** A package installed in an Opam switch *)
 module Package : sig
   type t
+
+  (** {4 Properties} *)
 
   val name : t -> string
 
@@ -21,32 +36,68 @@ module Package : sig
 
   val synopsis : t -> string option
 
-  val of_path : Path.t -> t option Promise.t
+  val has_dependencies : t -> bool
 
-  val sexp_of_t : t -> Sexplib.Sexp.t
-
-  val t_of_sexp : Sexplib.Sexp.t -> t
+  val dependencies : t -> (t list, string) result Promise.t
 end
 
 type t
 
 val make : unit -> t option Promise.t
 
+(** Install new packages in a switch *)
+val install : t -> Switch.t -> string list -> Cmd.t
+
+(** Update the opam repository *)
+val update : t -> Cmd.t
+
+(** Upgrade packages in a switch *)
+val upgrade : t -> Switch.t -> Cmd.t
+
+(* Remove a list of packages from a switch *)
+val remove : t -> Switch.t -> string list -> Cmd.t
+
+(** {4 Working with switches} *)
+
+(** Path of the switch on the filesystem.
+
+    If the switch is a local switch, the path is [switch_path ^ _opam],
+    otherwise it is the result of [opam var root]. *)
+val switch_path : t -> Switch.t -> (Path.t, string) result Promise.t
+
+(** List the opam switches available on the system. *)
 val switch_list : t -> Switch.t list Promise.t
 
+(** Checks that the given switch exists. *)
+val switch_exists : t -> Switch.t -> bool Promise.t
+
+(** Return the current opam switch. *)
 val switch_show : ?cwd:Path.t -> t -> Switch.t option Promise.t
 
-val exec : t -> switch:Switch.t -> args:string list -> Cmd.t
+(** Return the compiler version used by the given switch. *)
+val switch_compiler : t -> Switch.t -> string option Promise.t
 
-val exists : t -> switch:Switch.t -> bool Promise.t
+(** Remove the given switch by calling [opam switch remove]. *)
+val switch_remove : t -> Switch.t -> Cmd.t
 
+(** {4 Working with packages} *)
+
+(** Return the list of installed packages in the given opam switch. *)
+val packages : t -> Switch.t -> (Package.t list, string) result Promise.t
+
+(** Return the list of root packages in the given opam switch.
+
+    Root packages are packages that have been installed by the user, as opposed
+    to packages that have been installed as a dependency of another package. *)
+val root_packages : t -> Switch.t -> (Package.t list, string) result Promise.t
+
+(** Uninstall a package from a switch by calling [opam uninstall]. *)
+val package_remove : t -> Switch.t -> Package.t list -> Cmd.t
+
+(** {4 General utilities} *)
+
+(** Execute an opam sub-command with in the given switch. *)
+val exec : t -> Switch.t -> args:string list -> Cmd.t
+
+(** Check that two instances of [Opam] are equal. *)
 val equal : t -> t -> bool
-
-val get_switch_packages :
-  t -> Switch.t -> (Package.t list, string) result Promise.t
-
-val get_switch_compiler : t -> Switch.t -> string option Promise.t
-
-val remove_switch : t -> Switch.t -> Cmd.t
-
-val uninstall_package : t -> switch:Switch.t -> package:Package.t -> Cmd.t

--- a/src/path.ml
+++ b/src/path.ml
@@ -39,3 +39,5 @@ let parent x =
     None
   else
     Some (dirname x)
+
+let asset name = of_string (Node.__filename () ^ "/../../assets/" ^ name)

--- a/src/path.mli
+++ b/src/path.mli
@@ -33,3 +33,5 @@ val with_ext : t -> ext:string -> t
 val parent : t -> t option
 
 val is_root : t -> bool
+
+val asset : string -> t

--- a/src/sandbox.ml
+++ b/src/sandbox.ml
@@ -1,6 +1,11 @@
 open Import
 
 module Package = struct
+  (* TODO: this should be refactored. A list of package should be homogeneous,
+     so a variant is not a good type.
+
+     This is not too bad for now, as the type is not exposed in the interface,
+     and the constructions only happens in [packages] and [root_packages]. *)
   type t =
     | Opam of Opam.Package.t
     | Esy of Esy.Package.t

--- a/src/sandbox.ml
+++ b/src/sandbox.ml
@@ -1,21 +1,68 @@
 open Import
 
+module Package = struct
+  type t =
+    | Opam of Opam.Package.t
+    | Esy of Esy.Package.t
+
+  let of_opam opam_pkg = Opam opam_pkg
+
+  let of_esy opam_pkg = Esy opam_pkg
+
+  let name t =
+    match t with
+    | Opam pkg -> Opam.Package.name pkg
+    | Esy pkg -> Esy.Package.name pkg
+
+  let version t =
+    match t with
+    | Opam pkg -> Opam.Package.version pkg
+    | Esy pkg -> Esy.Package.version pkg
+
+  let synopsis t =
+    match t with
+    | Opam pkg -> Opam.Package.synopsis pkg
+    | Esy pkg -> Esy.Package.synopsis pkg
+
+  let documentation t =
+    match t with
+    | Opam pkg -> Opam.Package.documentation pkg
+    | Esy pkg -> Esy.Package.documentation pkg
+
+  let dependencies t =
+    match t with
+    | Opam pkg ->
+      let open Promise.Result.Syntax in
+      let+ deps = Opam.Package.dependencies pkg in
+      List.map deps ~f:of_opam
+    | Esy pkg ->
+      let open Promise.Result.Syntax in
+      let+ deps = Esy.Package.dependencies pkg in
+      List.map deps ~f:of_esy
+
+  let has_dependencies t =
+    match t with
+    | Opam pkg -> Opam.Package.has_dependencies pkg
+    | Esy pkg -> Esy.Package.has_dependencies pkg
+end
+
 type t =
   | Opam of Opam.t * Opam.Switch.t
-  | Esy of Esy.t * Path.t
+  | Esy of Esy.t * Esy.Manifest.t
   | Global
   | Custom of string
 
 let equal t1 t2 =
   match (t1, t2) with
   | Global, Global -> true
-  | Esy (e1, p1), Esy (e2, p2) -> Path.equal p1 p2 && Esy.equal e1 e2
+  | Esy (e1, p1), Esy (e2, p2) -> Esy.Manifest.equal p1 p2 && Esy.equal e1 e2
   | Opam (o1, s1), Opam (o2, s2) -> Opam.Switch.equal s1 s2 && Opam.equal o1 o2
   | Custom s1, Custom s2 -> String.equal s1 s2
   | _, _ -> false
 
 let to_string = function
-  | Esy (_, root) -> Printf.sprintf "esy(%s)" (Path.to_string root)
+  | Esy (_, root) ->
+    Printf.sprintf "esy(%s)" (Esy.Manifest.path root |> Path.to_string)
   | Opam (_, switch) -> Printf.sprintf "opam(%s)" (Opam.Switch.name switch)
   | Global -> "global"
   | Custom _ -> "custom"
@@ -25,7 +72,7 @@ let to_pretty_string t =
   let print_esy = Printf.sprintf "esy(%s)" in
   match t with
   | Esy (_, root) ->
-    let project_name = Path.basename root in
+    let project_name = Esy.Manifest.path root |> Path.basename in
     print_esy project_name
   | Opam (_, Named name) -> print_opam name
   | Opam (_, Local path) ->
@@ -78,7 +125,7 @@ end
 module Setting = struct
   type t =
     | Opam of Opam.Switch.t
-    | Esy of Path.t
+    | Esy of Esy.Manifest.t
     | Global
     | Custom of string
 
@@ -96,7 +143,9 @@ module Setting = struct
     | Global -> Global
     | Esy ->
       let manifest =
-        field "root" (fun js -> Path.of_string (decode_vars js)) json
+        field "root"
+          (fun js -> Path.of_string (decode_vars js) |> Esy.Manifest.of_path)
+          json
       in
       Esy manifest
     | Opam ->
@@ -117,7 +166,11 @@ module Setting = struct
     match t with
     | Global -> Jsonoo.Encode.object_ [ kind ]
     | Esy manifest ->
-      object_ [ kind; ("root", encode_vars @@ Path.to_string manifest) ]
+      object_
+        [ kind
+        ; ( "root"
+          , encode_vars @@ (manifest |> Esy.Manifest.path |> Path.to_string) )
+        ]
     | Opam switch ->
       object_ [ kind; ("switch", encode_vars @@ Opam.Switch.name switch) ]
     | Custom template -> object_ [ kind; ("template", string template) ]
@@ -159,7 +212,7 @@ let of_settings () : t option Promise.t =
       not_available `Opam;
       Promise.return None
     | Some opam ->
-      let+ exists = Opam.exists opam ~switch in
+      let+ exists = Opam.switch_exists opam switch in
       if exists then
         Some (Opam (opam, switch))
       else (
@@ -182,16 +235,15 @@ let detect_esy_sandbox ~project_root esy () =
       , Esy.find_manifest_in_dir project_root )
   in
   match (esy_build_dir_exists, manifest) with
-  | true, _
-  | _, Some _ ->
+  | true, Some manifest ->
     (* Esy can be used with [esy.json], [package.json], or without any of those.
        So we check if we find an [_esy] directory, which means the user created
        an Esy sandbox.
 
        If we don't, but there is an [esy.json] file, we can assume the user
        wants to use Esy. *)
-    Some (Esy (esy, project_root))
-  | false, None -> None
+    Some (Esy (esy, manifest))
+  | _ -> None
 
 let detect_opam_local_switch ~project_root opam () =
   let open Promise.Option.Syntax in
@@ -265,7 +317,8 @@ module Candidate = struct
       let project_name = Path.basename path in
       let project_path = Path.to_string path in
       create ~label:project_name ~detail:project_path ?description ()
-    | Esy (_, p) ->
+    | Esy (_, manifest) ->
+      let p = Esy.Manifest.path manifest in
       let project_name = Path.basename p in
       let project_path = Path.to_string p in
       create ~detail:project_path ~label:project_name ?description ()
@@ -311,10 +364,8 @@ let sandbox_candidates ~workspace_folders =
         |> Promise.all_list
       in
       List.concat esys
-      |> List.map ~f:(fun (manifest : Esy.discover) ->
-             { Candidate.sandbox = Esy (esy, manifest.file)
-             ; status = manifest.status
-             })
+      |> List.map ~f:(fun ({ manifest; status } : Esy.discover) ->
+             { Candidate.sandbox = Esy (esy, manifest); status })
   in
   let opam =
     let* opam = available.opam in
@@ -338,7 +389,7 @@ let sandbox_candidates ~workspace_folders =
 
 let setup_sandbox (kind : t) =
   match kind with
-  | Esy (esy, manifest) -> Esy.setup_sandbox esy ~manifest
+  | Esy (esy, manifest) -> Esy.setup_sandbox esy manifest
   | Opam _
   | Global
   | Custom _ ->
@@ -384,8 +435,8 @@ let select_sandbox_and_save () =
 
 let get_command sandbox bin args : Cmd.t =
   match sandbox with
-  | Opam (opam, switch) -> Opam.exec opam ~switch ~args:(bin :: args)
-  | Esy (esy, manifest) -> Esy.exec esy ~manifest ~args:(bin :: args)
+  | Opam (opam, switch) -> Opam.exec opam switch ~args:(bin :: args)
+  | Esy (esy, manifest) -> Esy.exec esy manifest ~args:(bin :: args)
   | Global -> Spawn { bin = Path.of_string bin; args }
   | Custom template ->
     let bin =
@@ -424,3 +475,148 @@ let run_setup sandbox =
        consider checking and suggesting installation for other tools: formatter,
        etc. *)
     Error (Printf.sprintf "Sandbox initialisation failed: %s" msg)
+
+let packages t =
+  let open Promise.Result.Syntax in
+  match t with
+  | Global -> Promise.Result.return []
+  | Custom _ -> Promise.Result.return []
+  | Esy (esy, manifest) ->
+    let+ r = Esy.packages esy manifest in
+    List.map r ~f:Package.of_esy
+  | Opam (opam, switch) ->
+    let+ r = Opam.packages opam switch in
+    List.map r ~f:Package.of_opam
+
+let root_packages t =
+  let open Promise.Result.Syntax in
+  match t with
+  | Global -> Promise.Result.return []
+  | Custom _ -> Promise.Result.return []
+  | Esy (esy, manifest) ->
+    let+ r = Esy.root_packages esy manifest in
+    List.map r ~f:Package.of_esy
+  | Opam (opam, switch) ->
+    let+ r = Opam.root_packages opam switch in
+    List.map r ~f:Package.of_opam
+
+let uninstall_packages t packages =
+  let options =
+    ProgressOptions.create ~location:(`ProgressLocation Notification)
+      ~title:"Uninstalling sandbox packages" ~cancellable:false ()
+  in
+  match t with
+  | Global ->
+    show_message `Error
+      "Uninstalling packages is not supported for Global sandboxes";
+    Promise.return ()
+  | Custom _ ->
+    show_message `Error
+      "Uninstalling packages is not supported for Custom sandboxes";
+    Promise.return ()
+  | Esy (_esy, _manifest) ->
+    (* TODO: Implement Esy sandbox inspection *)
+    show_message `Error
+      "Uninstalling packages is not supported for Esy sandboxes";
+    Promise.return ()
+  | Opam (opam, switch) ->
+    let opam_packages =
+      List.filter_map
+        ~f:(function
+          | Package.Esy _ -> None
+          | Opam pkg -> Some pkg)
+        packages
+    in
+    let task ~progress:_ ~token:_ =
+      let open Promise.Syntax in
+      let+ result =
+        let open Promise.Result.Syntax in
+        let+ _ = Opam.package_remove opam switch opam_packages |> Cmd.output in
+        ()
+      in
+      match result with
+      | Ok () -> Ojs.null
+      | Error err ->
+        show_message `Error
+          "An error occured while uninstalling the packages: %s" err;
+        Ojs.null
+    in
+    let open Promise.Syntax in
+    let+ _ = Vscode.Window.withProgress (module Ojs) ~options ~task in
+    ()
+
+let install_packages t packages =
+  let options =
+    ProgressOptions.create ~location:(`ProgressLocation Notification)
+      ~title:"Installing sandbox packages" ~cancellable:false ()
+  in
+  match t with
+  | Global ->
+    show_message `Error
+      "Installing packages is not supported for Global sandboxes";
+    Promise.return ()
+  | Custom _ ->
+    show_message `Error
+      "Installing packages is not supported for Custom sandboxes";
+    Promise.return ()
+  | Esy (_esy, _manifest) ->
+    (* TODO: Implement Esy sandbox inspection *)
+    show_message `Error "Installing packages is not supported for Esy sandboxes";
+    Promise.return ()
+  | Opam (opam, switch) ->
+    let task ~progress:_ ~token:_ =
+      let open Promise.Syntax in
+      let+ result =
+        let open Promise.Result.Syntax in
+        let* _ = Opam.update opam |> Cmd.output in
+        let+ _ = Opam.install opam switch packages |> Cmd.output in
+        ()
+      in
+      match result with
+      | Ok () -> Ojs.null
+      | Error err ->
+        show_message `Error "An error occured while installing the packages: %s"
+          err;
+        Ojs.null
+    in
+    let open Promise.Syntax in
+    let+ _ = Vscode.Window.withProgress (module Ojs) ~options ~task in
+    ()
+
+let upgrade_packages t =
+  let options =
+    ProgressOptions.create ~location:(`ProgressLocation Notification)
+      ~title:"Upgrading sandbox packages" ~cancellable:false ()
+  in
+  match t with
+  | Global ->
+    show_message `Error
+      "Upgrading packages is not supported for Global sandboxes";
+    Promise.return ()
+  | Custom _ ->
+    show_message `Error
+      "Upgrading packages is not supported for Custom sandboxes";
+    Promise.return ()
+  | Esy (_esy, _manifest) ->
+    (* TODO: Implement Esy sandbox inspection *)
+    show_message `Error "Upgrading packages is not supported for Esy sandboxes";
+    Promise.return ()
+  | Opam (opam, switch) ->
+    let task ~progress:_ ~token:_ =
+      let open Promise.Syntax in
+      let+ result =
+        let open Promise.Result.Syntax in
+        let* _ = Opam.update opam |> Cmd.output in
+        let+ _ = Opam.upgrade opam switch |> Cmd.output in
+        ()
+      in
+      match result with
+      | Ok () -> Ojs.null
+      | Error err ->
+        show_message `Error "An error occured while upgrading the packages: %s"
+          err;
+        Ojs.null
+    in
+    let open Promise.Syntax in
+    let+ _ = Vscode.Window.withProgress (module Ojs) ~options ~task in
+    ()

--- a/src/sandbox.mli
+++ b/src/sandbox.mli
@@ -1,7 +1,5 @@
-(** Sandbox.ml exposes functions that let us
-
-    1. Run initial checks in the environment looking for a reliable sandbox
-    ([Sandbox.init])
+(** Sandbox.ml exposes functions that let us 1. Run initial checks in the
+    environment looking for a reliable sandbox ([Sandbox.init])
 
     2. Run a setup that would setup the sandbox provided that basic requirements
     are met ([Sandbox.run_setup])
@@ -16,9 +14,25 @@
     performance, direct user to install missing tools etc). Having a single
     [Sandbox.make()], for instance, would not make it this flexible. *)
 
+module Package : sig
+  type t
+
+  val name : t -> string
+
+  val version : t -> string
+
+  val synopsis : t -> string option
+
+  val documentation : t -> string option
+
+  val has_dependencies : t -> bool
+
+  val dependencies : t -> (t list, string) result Promise.t
+end
+
 type t =
   | Opam of Opam.t * Opam.Switch.t
-  | Esy of Esy.t * Path.t
+  | Esy of Esy.t * Esy.Manifest.t
   | Global
   | Custom of string
 
@@ -65,3 +79,18 @@ val get_lsp_command : ?args:string list -> t -> Cmd.t
 
 (** Extract a dune command *)
 val get_dune_command : t -> string list -> Cmd.t
+
+(** The packages installed in the sandbox *)
+val packages : t -> (Package.t list, string) result Promise.t
+
+(** The packages that have been installed manually by the user in the sandbox *)
+val root_packages : t -> (Package.t list, string) result Promise.t
+
+(** Uninstall existing packages from the sandbox *)
+val uninstall_packages : t -> Package.t list -> unit Promise.t
+
+(** Install new packages in the sandbox *)
+val install_packages : t -> string list -> unit Promise.t
+
+(** Upgrade packages in the sandbox *)
+val upgrade_packages : t -> unit Promise.t

--- a/src/treeview_commands.ml
+++ b/src/treeview_commands.ml
@@ -1,9 +1,9 @@
-let select_sandbox_item ~extension_path =
+let select_sandbox_item =
   let icon =
     `LightDark
       Vscode.TreeItem.LightDarkIcon.
-        { light = `String (extension_path ^ "/assets/collection-light.svg")
-        ; dark = `String (extension_path ^ "/assets/collection-dark.svg")
+        { light = `String (Path.asset "collection-light.svg" |> Path.to_string)
+        ; dark = `String (Path.asset "collection-dark.svg" |> Path.to_string)
         }
   in
   let label =
@@ -18,12 +18,12 @@ let select_sandbox_item ~extension_path =
   Vscode.TreeItem.set_command item command;
   item
 
-let terminal_item ~extension_path =
+let terminal_item =
   let icon =
     `LightDark
       Vscode.TreeItem.LightDarkIcon.
-        { light = `String (extension_path ^ "/assets/terminal-light.svg")
-        ; dark = `String (extension_path ^ "/assets/terminal-dark.svg")
+        { light = `String (Path.asset "terminal-light.svg" |> Path.to_string)
+        ; dark = `String (Path.asset "terminal-dark.svg" |> Path.to_string)
         }
   in
   let label =
@@ -39,25 +39,18 @@ let terminal_item ~extension_path =
   Vscode.TreeItem.set_command item command;
   item
 
-let items ~extension_path =
-  [ select_sandbox_item ~extension_path; terminal_item ~extension_path ]
+let items = [ select_sandbox_item; terminal_item ]
 
-let getTreeItem ~extension_path:_ ~element = `Value element
+let getTreeItem ~element = `Value element
 
-let getChildren ~extension_path ?element () =
+let getChildren ?element () =
   match element with
-  | None -> `Value (Some (items ~extension_path))
+  | None -> `Value (Some items)
   | Some _ -> `Value (Some [])
 
 let register extension =
-  let extension_path = Vscode.ExtensionContext.extensionPath extension in
   let module TreeDataProvider = Vscode.TreeDataProvider.Make (Vscode.TreeItem) in
-  let treeDataProvider =
-    TreeDataProvider.create
-      ~getTreeItem:(getTreeItem ~extension_path)
-      ~getChildren:(getChildren ~extension_path)
-      ()
-  in
+  let treeDataProvider = TreeDataProvider.create ~getTreeItem ~getChildren () in
   let disposable =
     Vscode.Window.registerTreeDataProvider
       (module Vscode.TreeItem)

--- a/src/treeview_help.ml
+++ b/src/treeview_help.ml
@@ -1,9 +1,9 @@
-let discord_item ~extension_path =
+let discord_item =
   let icon =
     `LightDark
       Vscode.TreeItem.LightDarkIcon.
-        { light = `String (extension_path ^ "/assets/discord-light.svg")
-        ; dark = `String (extension_path ^ "/assets/discord-dark.svg")
+        { light = `String (Path.asset "discord-light.svg" |> Path.to_string)
+        ; dark = `String (Path.asset "discord-dark.svg" |> Path.to_string)
         }
   in
   let label =
@@ -21,12 +21,12 @@ let discord_item ~extension_path =
   Vscode.TreeItem.set_command item command;
   item
 
-let discuss_item ~extension_path =
+let discuss_item =
   let icon =
     `LightDark
       Vscode.TreeItem.LightDarkIcon.
-        { light = `String (extension_path ^ "/assets/chat-light.svg")
-        ; dark = `String (extension_path ^ "/assets/chat-dark.svg")
+        { light = `String (Path.asset "chat-light.svg" |> Path.to_string)
+        ; dark = `String (Path.asset "chat-dark.svg" |> Path.to_string)
         }
   in
   let label =
@@ -45,12 +45,12 @@ let discuss_item ~extension_path =
   Vscode.TreeItem.set_command item command;
   item
 
-let github_item ~extension_path =
+let github_item =
   let icon =
     `LightDark
       Vscode.TreeItem.LightDarkIcon.
-        { light = `String (extension_path ^ "/assets/github-light.svg")
-        ; dark = `String (extension_path ^ "/assets/github-dark.svg")
+        { light = `String (Path.asset "github-light.svg" |> Path.to_string)
+        ; dark = `String (Path.asset "github-dark.svg" |> Path.to_string)
         }
   in
   let label =
@@ -71,28 +71,18 @@ let github_item ~extension_path =
   Vscode.TreeItem.set_command item command;
   item
 
-let items ~extension_path =
-  [ discord_item ~extension_path
-  ; discuss_item ~extension_path
-  ; github_item ~extension_path
-  ]
+let items = [ discord_item; discuss_item; github_item ]
 
-let getTreeItem ~extension_path:_ ~element = `Value element
+let getTreeItem ~element = `Value element
 
-let getChildren ~extension_path ?element () =
+let getChildren ?element () =
   match element with
-  | None -> `Value (Some (items ~extension_path))
+  | None -> `Value (Some items)
   | Some _ -> `Value (Some [])
 
 let register extension =
-  let extension_path = Vscode.ExtensionContext.extensionPath extension in
   let module TreeDataProvider = Vscode.TreeDataProvider.Make (Vscode.TreeItem) in
-  let treeDataProvider =
-    TreeDataProvider.create
-      ~getTreeItem:(getTreeItem ~extension_path)
-      ~getChildren:(getChildren ~extension_path)
-      ()
-  in
+  let treeDataProvider = TreeDataProvider.create ~getTreeItem ~getChildren () in
   let disposable =
     Vscode.Window.registerTreeDataProvider
       (module Vscode.TreeItem)

--- a/src/treeview_sandbox.ml
+++ b/src/treeview_sandbox.ml
@@ -1,0 +1,198 @@
+open Import
+
+module Dependency = struct
+  type t = Sandbox.Package.t
+
+  let t_of_js : Ojs.t -> t = Obj.magic
+
+  let t_to_js : t -> Ojs.t = Obj.magic
+
+  let label t = Sandbox.Package.name t
+
+  let description t = Promise.return (Some (Sandbox.Package.version t))
+
+  let tooltip t = Sandbox.Package.synopsis t
+
+  let context_value t =
+    match Sandbox.Package.documentation t with
+    | Some _ -> "package-with-doc"
+    | None -> "package"
+
+  let icon _ =
+    TreeItem.LightDarkIcon.
+      { light = `String (Node.__filename () ^ "/../../assets/number-light.svg")
+      ; dark = `String (Node.__filename () ^ "/../../assets/number-dark.svg")
+      }
+
+  let collapsible_state t =
+    if Sandbox.Package.has_dependencies t then
+      TreeItemCollapsibleState.Collapsed
+    else
+      TreeItemCollapsibleState.None
+
+  let to_treeitem dependency =
+    let open Promise.Syntax in
+    let icon = `LightDark (icon dependency) in
+    let collapsibleState = collapsible_state dependency in
+    let label =
+      `TreeItemLabel (Vscode.TreeItemLabel.create ~label:(label dependency) ())
+    in
+    let item = Vscode.TreeItem.make_label ~label ~collapsibleState () in
+    Vscode.TreeItem.set_iconPath item icon;
+    TreeItem.set_contextValue item (context_value dependency);
+    let+ _ =
+      Promise.Option.iter
+        (fun desc -> TreeItem.set_description item (`String desc))
+        (description dependency)
+    in
+    Option.iter (tooltip dependency) ~f:(fun desc ->
+        TreeItem.set_tooltip item (`String desc));
+    item
+
+  let get_dependencies t =
+    let open Promise.Syntax in
+    let+ deps = Sandbox.Package.dependencies t in
+    match deps with
+    | Error _ -> None
+    | Ok packages -> Some packages
+end
+
+module Command = struct
+  let _open_documentation =
+    let handler (_ : Extension_instance.t) ~args =
+      let (_ : unit Promise.t) =
+        let arg = List.hd_exn args in
+        let dep = Dependency.t_of_js arg in
+        let open Promise.Syntax in
+        let doc = Sandbox.Package.documentation dep in
+        match doc with
+        | None -> Promise.return ()
+        | Some doc ->
+          let+ _ =
+            Vscode.Commands.executeCommand ~command:"vscode.open"
+              ~args:[ Vscode.Uri.parse doc () |> Vscode.Uri.t_to_js ]
+          in
+          ()
+      in
+      ()
+    in
+    Extension_commands.register
+      Extension_consts.Commands.open_sandbox_documentation handler
+
+  let _uninstall =
+    let handler (instance : Extension_instance.t) ~args =
+      let (_ : unit Promise.t) =
+        let arg = List.hd_exn args in
+        let dep = Dependency.t_of_js arg in
+        let open Promise.Syntax in
+        let sandbox = Extension_instance.sandbox instance in
+        let+ () = Sandbox.uninstall_packages sandbox [ dep ] in
+        let (_ : Ojs.t option Promise.t) =
+          Vscode.Commands.executeCommand
+            ~command:Extension_consts.Commands.refresh_switches ~args:[]
+        in
+        let (_ : Ojs.t option Promise.t) =
+          Vscode.Commands.executeCommand
+            ~command:Extension_consts.Commands.refresh_sandbox ~args:[]
+        in
+        ()
+      in
+      ()
+    in
+    Extension_commands.register
+      Extension_consts.Commands.uninstall_sandbox_package handler
+
+  let _upgrade =
+    let handler (instance : Extension_instance.t) ~args:_ =
+      let (_ : unit Promise.t) =
+        let open Promise.Syntax in
+        let sandbox = Extension_instance.sandbox instance in
+        let+ () = Sandbox.upgrade_packages sandbox in
+        let (_ : Ojs.t option Promise.t) =
+          Vscode.Commands.executeCommand
+            ~command:Extension_consts.Commands.refresh_switches ~args:[]
+        in
+        let (_ : Ojs.t option Promise.t) =
+          Vscode.Commands.executeCommand
+            ~command:Extension_consts.Commands.refresh_sandbox ~args:[]
+        in
+        ()
+      in
+      ()
+    in
+    Extension_commands.register Extension_consts.Commands.upgrade_sandbox
+      handler
+
+  let ask_packages () =
+    let options =
+      InputBoxOptions.create ~prompt:"Install Packages"
+        ~placeHolder:"Type the packages names, separated with a space" ()
+    in
+    Window.showInputBox ~options ()
+
+  let _install =
+    let handler (instance : Extension_instance.t) ~args:_ =
+      let (_ : unit Promise.t) =
+        let open Promise.Syntax in
+        let* package_str_opt = ask_packages () in
+        match package_str_opt with
+        | None -> Promise.return ()
+        | Some package_str ->
+          let sandbox = Extension_instance.sandbox instance in
+          let packages = String.split package_str ~on:' ' in
+          let+ () = Sandbox.install_packages sandbox packages in
+          let (_ : Ojs.t option Promise.t) =
+            Vscode.Commands.executeCommand
+              ~command:Extension_consts.Commands.refresh_switches ~args:[]
+          in
+          let (_ : Ojs.t option Promise.t) =
+            Vscode.Commands.executeCommand
+              ~command:Extension_consts.Commands.refresh_sandbox ~args:[]
+          in
+          ()
+      in
+      ()
+    in
+    Extension_commands.register Extension_consts.Commands.install_sandbox
+      handler
+end
+
+let getTreeItem ~element = `Promise (Dependency.to_treeitem element)
+
+let getChildren ~instance ?element () =
+  let sandbox = Extension_instance.sandbox instance in
+  match element with
+  | Some element -> `Promise (Dependency.get_dependencies element)
+  | None ->
+    let open Promise.Syntax in
+    let items =
+      let+ packages = Sandbox.root_packages sandbox in
+      match packages with
+      | Ok packages -> Some packages
+      | Error _ -> None
+    in
+    `Promise items
+
+let register extension instance =
+  let getChildren = getChildren ~instance in
+  let module EventEmitter =
+    Vscode.EventEmitter.Make (Interop.Js.Or_undefined (Dependency)) in
+  let event_emitter = EventEmitter.make () in
+  let event = EventEmitter.event event_emitter in
+  let module TreeDataProvider = Vscode.TreeDataProvider.Make (Dependency) in
+  let treeDataProvider =
+    TreeDataProvider.create ~getTreeItem ~getChildren ~onDidChangeTreeData:event
+      ()
+  in
+  let disposable =
+    Vscode.Window.registerTreeDataProvider
+      (module Dependency)
+      ~viewId:"ocaml-sandbox" ~treeDataProvider
+  in
+  ExtensionContext.subscribe extension ~disposable;
+
+  let disposable =
+    Commands.registerCommand ~command:Extension_consts.Commands.refresh_sandbox
+      ~callback:(fun ~args:_ -> EventEmitter.fire event_emitter None)
+  in
+  ExtensionContext.subscribe extension ~disposable

--- a/src/treeview_sandbox.ml
+++ b/src/treeview_sandbox.ml
@@ -20,8 +20,8 @@ module Dependency = struct
 
   let icon _ =
     TreeItem.LightDarkIcon.
-      { light = `String (Node.__filename () ^ "/../../assets/number-light.svg")
-      ; dark = `String (Node.__filename () ^ "/../../assets/number-dark.svg")
+      { light = `String (Path.asset "number-light.svg" |> Path.to_string)
+      ; dark = `String (Path.asset "number-dark.svg" |> Path.to_string)
       }
 
   let collapsible_state t =
@@ -77,7 +77,7 @@ module Command = struct
       ()
     in
     Extension_commands.register
-      Extension_consts.Commands.open_sandbox_documentation handler
+      ~id:Extension_consts.Commands.open_sandbox_documentation handler
 
   let _uninstall =
     let handler (instance : Extension_instance.t) ~args =
@@ -100,7 +100,7 @@ module Command = struct
       ()
     in
     Extension_commands.register
-      Extension_consts.Commands.uninstall_sandbox_package handler
+      ~id:Extension_consts.Commands.uninstall_sandbox_package handler
 
   let _upgrade =
     let handler (instance : Extension_instance.t) ~args:_ =
@@ -120,7 +120,7 @@ module Command = struct
       in
       ()
     in
-    Extension_commands.register Extension_consts.Commands.upgrade_sandbox
+    Extension_commands.register ~id:Extension_consts.Commands.upgrade_sandbox
       handler
 
   let ask_packages () =
@@ -153,7 +153,7 @@ module Command = struct
       in
       ()
     in
-    Extension_commands.register Extension_consts.Commands.install_sandbox
+    Extension_commands.register ~id:Extension_consts.Commands.install_sandbox
       handler
 end
 

--- a/src/treeview_sandbox.mli
+++ b/src/treeview_sandbox.mli
@@ -1,0 +1,2 @@
+(** Register the ocaml-sandbox tree view *)
+val register : Vscode.ExtensionContext.t -> Extension_instance.t -> unit

--- a/src/treeview_switches.ml
+++ b/src/treeview_switches.ml
@@ -35,15 +35,13 @@ module Dependency = struct
   let icon = function
     | Switch _ ->
       TreeItem.LightDarkIcon.
-        { light =
-            `String (Node.__filename () ^ "/../../assets/dependency-light.svg")
-        ; dark =
-            `String (Node.__filename () ^ "/../../assets/dependency-dark.svg")
+        { light = `String (Path.asset "dependency-light.svg" |> Path.to_string)
+        ; dark = `String (Path.asset "dependency-dark.svg" |> Path.to_string)
         }
     | Package _ ->
       TreeItem.LightDarkIcon.
-        { light = `String (Node.__filename () ^ "/../../assets/number-light.svg")
-        ; dark = `String (Node.__filename () ^ "/../../assets/number-dark.svg")
+        { light = `String (Path.asset "number-light.svg" |> Path.to_string)
+        ; dark = `String (Path.asset "number-dark.svg" |> Path.to_string)
         }
 
   let collapsible_state = function

--- a/src/treeview_switches.ml
+++ b/src/treeview_switches.ml
@@ -2,109 +2,110 @@ open Import
 
 module Dependency = struct
   type t =
-    | Switch of Opam.Switch.t
-    | Dependency of (Opam.Package.t * t option)
+    | Package : Opam.Package.t -> t
+    | Switch : Opam.t * Opam.Switch.t -> t
 
-  let rec sexp_of_t : t -> Sexp.t = function
-    | Switch (Named name) ->
-      List [ Atom "switch"; List [ Atom "named"; Atom name ] ]
-    | Switch (Local path) ->
-      let name = Path.to_string path in
-      List [ Atom "switch"; List [ Atom "local"; Atom name ] ]
-    | Dependency (package, None) ->
-      List
-        [ Atom "dependency"
-        ; List [ Atom "package"; Opam.Package.sexp_of_t package ]
-        ]
-    | Dependency (package, Some t) ->
-      List
-        [ Atom "dependency"
-        ; List [ Atom "package"; Opam.Package.sexp_of_t package ]
-        ; List [ Atom "parent"; sexp_of_t t ]
-        ]
+  let t_of_js : Ojs.t -> t = Obj.magic
 
-  let rec t_of_sexp : Sexp.t -> t = function
-    | List [ Atom "switch"; List [ Atom "named"; Atom name ] ] ->
-      Switch (Named name)
-    | List [ Atom "switch"; List [ Atom "local"; Atom name ] ] ->
-      let path = Path.of_string name in
-      Switch (Local path)
-    | List [ Atom "dependency"; List [ Atom "package"; package ] ] ->
-      Dependency (Opam.Package.t_of_sexp package, None)
-    | List
-        [ Atom "dependency"
-        ; List [ Atom "package"; package ]
-        ; List [ Atom "parent"; parent ]
-        ] ->
-      Dependency (Opam.Package.t_of_sexp package, Some (t_of_sexp parent))
-    | _ -> assert false
-
-  let to_string t = t |> sexp_of_t |> Sexp.to_string
-
-  let of_string s = s |> Sexp.of_string |> t_of_sexp
+  let t_to_js : t -> Ojs.t = Obj.magic
 
   let label = function
-    | Switch (Named name) -> name
-    | Switch (Local path) ->
+    | Switch (_, Named name) -> name
+    | Switch (_, Local path) ->
       let name = Path.to_string path in
       name
-    | Dependency (dep, _) -> Opam.Package.name dep
+    | Package dep -> Opam.Package.name dep
 
-  let description ~opam = function
-    | Dependency (dep, _) -> Promise.return (Some (Opam.Package.version dep))
-    | Switch switch -> Opam.get_switch_compiler opam switch
+  let description = function
+    | Switch (opam, switch) -> Opam.switch_compiler opam switch
+    | Package dep -> Promise.return (Some (Opam.Package.version dep))
 
   let tooltip = function
-    | Dependency (dep, _) -> Opam.Package.synopsis dep
-    | Switch (Named _) -> None
-    | Switch (Local _) -> None
+    | Switch (_, Named _) -> None
+    | Switch (_, Local _) -> None
+    | Package dep -> Opam.Package.synopsis dep
 
   let context_value = function
-    | Dependency (dep, _) -> (
+    | Switch _ -> "opam-switch"
+    | Package dep -> (
       match Opam.Package.documentation dep with
       | Some _ -> "package-with-doc"
       | None -> "package" )
-    | Switch _ -> "switch"
 
-  let icon ~extension_path = function
-    | Dependency _ ->
-      TreeItem.LightDarkIcon.
-        { light = `String (extension_path ^ "/assets/number-light.svg")
-        ; dark = `String (extension_path ^ "/assets/number-dark.svg")
-        }
+  let icon = function
     | Switch _ ->
       TreeItem.LightDarkIcon.
-        { light = `String (extension_path ^ "/assets/dependency-light.svg")
-        ; dark = `String (extension_path ^ "/assets/dependency-dark.svg")
+        { light =
+            `String (Node.__filename () ^ "/../../assets/dependency-light.svg")
+        ; dark =
+            `String (Node.__filename () ^ "/../../assets/dependency-dark.svg")
+        }
+    | Package _ ->
+      TreeItem.LightDarkIcon.
+        { light = `String (Node.__filename () ^ "/../../assets/number-light.svg")
+        ; dark = `String (Node.__filename () ^ "/../../assets/number-dark.svg")
         }
 
   let collapsible_state = function
-    | Dependency _ -> Vscode.TreeItemCollapsibleState.None
     | Switch _ -> Vscode.TreeItemCollapsibleState.Collapsed
+    | Package dep ->
+      if Opam.Package.has_dependencies dep then
+        TreeItemCollapsibleState.Collapsed
+      else
+        TreeItemCollapsibleState.None
+
+  let to_treeitem dependency =
+    let open Promise.Syntax in
+    let icon = `LightDark (icon dependency) in
+    let collapsibleState = collapsible_state dependency in
+    let label =
+      `TreeItemLabel (Vscode.TreeItemLabel.create ~label:(label dependency) ())
+    in
+    let item = Vscode.TreeItem.make_label ~label ~collapsibleState () in
+    Vscode.TreeItem.set_iconPath item icon;
+    TreeItem.set_contextValue item (context_value dependency);
+    let+ _ =
+      Promise.Option.iter
+        (fun desc -> TreeItem.set_description item (`String desc))
+        (description dependency)
+    in
+    Option.iter (tooltip dependency) ~f:(fun desc ->
+        TreeItem.set_tooltip item (`String desc));
+    item
+
+  let get_dependencies =
+    let open Promise.Syntax in
+    function
+    | Switch (opam, switch) -> (
+      let* packages = Opam.root_packages opam switch in
+      match packages with
+      | Ok packages ->
+        let names = packages |> List.map ~f:(fun n -> Package n) in
+        Promise.return (Some names)
+      | Error err ->
+        show_message `Info
+          "An error occured while reading the switch dependencies: %s" err;
+        Promise.return None )
+    | Package pkg -> (
+      let+ deps = Opam.Package.dependencies pkg in
+      match deps with
+      | Error _ -> None
+      | Ok packages -> Some (List.map ~f:(fun x -> Package x) packages) )
 end
 
 module Command = struct
-  let remove_switch ~args =
-    let (_ : unit Promise.t) =
-      let arg = List.hd_exn args in
-      let tree_item = TreeItem.t_of_js arg in
-      let dependency =
-        tree_item |> TreeItem.id |> Stdlib.Option.get |> Dependency.of_string
-      in
-      match dependency with
-      | Dependency _ ->
-        Promise.return
-        @@ show_message `Warn
-             "Cannot delete a switch from a package dependency."
-      | Switch switch -> (
-        let open Promise.Syntax in
-        let* opam_opt = Opam.make () in
-        match opam_opt with
-        | None ->
+  let _remove_switch =
+    let handler (_ : Extension_instance.t) ~args =
+      let (_ : unit Promise.t) =
+        let arg = List.hd_exn args in
+        let dep = Dependency.t_of_js arg in
+        match dep with
+        | Package _ ->
           Promise.return
-          @@ show_message `Warn "Opam could not be found on your system."
-        | Some opam -> (
-          let+ result = Opam.remove_switch opam switch |> Cmd.output in
+          @@ show_message `Warn "The selected item is not an opam switch."
+        | Switch (opam, switch) -> (
+          let open Promise.Syntax in
+          let+ result = Opam.switch_remove opam switch |> Cmd.output in
           match result with
           | Error err -> show_message `Error "%s" err
           | Ok _ ->
@@ -112,141 +113,70 @@ module Command = struct
               Vscode.Commands.executeCommand
                 ~command:Extension_consts.Commands.refresh_switches ~args:[]
             in
-            show_message `Info "The switch has been removed successfully." ) )
-    in
-    ()
-
-  let open_documentation ~args =
-    let (_ : unit Promise.t) =
-      let arg = List.hd_exn args in
-      let tree_item = TreeItem.t_of_js arg in
-      let dependency =
-        tree_item |> TreeItem.id |> Stdlib.Option.get |> Dependency.of_string
+            let (_ : Ojs.t option Promise.t) =
+              Vscode.Commands.executeCommand
+                ~command:Extension_consts.Commands.refresh_sandbox ~args:[]
+            in
+            show_message `Info "The switch has been removed successfully." )
       in
-      match dependency with
-      | Switch _ ->
-        Promise.return
-        @@ show_message `Warn "Cannot open documentation of a switch."
-      | Dependency (pkg, _) -> (
-        let open Promise.Syntax in
-        let doc = Opam.Package.documentation pkg in
-        match doc with
-        | None -> Promise.return ()
-        | Some doc ->
-          let+ _ =
-            Vscode.Commands.executeCommand ~command:"vscode.open"
-              ~args:[ Vscode.Uri.parse doc () |> Vscode.Uri.t_to_js ]
-          in
-          () )
+      ()
     in
-    ()
+    Extension_commands.register Extension_consts.Commands.remove_switch handler
+
+  let _open_documentation =
+    let handler (_ : Extension_instance.t) ~args =
+      let (_ : unit Promise.t) =
+        let arg = List.hd_exn args in
+        let dep = Dependency.t_of_js arg in
+        match dep with
+        | Switch _ ->
+          Promise.return
+          @@ show_message `Warn "Cannot open documentation of a switch."
+        | Package pkg -> (
+          let open Promise.Syntax in
+          let doc = Opam.Package.documentation pkg in
+          match doc with
+          | None -> Promise.return ()
+          | Some doc ->
+            let+ _ =
+              Vscode.Commands.executeCommand ~command:"vscode.open"
+                ~args:[ Vscode.Uri.parse doc () |> Vscode.Uri.t_to_js ]
+            in
+            () )
+      in
+      ()
+    in
+    Extension_commands.register
+      Extension_consts.Commands.open_switches_documentation handler
 end
 
-let make_item ~extension_path ~opam dependency =
-  let open Promise.Syntax in
-  let icon = `LightDark (Dependency.icon ~extension_path dependency) in
-  let collapsibleState = Dependency.collapsible_state dependency in
-  let label =
-    `TreeItemLabel
-      (Vscode.TreeItemLabel.create ~label:(Dependency.label dependency) ())
-  in
-  let item = Vscode.TreeItem.make_label ~label ~collapsibleState () in
-  TreeItem.set_id item (Dependency.to_string dependency);
-  TreeItem.set_iconPath item icon;
-  TreeItem.set_contextValue item (Dependency.context_value dependency);
-  let+ _ =
-    Promise.Option.iter
-      (fun desc -> TreeItem.set_description item (`String desc))
-      (Dependency.description ~opam dependency)
-  in
-  Option.iter (Dependency.tooltip dependency) ~f:(fun desc ->
-      TreeItem.set_tooltip item (`String desc));
-  item
+let getTreeItem ~element = `Promise (Dependency.to_treeitem element)
 
-let get_dependency_dependencies _dependency = Promise.return (Some [])
-
-let get_switch_dependencies opam switch =
-  let open Promise.Syntax in
-  let* packages = Opam.get_switch_packages opam switch in
-  match packages with
-  | Ok packages ->
-    let names =
-      packages
-      |> List.map ~f:(fun n ->
-             Dependency.Dependency (n, Some (Dependency.Switch switch)))
-    in
-    Promise.return (Some names)
-  | Error err ->
-    let* _ =
-      Vscode.Window.showInformationMessage
-        ~message:
-          (Printf.sprintf
-             "An error occured while reading the switch dependencies: %s" err)
-        ()
-    in
-    Promise.return None
-
-let get_dependencies ~opam ~extension_path element =
-  let open Promise.Syntax in
-  let dependency =
-    match Vscode.TreeItem.id element with
-    | None ->
-      (* This should never happen, the elements are always created with an ID. *)
-      assert false
-    | Some dep -> Dependency.of_string dep
-  in
-  let dependencies_opt_to_tree_items deps_opt =
-    let* deps_opt = deps_opt in
-    match deps_opt with
-    | None -> Promise.return None
-    | Some deps ->
-      let* items =
-        List.map deps ~f:(make_item ~opam ~extension_path) |> Promise.all_list
+let getChildren ?opam ?element () =
+  match (opam, element) with
+  | None, _ -> `Value None
+  | Some _, Some element -> `Promise (Dependency.get_dependencies element)
+  | Some opam, None ->
+    let open Promise.Syntax in
+    let items =
+      let+ switches = Opam.switch_list opam in
+      let items =
+        List.map ~f:(fun switch -> Dependency.Switch (opam, switch)) switches
       in
-      Promise.return (Some items)
-  in
-  match dependency with
-  | Dependency.Switch switch ->
-    let deps = get_switch_dependencies opam switch in
-    dependencies_opt_to_tree_items deps
-  | Dependency.Dependency dependency ->
-    let deps = get_dependency_dependencies dependency in
-    dependencies_opt_to_tree_items deps
+      Some items
+    in
+    `Promise items
 
 let register extension =
   let (_ : unit Promise.t) =
     let open Promise.Syntax in
-    let extension_path = Vscode.ExtensionContext.extensionPath extension in
     let+ opam = Opam.make () in
-    let getChildren ?element () =
-      match opam with
-      | None -> `Value None
-      | Some opam -> (
-        match element with
-        | Some element ->
-          `Promise (get_dependencies ~opam ~extension_path element)
-        | None ->
-          let items =
-            let* switches = Opam.switch_list opam in
-            let+ items =
-              Promise.List.filter_map
-                (fun switch ->
-                  let+ deps =
-                    make_item ~opam ~extension_path (Dependency.Switch switch)
-                  in
-                  Some deps)
-                switches
-            in
-            Some items
-          in
-          `Promise items )
-    in
-    let getTreeItem ~element = `Value element in
+    let getChildren = getChildren ?opam in
     let module EventEmitter =
-      Vscode.EventEmitter.Make (Interop.Js.Or_undefined (TreeItem)) in
+      Vscode.EventEmitter.Make (Interop.Js.Or_undefined (Dependency)) in
     let event_emitter = EventEmitter.make () in
     let event = EventEmitter.event event_emitter in
-    let module TreeDataProvider = Vscode.TreeDataProvider.Make (Vscode.TreeItem) in
+    let module TreeDataProvider = Vscode.TreeDataProvider.Make (Dependency) in
     let treeDataProvider =
       TreeDataProvider.create ~getTreeItem ~getChildren
         ~onDidChangeTreeData:event ()
@@ -254,21 +184,8 @@ let register extension =
 
     let disposable =
       Vscode.Window.registerTreeDataProvider
-        (module Vscode.TreeItem)
+        (module Dependency)
         ~viewId:"ocaml-switches" ~treeDataProvider
-    in
-    ExtensionContext.subscribe extension ~disposable;
-
-    let disposable =
-      Commands.registerCommand
-        ~command:Extension_consts.Commands.open_documentation
-        ~callback:Command.open_documentation
-    in
-    ExtensionContext.subscribe extension ~disposable;
-
-    let disposable =
-      Commands.registerCommand ~command:Extension_consts.Commands.remove_switch
-        ~callback:Command.remove_switch
     in
     ExtensionContext.subscribe extension ~disposable;
 

--- a/src/treeview_switches.ml
+++ b/src/treeview_switches.ml
@@ -121,7 +121,8 @@ module Command = struct
       in
       ()
     in
-    Extension_commands.register Extension_consts.Commands.remove_switch handler
+    Extension_commands.register ~id:Extension_consts.Commands.remove_switch
+      handler
 
   let _open_documentation =
     let handler (_ : Extension_instance.t) ~args =
@@ -147,7 +148,7 @@ module Command = struct
       ()
     in
     Extension_commands.register
-      Extension_consts.Commands.open_switches_documentation handler
+      ~id:Extension_consts.Commands.open_switches_documentation handler
 end
 
 let getTreeItem ~element = `Promise (Dependency.to_treeitem element)

--- a/src/vscode_ocaml_platform.ml
+++ b/src/vscode_ocaml_platform.ml
@@ -27,12 +27,13 @@ let activate (extension : ExtensionContext.t) =
   Dune_task_provider.register extension instance;
   Extension_commands.register_all_commands extension instance;
   Treeview_switches.register extension;
+  Treeview_sandbox.register extension instance;
   Treeview_commands.register extension;
   Treeview_help.register extension;
-  let sandbox = Sandbox.of_settings_or_detect () in
+  let sandbox_opt = Sandbox.of_settings_or_detect () in
   let (_ : unit Promise.t) =
-    let* sandbox = sandbox in
-    let is_fallback = Option.is_empty sandbox in
+    let* sandbox_opt = sandbox_opt in
+    let is_fallback = Option.is_empty sandbox_opt in
     if
       is_fallback
       (* if the sandbox we just set up is a fallback sandbox, we create a pop-up
@@ -48,8 +49,8 @@ let activate (extension : ExtensionContext.t) =
       Promise.return ()
   in
   let (_ : unit Promise.t) =
-    let* sandbox = sandbox in
-    let sandbox = Option.value sandbox ~default:Sandbox.Global in
+    let* sandbox_opt = sandbox_opt in
+    let sandbox = Option.value sandbox_opt ~default:Sandbox.Global in
     Extension_instance.set_sandbox instance sandbox;
     let+ () = Extension_instance.start_language_server instance in
     ()

--- a/vscode/vscode/vscode.ml
+++ b/vscode/vscode/vscode.ml
@@ -1062,7 +1062,7 @@ module ProgressLocation = struct
   type t =
     | SourceControl [@js 1]
     | Window [@js 10]
-    | Notification [@js 25]
+    | Notification [@js 15]
   [@@js.enum] [@@js]
 end
 
@@ -2041,13 +2041,6 @@ module TreeItem = struct
     [@@js.new "vscode.TreeItem"]
 
   val make_resource :
-       resourceUri:Uri.t
-    -> ?collapsibleState:TreeItemCollapsibleState.t
-    -> unit
-    -> t
-    [@@js.new "vscode.TreeItem"]
-
-  val of_uri :
        resourceUri:Uri.t
     -> ?collapsibleState:TreeItemCollapsibleState.t
     -> unit

--- a/vscode/vscode/vscode.mli
+++ b/vscode/vscode/vscode.mli
@@ -1649,12 +1649,6 @@ module TreeItem : sig
     -> unit
     -> t
 
-  val of_uri :
-       resourceUri:Uri.t
-    -> ?collapsibleState:TreeItemCollapsibleState.t
-    -> unit
-    -> t
-
   val label : t -> label option
 
   val set_label : t -> label -> unit


### PR DESCRIPTION
This PR adds a sandbox view to the OCaml activity tab.

It builds on top of https://github.com/ocamllabs/vscode-ocaml-platform/pull/497 to provide a cleaner implementation of the treeview using the functorized VSCode bindings.

Where the Opam Switch view displays a list of switches on the user system and the opam packages in each of them, the Sandbox view displays the list of packages installed in the currently selected sandbox.

![image](https://user-images.githubusercontent.com/6162008/105163581-63fe0f00-5b14-11eb-8af0-7f1878e98398.png)

## Switch view

In addition to the Sandbox view, the following changes have been implemented on the Opam Switch view:

- The direct descendants of the switch are now the "root" packages: the packages that have been installed by the user manually.
- The packages now list their own dependencies

## Sandbox view

The sandbox view displays the package the same way as the Opam Switch one, that is, the top-level items are the root packages of the sandbox, and each package lists its own dependencies.

The view also provides the following features:

- Uninstalling a package
- Opening documentation for a package
- Upgrading the packages of the sandbox
- Installing packages (the command will open an input box to prompt the user the list of packages to install)
- Refreshing the view

## Esy support

The Sandbox view only supports Opam sandboxes for now. It'd be nice to support Esy sandboxes as well, so I implemented the boilerplate and let TODOs (`TODO: Implement Esy sandbox inspection`) in the code to identify the pieces we need to implement to support Esy.

Here are the things that need to be implemented:

- Read the list of `root` packages (the ones installed by the user directly)
- Read the list of all installed packages
- Command to upgrade package
- Command to install packages
- Command to remove packages
- For each package, read:
  - The name
  - The version
  - The documentation
  - The synopsis
  - The dependencies

cc @andreypopp @ManasJayanth - Not sure if that's something you'd be willing to contribute? If not, some pointers on how you think the above should be implemented would be greatly appreciated (especially the package discovery part, the format of the lock files and where the packages are stored is a bit confusing to me).

## Next

With this PR in, we have almost all the features we talked about regarding the UI and the interaction with Opam.

If we're happy with it, we could release it and let users provide feedback on what they would like to see.

If we're not quite satisfied with it yet, it'd be nice to identify the blockers. I have the following list of remaining features, but they don't seem critical:

- Display packages that can be upgraded
- Pin/unpin packages
- New project if empty

@rgrinberg what do you think, any blockers for a release?

cc @avsm since you were enthusiastic about having a UI for Opam in VSCode - is there anything you would have liked that is not in there?
