### PR TITLE
New command: open "current" 'dune' file 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,11 @@
   `mli` file. If the new `mli` file isn't empty, we don't insert inferred
   interface (#498)
 
+- Add a new command "Dune: open current dune file", which is available in the command
+  palette if an ocaml-related (ocaml, reason, etc.) file is currently open. The command
+  opens the dune file that is located in the same folder as the open file or creates the
+  dune file in a draft mode (not yet saved on the disk). (#499)
+
 ## 1.5.1
 
 - Improve highlighting of type parameters and `module type of` (#461)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,10 +24,11 @@
   `mli` file. If the new `mli` file isn't empty, we don't insert inferred
   interface (#498)
 
-- Add a new command "Dune: open current dune file", which is available in the command
-  palette if an ocaml-related (ocaml, reason, etc.) file is currently open. The command
-  opens the dune file that is located in the same folder as the open file or creates the
-  dune file in a draft mode (not yet saved on the disk). (#499)
+- Add a new command "Dune: open current dune file", which is available in the
+  command palette if an ocaml-related (ocaml, reason, etc.) file is currently
+  open. The command opens the dune file that is located in the same folder as
+  the open file or creates the dune file in a draft mode (not yet saved on the
+  disk). (#499)
 
 ## 1.5.1
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,10 +25,9 @@
   interface (#498)
 
 - Add a new command "Dune: open current dune file", which is available in the
-  command palette if an ocaml-related (ocaml, reason, etc.) file is currently
-  open. The command opens the dune file that is located in the same folder as
-  the open file or creates the dune file in a draft mode (not yet saved on the
-  disk). (#499)
+  command palette if there is an open file. The command opens the dune file that
+  is located in the same folder as the open file or creates the dune file in a
+  draft mode (not yet saved on the disk). (#499)
 
 ## 1.5.1
 

--- a/README.md
+++ b/README.md
@@ -114,7 +114,7 @@ You can execute it by entering the following command at the command palette
 MacOS).
 
 | Name                         | Description                                 | Keyboard Shortcuts | Menu Contents |
-| ---------------------------- | ----------------------------------          | ------------------ | ------------- |
+| ---------------------------- | ------------------------------------------- | ------------------ | ------------- |
 | `ocaml.select-sandbox`       | Select sandbox for this workspace           |                    |               |
 | `ocaml.server.restart`       | Restart language server                     |                    |               |
 | `ocaml.open-terminal`        | Open a terminal (current sandbox)           |                    |               |

--- a/README.md
+++ b/README.md
@@ -113,12 +113,13 @@ You can execute it by entering the following command at the command palette
 <kbd>Ctrl</kbd>+<kbd>P</kbd> (<kbd>Cmd</kbd>+<kbd>Shift</kbd>+<kbd>P</kbd> on
 MacOS).
 
-| Name                         | Description                        | Keyboard Shortcuts | Menu Contents |
-| ---------------------------- | ---------------------------------- | ------------------ | ------------- |
-| `ocaml.select-sandbox`       | Select sandbox for this workspace  |                    |               |
-| `ocaml.server.restart`       | Restart language server            |                    |               |
-| `ocaml.open-terminal`        | Open a terminal (current sandbox)  |                    |               |
-| `ocaml.open-terminal-select` | Open a terminal (select a sandbox) |                    |               |
+| Name                         | Description                                 | Keyboard Shortcuts | Menu Contents |
+| ---------------------------- | ----------------------------------          | ------------------ | ------------- |
+| `ocaml.select-sandbox`       | Select sandbox for this workspace           |                    |               |
+| `ocaml.server.restart`       | Restart language server                     |                    |               |
+| `ocaml.open-terminal`        | Open a terminal (current sandbox)           |                    |               |
+| `ocaml.open-terminal-select` | Open a terminal (select a sandbox)          |                    |               |
+| `ocaml.current-dune-file`    | Open Dune File (located in the same folder) |                    |               |
 
 ## Requirements
 

--- a/package.json
+++ b/package.json
@@ -183,7 +183,7 @@
       {
         "command": "dune.current-dune-file",
         "category": "Dune",
-        "title": "Open current dune file"
+        "title": "Open Dune File (located in the same folder)"
       }
     ],
     "keybindings": [
@@ -213,7 +213,7 @@
       "commandPalette": [
         {
           "command": "dune.current-dune-file",
-          "when": "editorLangId  == ocaml || editorLangId  == ocaml.interface || editorLangId == reason || editorLangId == ocaml.ocamllex || editorLangId == ocaml.menhir"
+          "when": "editorIsOpen"
         },
         {
           "command": "ocaml.refresh-switches",

--- a/package.json
+++ b/package.json
@@ -207,21 +207,6 @@
     "menus": {
       "commandPalette": [
         {
-          "command": "ocaml.select-sandbox"
-        },
-        {
-          "command": "ocaml.server.restart"
-        },
-        {
-          "command": "ocaml.open-terminal"
-        },
-        {
-          "command": "ocaml.open-terminal-select"
-        },
-        {
-          "command": "ocaml.switch-impl-intf"
-        },
-        {
           "command": "ocaml.refresh-switches",
           "when": "false"
         },

--- a/package.json
+++ b/package.json
@@ -179,6 +179,11 @@
           "light": "assets/document-search-light.svg",
           "dark": "assets/document-search-dark.svg"
         }
+      },
+      {
+        "command": "dune.current-dune-file",
+        "category": "Dune",
+        "title": "Open current dune file"
       }
     ],
     "keybindings": [
@@ -206,6 +211,10 @@
     ],
     "menus": {
       "commandPalette": [
+        {
+          "command": "dune.current-dune-file",
+          "when": "editorLangId  == ocaml || editorLangId  == ocaml.interface || editorLangId == reason || editorLangId == ocaml.ocamllex || editorLangId == ocaml.menhir"
+        },
         {
           "command": "ocaml.refresh-switches",
           "when": "false"

--- a/package.json
+++ b/package.json
@@ -181,8 +181,8 @@
         }
       },
       {
-        "command": "dune.current-dune-file",
-        "category": "Dune",
+        "command": "ocaml.current-dune-file",
+        "category": "OCaml",
         "title": "Open Dune File (located in the same folder)"
       }
     ],
@@ -212,7 +212,7 @@
     "menus": {
       "commandPalette": [
         {
-          "command": "dune.current-dune-file",
+          "command": "ocaml.current-dune-file",
           "when": "editorIsOpen"
         },
         {

--- a/src/extension_commands.ml
+++ b/src/extension_commands.ml
@@ -90,8 +90,8 @@ module Dune_commands = struct
       match Vscode.Window.activeTextEditor () with
       | None ->
         assert false
-        (* this command is available in the command palette only when a
-           ocaml/reason/mehnir/ocamllex files are open *)
+        (* this command is available (in the command) palette only when a file
+           is open *)
       | Some text_editor ->
         let doc = TextEditor.document text_editor in
         let uri = TextDocument.uri doc in

--- a/src/extension_commands.ml
+++ b/src/extension_commands.ml
@@ -96,11 +96,14 @@ module Dune_commands = struct
         let doc = TextEditor.document text_editor in
         let uri = TextDocument.uri doc in
         let dune_file_uri =
-          Uri.fsPath uri |> Path.of_string |> fun path ->
-          Path.relative path "../dune" |> Path.to_string |> Uri.file
-          |> fun uri -> Uri.toString uri ()
+          let path = Uri.fsPath uri |> Path.of_string in
+          let uri =
+            Path.relative path "../dune" |> Path.to_string |> Uri.file
+          in
+          Uri.toString uri ()
         in
-        open_file_in_text_editor dune_file_uri |> ignore
+        (open_file_in_text_editor dune_file_uri : TextEditor.t Promise.t)
+        |> ignore
     in
     command Extension_consts.Commands.Dune.open_current_dune_file handler
 end

--- a/src/extension_commands.ml
+++ b/src/extension_commands.ml
@@ -84,31 +84,27 @@ let switch_impl_intf =
   in
   command Extension_consts.Commands.switch_impl_intf handler
 
-module Dune_commands = struct
-  let open_current_dune_file =
-    let handler (_instance : Extension_instance.t) ~args:_ =
-      match Vscode.Window.activeTextEditor () with
-      | None ->
-        assert false
-        (* this command is available (in the command) palette only when a file
-           is open *)
-      | Some text_editor ->
-        let doc = TextEditor.document text_editor in
-        let uri = TextDocument.uri doc in
-        let dune_file_uri =
-          let path = Uri.fsPath uri |> Path.of_string in
-          let uri =
-            Path.relative path "../dune" |> Path.to_string |> Uri.file
-          in
-          Uri.toString uri ()
-        in
-        let (_ : TextEditor.t Promise.t) =
-          open_file_in_text_editor dune_file_uri
-        in
-        ()
-    in
-    command Extension_consts.Commands.Dune.open_current_dune_file handler
-end
+let open_current_dune_file =
+  let handler (_instance : Extension_instance.t) ~args:_ =
+    match Vscode.Window.activeTextEditor () with
+    | None ->
+      assert false
+      (* this command is available (in the command palette) only when a file is
+         open *)
+    | Some text_editor ->
+      let doc = TextEditor.document text_editor in
+      let uri = TextDocument.uri doc in
+      let dune_file_uri =
+        let path = Uri.fsPath uri |> Path.of_string in
+        let uri = Path.relative path "../dune" |> Path.to_string |> Uri.file in
+        Uri.toString uri ()
+      in
+      let (_ : TextEditor.t Promise.t) =
+        open_file_in_text_editor dune_file_uri
+      in
+      ()
+  in
+  command Extension_consts.Commands.open_current_dune_file handler
 
 let register extension instance { id; handler } =
   let callback = handler instance in

--- a/src/extension_commands.ml
+++ b/src/extension_commands.ml
@@ -88,9 +88,12 @@ let open_current_dune_file =
   let handler (_instance : Extension_instance.t) ~args:_ =
     match Vscode.Window.activeTextEditor () with
     | None ->
-      assert false
       (* this command is available (in the command palette) only when a file is
          open *)
+      show_message `Error
+        "The command \"OCaml: Open Dune File\" should be run only with a file \
+         open in the editor, so the command can look for a dune file in the \
+         same folder as the open file."
     | Some text_editor ->
       let doc = TextEditor.document text_editor in
       let uri = TextDocument.uri doc in

--- a/src/extension_commands.ml
+++ b/src/extension_commands.ml
@@ -84,6 +84,27 @@ let switch_impl_intf =
   in
   command Extension_consts.Commands.switch_impl_intf handler
 
+module Dune_commands = struct
+  let open_current_dune_file =
+    let handler (_instance : Extension_instance.t) ~args:_ =
+      match Vscode.Window.activeTextEditor () with
+      | None ->
+        assert false
+        (* this command is available in the command palette only when a
+           ocaml/reason/mehnir/ocamllex files are open *)
+      | Some text_editor ->
+        let doc = TextEditor.document text_editor in
+        let uri = TextDocument.uri doc in
+        let dune_file_uri =
+          Uri.fsPath uri |> Path.of_string |> fun path ->
+          Path.relative path "../dune" |> Path.to_string |> Uri.file
+          |> fun uri -> Uri.toString uri ()
+        in
+        open_file_in_text_editor dune_file_uri |> ignore
+    in
+    command Extension_consts.Commands.Dune.open_current_dune_file handler
+end
+
 let register extension instance { id; handler } =
   let callback = handler instance in
   let disposable = Commands.registerCommand ~command:id ~callback in

--- a/src/extension_commands.ml
+++ b/src/extension_commands.ml
@@ -102,8 +102,10 @@ module Dune_commands = struct
           in
           Uri.toString uri ()
         in
-        (open_file_in_text_editor dune_file_uri : TextEditor.t Promise.t)
-        |> ignore
+        let (_ : TextEditor.t Promise.t) =
+          open_file_in_text_editor dune_file_uri
+        in
+        ()
     in
     command Extension_consts.Commands.Dune.open_current_dune_file handler
 end

--- a/src/extension_commands.mli
+++ b/src/extension_commands.mli
@@ -24,6 +24,10 @@ val open_terminal : command
 
 val switch_impl_intf : command
 
+module Dune_commands : sig
+  val open_current_dune_file : command
+end
+
 (** Registers commands with vscode. Should be called in
     [Vscode_ocaml_platform.activate]. It subscribes the disposables to the
     extension context provided. *)

--- a/src/extension_commands.mli
+++ b/src/extension_commands.mli
@@ -24,9 +24,7 @@ val open_terminal : command
 
 val switch_impl_intf : command
 
-module Dune_commands : sig
-  val open_current_dune_file : command
-end
+val open_current_dune_file : command
 
 (** Registers commands with vscode. Should be called in
     [Vscode_ocaml_platform.activate]. It subscribes the disposables to the

--- a/src/extension_consts.ml
+++ b/src/extension_consts.ml
@@ -1,5 +1,7 @@
 let ocaml_prefixed key = "ocaml." ^ key
 
+let dune_prefixed key = "dune." ^ key
+
 module Commands = struct
   let select_sandbox = ocaml_prefixed "select-sandbox"
 
@@ -26,6 +28,10 @@ module Commands = struct
   let open_switches_documentation = ocaml_prefixed "open-switches-documentation"
 
   let open_sandbox_documentation = ocaml_prefixed "open-sandbox-documentation"
+
+  module Dune = struct
+    let open_current_dune_file = dune_prefixed "current-dune-file"
+  end
 end
 
 (* TODO: Refactor the code so that we don't need any "constants" module *)

--- a/src/extension_consts.ml
+++ b/src/extension_consts.ml
@@ -27,9 +27,7 @@ module Commands = struct
 
   let open_sandbox_documentation = ocaml_prefixed "open-sandbox-documentation"
 
-  module Dune = struct
-    let open_current_dune_file = ocaml_prefixed "current-dune-file"
-  end
+  let open_current_dune_file = ocaml_prefixed "current-dune-file"
 end
 
 (* TODO: Refactor the code so that we don't need any "constants" module *)

--- a/src/extension_consts.ml
+++ b/src/extension_consts.ml
@@ -1,7 +1,5 @@
 let ocaml_prefixed key = "ocaml." ^ key
 
-let dune_prefixed key = "dune." ^ key
-
 module Commands = struct
   let select_sandbox = ocaml_prefixed "select-sandbox"
 
@@ -30,7 +28,7 @@ module Commands = struct
   let open_sandbox_documentation = ocaml_prefixed "open-sandbox-documentation"
 
   module Dune = struct
-    let open_current_dune_file = dune_prefixed "current-dune-file"
+    let open_current_dune_file = ocaml_prefixed "current-dune-file"
   end
 end
 

--- a/src/switch_impl_intf.ml
+++ b/src/switch_impl_intf.ml
@@ -33,24 +33,6 @@ let insert_inferred_intf ~source_uri client text_editor =
   else
     Promise.return ()
 
-(** given a file uri, opens the file if it exists; otherwise, creates the file
-    in "draft" mode (doesn't save it on disk)
-
-    @return TextEditor.t in which the document was opened *)
-let open_file_in_text_editor target_uri =
-  let open Promise.Syntax in
-  let uri = Uri.parse target_uri () in
-  let* doc =
-    Workspace.openTextDocument (`Uri uri)
-    |> Promise.catch ~rejected:(fun (_ : Promise.error) ->
-           (* if file does not exist *)
-           let create_file_uri = Uri.with_ uri ~scheme:`Untitled () in
-           let+ doc = Workspace.openTextDocument (`Uri create_file_uri) in
-           doc)
-  in
-  let+ text_editor = Window.showTextDocument ~document:(`TextDocument doc) () in
-  text_editor
-
 let request_switch client document =
   let open Promise.Syntax in
   let source_uri =


### PR DESCRIPTION
The PR adds a command to open the dune file located in the same folder the currently open file. The command is available in the command palette iff an ocaml-related (ocaml, reason, etc.) file is open. 

If the dune file is missing, a new dune file is opened in a draft (non-saved) mode. 

The PR is based on #498 

The dune rpc is coming and can replace the implementation, but the code innocuously small, so it shouldn't be a big deal. 

Without this command, I do `cmd+p`, type 'dune' and have to remember which library I'm in to disambiguate among many other dune files 

![image](https://user-images.githubusercontent.com/16353531/104448451-ff482f00-55be-11eb-80fd-6923a0ca0ddd.png)
