### PR TITLE
Remove BuckleScript support instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,9 +26,40 @@ the `usr/local/bin` folder relative to the installation directory).
 
 ### ReScript / BuckleScript
 
-ReScript (previously BuckleScript) is not supported, use [rescript-vscode](https://github.com/rescript-lang/rescript-vscode) instead.
+The new ReScript syntax (`res` and `resi` files) is not supported, you should
+use [rescript-vscode](https://github.com/rescript-lang/rescript-vscode) instead.
 
-ReasonML, as an alternative syntax for OCaml, is supported out-of-the-box, as long as `reason` is installed in your environment.
+ReasonML, as an alternative syntax for OCaml, is supported out-of-the-box, as
+long as `reason` is installed in your environment.
+
+If you're looking for a way to use OCaml or ReasonML syntax in a ReScript
+project, you'll need to install `ocaml-lsp` in your environment. We recommend
+using Esy for this:
+
+1. Install esy
+
+```bash
+npm install esy --global
+```
+
+2. Add `esy.json` to the project root with following content:
+
+```json
+{
+  "dependencies": {
+    "@opam/ocaml-lsp-server": "*",
+    "@opam/ocamlfind-secondary": "*",
+    "@opam/reason": "*",
+    "ocaml": "4.6.x"
+  }
+}
+```
+
+3. Install and build packages
+
+```bash
+esy
+```
 
 ## Features
 

--- a/README.md
+++ b/README.md
@@ -24,36 +24,11 @@ Install [OCaml for Windows](https://fdopen.github.io/opam-repository-mingw/) and
 make sure the `ocaml-env` program is accessible on the PATH (`ocaml-env` is in
 the `usr/local/bin` folder relative to the installation directory).
 
-### BuckleScript
+### ReScript / BuckleScript
 
-There is currently no way of installing
-[OCaml-LSP](https://github.com/ocaml/ocaml-lsp) _natively_ for BuckleScript
-projects. As a fast workaround, you can use [esy](https://github.com/esy/esy):
+ReScript (previously BuckleScript) is not supported, use [rescript-vscode](https://github.com/rescript-lang/rescript-vscode) instead.
 
-1. Install esy
-
-```bash
-npm install esy --global
-```
-
-2. Add `esy.json` to the project root with following content:
-
-```json
-{
-  "dependencies": {
-    "@opam/ocaml-lsp-server": "1.1.0",
-    "@opam/ocamlfind-secondary": "*",
-    "@opam/reason": "*",
-    "ocaml": "4.6.x"
-  }
-}
-```
-
-3. Install and build packages
-
-```bash
-esy
-```
+ReasonML, as an alternative syntax for OCaml, is supported out-of-the-box, as long as `reason` is installed in your environment.
 
 ## Features
 

--- a/src/sandbox.ml
+++ b/src/sandbox.ml
@@ -1,15 +1,5 @@
 open Import
 
-(* Terminology: - Sandbox: represents supported sandboxes with Global as the
-   fallback - project_root is different from Package_manager root (Eg. Opam
-   (Path.of_string "/foo/bar")). Project root is the directory where manifest
-   file (opam/esy.json/package.json) was found. Package_manager root is the
-   directory that contains the manifest file responsible for setting up the
-   sandbox - the two are same for Esy and Opam project but different for
-   bucklescript. Bucklescript projects have this manifest file abstracted away
-   from the user (at least at the moment) - Manifest: abstracts functions
-   handling manifest files of the supported package managers *)
-
 type t =
   | Opam of Opam.t * Opam.Switch.t
   | Esy of Esy.t * Path.t

--- a/src/sandbox.mli
+++ b/src/sandbox.mli
@@ -47,23 +47,7 @@ val select_sandbox_and_save : unit -> t option Promise.t
 val select_sandbox : unit -> t option Promise.t
 
 (** [run_setup] is an effectful function that triggers setup instructions
-    automatically for the user. At present, this functionality resides in the
-    plugin itself for bucklescript users - to reliably use ocamllsp for
-    bucklescript users, a sandboxed environment provides a reliable way to setup
-    the OCaml sandbox.
-    {{:https://github.com/prometheansacrifice/esy-mode#npm-and-bucklescript-build-system-managed-projects}
-    More details} We use Esy to provide
-
-    1. A scrubbed environment with just OCaml tools in it - this is necessary
-    since OCaml tools are closely tied to compiler versions and look into the
-    global environments to find plugins (Eg. Merlin and Reason) 2. Relocatable
-    assets so that users can download the sandbox artifacts and compile it from
-    source in the same workflow.
-
-    [run_setup] is capable of setting up the sandbox for bucklescript project
-    using both Opam and Esy users. It provides and abstracted way to setup the
-    sandbox, so that we (developers) have the flexibility to iterate and improve
-    how the sandbox it provided.
+    automatically for the user.
 
     A hard requirement for [run_setup] is to not get in the way to existing
     setups. If users already have working sandboxes installed via some other


### PR DESCRIPTION
ReScript now has its own extension, so we can safely say we don't support it and redirect to the new extension instead.