### PR TITLE
Fix switch impl intf twice

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,12 +1,15 @@
 # Change Log
 
-# Unreleased
+## Unreleased
 
 - Highlight token aliases in Menhir associativity declarations (#473)
+
 - Activate the extension when workspace contains OCaml, Reason sources or
   project marker files. (#482)
+
 - Add `ocaml.useOcamlEnv` setting to determine whether to use `ocaml-env` for
   opam commands from OCaml for Windows (#481)
+
 - Fix terminal creation when using default shell and arguments (#484)
 
 - Add an OCaml activity tab.
@@ -15,6 +18,11 @@
   commands and an Help and Feedback section with links to community channels.
 
 - Support `eliom` and `eliomi` file extensions (#487)
+
+- Fix ocaml/ocaml-lsp#358: automatic insertion of an inferred interface was
+  inserting code incorrectly on the second switch to the newly created (unsaved)
+  `mli` file. If the new `mli` file isn't empty, we don't insert inferred
+  interface (#498)
 
 ## 1.5.1
 

--- a/src/switch_impl_intf.ml
+++ b/src/switch_impl_intf.ml
@@ -61,8 +61,8 @@ let request_switch client document =
   | [] ->
     (* 'ocamllsp/switchImplIntf' command's response array cannot be empty *)
     assert false
-  | [ filepath ] -> (
-    let* result = show_file filepath in
+  | [ file_uri ] -> (
+    let* result = show_file file_uri in
     match result with
     | editor, true -> insert_inferred_intf source_uri client editor
     | _ -> Promise.return () )

--- a/src/switch_impl_intf.ml
+++ b/src/switch_impl_intf.ml
@@ -44,7 +44,7 @@ let show_file target_uri =
          ~fulfilled:(fun doc -> Promise.return (doc, false))
          ~rejected:(fun (_ : Promise.error) ->
            (* if file does not exist *)
-           let create_file_uri = Uri.with_ uri ~scheme:"untitled" () in
+           let create_file_uri = Uri.with_ uri ~scheme:`Untitled () in
            let+ doc = Workspace.openTextDocument (`Uri create_file_uri) in
            (doc, true))
   in

--- a/src/switch_impl_intf.ml
+++ b/src/switch_impl_intf.ml
@@ -16,13 +16,13 @@ let send_infer_intf_request client uri : string Promise.t =
   in
   Jsonoo.Decode.string response
 
-let insert_inferred_intf source_uri client editor =
+let insert_inferred_intf ~source_uri client text_editor =
   let open Promise.Syntax in
   if String.is_suffix source_uri ~suffix:".ml" then
     (* If the source file was a .ml, infer the interface *)
     let+ inferred_intf = send_infer_intf_request client source_uri in
     let (_ : bool Promise.t) =
-      TextEditor.edit editor
+      TextEditor.edit text_editor
         ~callback:(fun ~editBuilder ->
           TextEditorEdit.insert editBuilder
             ~location:(Position.make ~line:1 ~character:1)
@@ -33,39 +33,45 @@ let insert_inferred_intf source_uri client editor =
   else
     Promise.return ()
 
-(* given a file uri, opens the file if it exists; otherwise, creates the file
-   but doesn't write it to disk *)
-let show_file target_uri =
+(** given a file uri, opens the file if it exists; otherwise, creates the file
+    in "draft" mode (doesn't save it on disk)
+
+    @return TextEditor.t in which the document was opened *)
+let open_file_in_text_editor target_uri =
   let open Promise.Syntax in
   let uri = Uri.parse target_uri () in
-  let* doc, new_file =
+  let* doc =
     Workspace.openTextDocument (`Uri uri)
-    |> Promise.then_
-         ~fulfilled:(fun doc -> Promise.return (doc, false))
-         ~rejected:(fun (_ : Promise.error) ->
+    |> Promise.catch ~rejected:(fun (_ : Promise.error) ->
            (* if file does not exist *)
            let create_file_uri = Uri.with_ uri ~scheme:`Untitled () in
            let+ doc = Workspace.openTextDocument (`Uri create_file_uri) in
-           (doc, true))
+           doc)
   in
-  let+ editor = Window.showTextDocument ~document:(`TextDocument doc) () in
-  (editor, new_file)
+  let+ text_editor = Window.showTextDocument ~document:(`TextDocument doc) () in
+  text_editor
 
 let request_switch client document =
   let open Promise.Syntax in
   let source_uri =
     Uri.toString (TextDocument.uri document) ~skipEncoding:true ()
   in
+  let fill_intf_if_empty_untitled text_editor =
+    let doc = TextEditor.document text_editor in
+    let is_empty_doc doc = TextDocument.getText doc () |> String.is_empty in
+    if TextDocument.isUntitled doc && is_empty_doc doc then
+      insert_inferred_intf ~source_uri client text_editor
+    else
+      Promise.return ()
+  in
   let* arr = send_switch_impl_intf_request client source_uri in
   match Array.to_list arr with
   | [] ->
     (* 'ocamllsp/switchImplIntf' command's response array cannot be empty *)
     assert false
-  | [ file_uri ] -> (
-    let* result = show_file file_uri in
-    match result with
-    | editor, true -> insert_inferred_intf source_uri client editor
-    | _ -> Promise.return () )
+  | [ file_uri ] ->
+    let* text_editor = open_file_in_text_editor file_uri in
+    fill_intf_if_empty_untitled text_editor
   | first_candidate :: other_candidates as candidates -> (
     let first_candidate_item =
       QuickPickItem.create
@@ -95,8 +101,6 @@ let request_switch client document =
     in
     match choice with
     | None -> Promise.return ()
-    | Some filepath -> (
-      let* result = show_file filepath in
-      match result with
-      | editor, true -> insert_inferred_intf source_uri client editor
-      | _ -> Promise.return () ) )
+    | Some file_uri ->
+      let* text_editor = open_file_in_text_editor file_uri in
+      fill_intf_if_empty_untitled text_editor )

--- a/vscode/vscode/vscode.ml
+++ b/vscode/vscode/vscode.ml
@@ -189,7 +189,8 @@ module Uri = struct
 
   let with_ this ?scheme ?authority ?path ?query ?fragment () =
     let change = Ojs.obj [||] in
-    iter_set change "scheme" [%js.of: string] scheme;
+    iter_set change "scheme" [%js.of: string]
+      (Option.map Scheme.to_string scheme);
     iter_set change "authority" [%js.of: string] authority;
     iter_set change "path" [%js.of: string] path;
     iter_set change "query" [%js.of: string] query;

--- a/vscode/vscode/vscode.ml
+++ b/vscode/vscode/vscode.ml
@@ -151,6 +151,18 @@ module TextEdit = struct
 end
 
 module Uri = struct
+  module Scheme = struct
+    type t =
+      [ `File
+      | `Untitled
+        (** URI scheme used by vscode for new draft (not-saved) files *)
+      ]
+
+    let to_string = function
+      | `File -> "file"
+      | `Untitled -> "untitled"
+  end
+
   type t = private (* class *) Ojs.t [@@js]
 
   val parse : string -> ?strict:bool -> unit -> t

--- a/vscode/vscode/vscode.mli
+++ b/vscode/vscode/vscode.mli
@@ -1,5 +1,3 @@
-val version : string
-
 module Disposable : sig
   type t
 
@@ -164,6 +162,16 @@ module TextEdit : sig
 end
 
 module Uri : sig
+  module Scheme : sig
+    type t =
+      [ `File
+      | `Untitled
+        (** URI scheme used by vscode for new draft (not-saved) files *)
+      ]
+
+    val to_string : t -> string
+  end
+
   type t
 
   val parse : string -> ?strict:bool -> unit -> t

--- a/vscode/vscode/vscode.mli
+++ b/vscode/vscode/vscode.mli
@@ -1,3 +1,5 @@
+val version : string
+
 module Disposable : sig
   type t
 

--- a/vscode/vscode/vscode.mli
+++ b/vscode/vscode/vscode.mli
@@ -194,7 +194,7 @@ module Uri : sig
 
   val with_ :
        t
-    -> ?scheme:string
+    -> ?scheme:Scheme.t
     -> ?authority:string
     -> ?path:string
     -> ?query:string


### PR DESCRIPTION
* Fixes https://github.com/ocaml/ocaml-lsp/issues/358 

The PR provides a _quick_ fix. If the new mli file isn't empty, we don't insert inferred interface. 
Not sure whether it is better to replace the contents with the (potentially new) interface or maybe show a diff window with new interface. 

* Adds more structured support for URI schemes
* Improves 'Switch_impl_intf.show_file' by refactoring, renaming, and removing redundant value returned 

---

Reviewing commit by commit should be easiest.

