### PR TITLE
Add Utop integration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,11 @@
 
 - `vscode-ocaml-platform` now depends on `ocaml-lsp-server.1.3.0`
 
+- Add a command to open a Utop REPL in the current sandbox (#504)
+
+- Add a code evaluation command that sends selected expressions to the REPL
+  (#504)
+
 ## 1.6.0
 
 - Highlight token aliases in Menhir associativity declarations (#473)

--- a/README.md
+++ b/README.md
@@ -103,9 +103,19 @@ the settings under `File > Preferences > Settings`.
 | `ocaml.terminal.shellArgs.linux`   | The command line arguments that the sandbox terminal uses on Linux                                      | `null`  |
 | `ocaml.terminal.shellArgs.osx`     | The command line arguments that the sandbox terminal uses on macOS                                      | `null`  |
 | `ocaml.terminal.shellArgs.windows` | The command line arguments that the sandbox terminal uses on Window                                     | `null`  |
+| `ocaml.repl.path`                  | The path of the REPL that the extension uses                                                            | `null`  |
+| `ocaml.repl.args`                  | The REPL arguments that the extension uses                                                              | `null`  |
 
 If `ocaml.terminal.shell.*` or `ocaml.terminal.shellArgs.*` is `null`, the
 configured VSCode shell and shell arguments will be used instead.
+
+If `ocaml.repl.path` or `ocaml.repl.args` is `null`, the default REPL is used instead. The default REPL used depends on the packages installed in your current sandbox:
+
+- If `dune build` passes and the current sandbox has `utop` installed, the REPL will be `dune utop`
+- If `dune build` fails and the current sandbox has `utop` installed, the REPL will be `utop`
+- Else, the REPL will be `ocaml`
+
+If a REPL already exists, it will be used instead, so if you installed `utop` after openning a REPL, or if you fixed your project compilation, you will need to re-open the REPL to change it.
 
 ## Commands
 
@@ -120,6 +130,9 @@ MacOS).
 | `ocaml.open-terminal`        | Open a terminal (current sandbox)           |                    |               |
 | `ocaml.open-terminal-select` | Open a terminal (select a sandbox)          |                    |               |
 | `ocaml.current-dune-file`    | Open Dune File (located in the same folder) |                    |               |
+| `ocaml.switch-impl-intf`     | Switch implementation/interface             | `Alt+O`            |               |
+| `ocaml.open-repl`            | Open REPL                                   |                    |               |
+| `ocaml.evaluate-selection`   | Evaluate Selection                          | `Shift+Enter`      |               |
 
 ## Requirements
 

--- a/README.md
+++ b/README.md
@@ -109,13 +109,19 @@ the settings under `File > Preferences > Settings`.
 If `ocaml.terminal.shell.*` or `ocaml.terminal.shellArgs.*` is `null`, the
 configured VSCode shell and shell arguments will be used instead.
 
-If `ocaml.repl.path` or `ocaml.repl.args` is `null`, the default REPL is used instead. The default REPL used depends on the packages installed in your current sandbox:
+If `ocaml.repl.path` or `ocaml.repl.args` is `null`, the default REPL is used
+instead. The default REPL used depends on the packages installed in your current
+sandbox:
 
-- If `dune build` passes and the current sandbox has `utop` installed, the REPL will be `dune utop`
-- If `dune build` fails and the current sandbox has `utop` installed, the REPL will be `utop`
+- If `dune build` passes and the current sandbox has `utop` installed, the REPL
+  will be `dune utop`
+- If `dune build` fails and the current sandbox has `utop` installed, the REPL
+  will be `utop`
 - Else, the REPL will be `ocaml`
 
-If a REPL already exists, it will be used instead, so if you installed `utop` after openning a REPL, or if you fixed your project compilation, you will need to re-open the REPL to change it.
+If a REPL already exists, it will be used instead, so if you installed `utop`
+after openning a REPL, or if you fixed your project compilation, you will need
+to re-open the REPL to change it.
 
 ## Commands
 

--- a/package.json
+++ b/package.json
@@ -419,6 +419,7 @@
           "items": "string",
           "default": null
         }
+      }
     },
     "configurationDefaults": {
       "[ocaml]": {

--- a/package.json
+++ b/package.json
@@ -184,13 +184,23 @@
         "command": "ocaml.current-dune-file",
         "category": "OCaml",
         "title": "Open Dune File (located in the same folder)"
+      },
+      {
+        "command": "ocaml.open-repl",
+        "category": "OCaml",
+        "title": "Open REPL"
+      },
+      {
+        "command": "ocaml.evaluate-selection",
+        "category": "OCaml",
+        "title": "Evaluate Selection"
       }
     ],
     "keybindings": [
       {
         "command": "ocaml.switch-impl-intf",
         "key": "Alt+O",
-        "when": "editorLangId  == ocaml || editorLangId  == ocaml.interface || editorLangId == reason || editorLangId == ocaml.ocamllex || editorLangId == ocaml.menhir"
+        "when": "editorLangId == ocaml || editorLangId == ocaml.interface || editorLangId == reason || editorLangId == ocaml.ocamllex || editorLangId == ocaml.menhir"
       },
       {
         "command": "editor.action.codeAction",
@@ -198,7 +208,7 @@
         "args": {
           "kind": "destruct"
         },
-        "when": "editorLangId  == ocaml || editorLangId == reason"
+        "when": "editorLangId == ocaml || editorLangId == reason"
       },
       {
         "command": "editor.action.codeAction",
@@ -206,10 +216,22 @@
         "args": {
           "kind": "inferred_intf"
         },
-        "when": "editorLangId  == ocaml.interface || editorLangId == reason"
+        "when": "editorLangId == ocaml.interface || editorLangId == reason"
+      },
+      {
+        "command": "ocaml.evaluate-selection",
+        "key": "Shift+Enter",
+        "when": "editorTextFocus && editorLangId == ocaml || editorTextFocus && editorLangId == ocaml.interface || editorTextFocus && editorLangId == reason || editorTextFocus && editorLangId == ocaml.ocamllex || editorTextFocus && editorLangId == ocaml.menhir"
       }
     ],
     "menus": {
+      "editor/context": [
+        {
+          "command": "ocaml.evaluate-selection",
+          "group": "OCaml",
+          "when": "editorTextFocus && editorLangId == ocaml || editorTextFocus && editorLangId == ocaml.interface || editorTextFocus && editorLangId == reason || editorTextFocus && editorLangId == ocaml.ocamllex || editorTextFocus && editorLangId == ocaml.menhir"
+        }
+      ],
       "commandPalette": [
         {
           "command": "ocaml.current-dune-file",
@@ -252,7 +274,7 @@
         {
           "command": "ocaml.switch-impl-intf",
           "key": "Alt+O",
-          "when": "editorLangId  == ocaml || editorLangId  == ocaml.interface || editorLangId == reason || editorLangId == ocaml.ocamllex || editorLangId == ocaml.menhir",
+          "when": "editorLangId == ocaml || editorLangId == ocaml.interface || editorLangId == reason || editorLangId == ocaml.ocamllex || editorLangId == ocaml.menhir",
           "group": "navigation"
         }
       ],
@@ -379,8 +401,24 @@
           ],
           "items": "string",
           "default": null
+        },
+        "ocaml.repl.path": {
+          "description": "The path of the REPL that the extension uses",
+          "type": [
+            "string",
+            "null"
+          ],
+          "default": null
+        },
+        "ocaml.repl.args": {
+          "description": "The REPL arguments that the extension uses",
+          "type": [
+            "array",
+            "null"
+          ],
+          "items": "string",
+          "default": null
         }
-      }
     },
     "configurationDefaults": {
       "[ocaml]": {

--- a/src/bindings/node/node.ml
+++ b/src/bindings/node/node.ml
@@ -7,7 +7,7 @@ let __dirname () =
   Js_of_ocaml.Js.Unsafe.eval_string "__dirname" |> Js_of_ocaml.Js.to_string
 
 module Timeout = struct
-  type t = private Ojs.t [@@js]
+  include Class.Make ()
 
   val hasRef : t -> bool [@@js.get]
 
@@ -27,12 +27,16 @@ module Process = struct
 
   val platform : string [@@js.global "process.platform"]
 
+  val arch : string [@@js.global "process.arch"]
+
   module Env = struct
     val env : Ojs.t [@@js.global "process.env"]
 
     let get k = [%js.to: string or_undefined] (Ojs.get env k)
 
     let set k v = Ojs.set env k ([%js.of: string] v)
+
+    val env : string Interop.Dict.t [@@js.global "process.env"]
   end
 end
 

--- a/src/bindings/node/node.ml
+++ b/src/bindings/node/node.ml
@@ -6,6 +6,22 @@ let __filename () =
 let __dirname () =
   Js_of_ocaml.Js.Unsafe.eval_string "__dirname" |> Js_of_ocaml.Js.to_string
 
+module Timeout = struct
+  type t = private Ojs.t [@@js]
+
+  val hasRef : t -> bool [@@js.get]
+
+  val ref : t -> t [@@js.get]
+
+  val refresh : t -> t [@@js.get]
+
+  val unref : t -> t [@@js.get]
+end
+
+val setInterval : (unit -> unit) -> int -> Timeout.t [@@js.global]
+
+val setTimeout : (unit -> unit) -> int -> Timeout.t [@@js.global]
+
 module Process = struct
   val cwd : unit -> string [@@js.global "process.cwd"]
 

--- a/src/bindings/node/node.mli
+++ b/src/bindings/node/node.mli
@@ -4,6 +4,22 @@ val __filename : unit -> string
 
 val __dirname : unit -> string
 
+module Timeout : sig
+  include Js.T
+
+  val hasRef : t -> bool
+
+  val ref : t -> t
+
+  val refresh : t -> t
+
+  val unref : t -> t
+end
+
+val setInterval : (unit -> unit) -> int -> Timeout.t
+
+val setTimeout : (unit -> unit) -> int -> Timeout.t
+
 module Process : sig
   val cwd : unit -> string
 

--- a/src/bindings/node/node.mli
+++ b/src/bindings/node/node.mli
@@ -25,10 +25,14 @@ module Process : sig
 
   val platform : string
 
+  val arch : string
+
   module Env : sig
     val get : string -> string option
 
     val set : string -> string -> unit
+
+    val env : string Interop.Dict.t
   end
 end
 

--- a/src/cmd.mli
+++ b/src/cmd.mli
@@ -19,13 +19,25 @@ type stderr = string
 
 val append : spawn -> string list -> spawn
 
-val check_spawn : spawn -> spawn Or_error.t Promise.t
+val check_spawn :
+  ?env:string Interop.Dict.t -> spawn -> spawn Or_error.t Promise.t
 
-val check : t -> t Or_error.t Promise.t
+val check : ?env:string Interop.Dict.t -> t -> t Or_error.t Promise.t
 
 val log : ?result:ChildProcess.return -> t -> unit
 
 val output :
-  ?cwd:Path.t -> ?stdin:string -> t -> (stdout, stderr) result Promise.t
+     ?cwd:Path.t
+  -> ?env:string Interop.Dict.t
+  -> ?stdin:string
+  -> t
+  -> (stdout, stderr) result Promise.t
 
 val equal_spawn : spawn -> spawn -> bool
+
+val run :
+     ?cwd:Path.t
+  -> ?env:string Interop.Dict.t
+  -> ?stdin:stderr
+  -> t
+  -> ChildProcess.return Promise.t

--- a/src/extension_commands.mli
+++ b/src/extension_commands.mli
@@ -9,23 +9,6 @@
 
     [1] https://code.visualstudio.com/api/references/vscode-api#commands *)
 
-type command = private
-  { id : string
-  ; handler : Extension_instance.t -> args:Ojs.t list -> unit
-  }
-
-val select_sandbox : command
-
-val restart_language_server : command
-
-val select_sandbox_and_open_terminal : command
-
-val open_terminal : command
-
-val switch_impl_intf : command
-
-val open_current_dune_file : command
-
 (** Registers commands with vscode. Should be called in
     [Vscode_ocaml_platform.activate]. It subscribes the disposables to the
     extension context provided. *)
@@ -34,3 +17,12 @@ val register_all_commands :
 
 val register :
   id:string -> (Extension_instance.t -> args:Ojs.t list -> unit) -> unit
+
+val register_text_editor :
+     id:string
+  -> (   Extension_instance.t
+      -> textEditor:Vscode.TextEditor.t
+      -> edit:Vscode.TextEditorEdit.t
+      -> args:Ojs.t list
+      -> unit)
+  -> unit

--- a/src/extension_consts.ml
+++ b/src/extension_consts.ml
@@ -28,6 +28,10 @@ module Commands = struct
   let open_sandbox_documentation = ocaml_prefixed "open-sandbox-documentation"
 
   let open_current_dune_file = ocaml_prefixed "current-dune-file"
+
+  let evaluate_selection = ocaml_prefixed "evaluate-selection"
+
+  let open_repl = ocaml_prefixed "open-repl"
 end
 
 (* TODO: Refactor the code so that we don't need any "constants" module *)

--- a/src/extension_instance.ml
+++ b/src/extension_instance.ml
@@ -2,6 +2,7 @@ open Import
 
 type t =
   { mutable sandbox : Sandbox.t
+  ; mutable repl : Terminal_sandbox.t option
   ; mutable lsp_client : (LanguageClient.t * Ocaml_lsp.t) option
   ; sandbox_info : StatusBarItem.t
   }
@@ -114,7 +115,7 @@ end
 let make () =
   let sandbox = Sandbox.Global in
   let sandbox_info = Sandbox_info.make sandbox in
-  { sandbox; lsp_client = None; sandbox_info }
+  { sandbox; lsp_client = None; sandbox_info; repl = None }
 
 let set_sandbox t new_sandbox =
   Sandbox_info.update t.sandbox_info ~new_sandbox;
@@ -124,6 +125,12 @@ let set_sandbox t new_sandbox =
       ~command:Extension_consts.Commands.refresh_sandbox ~args:[]
   in
   ()
+
+let repl t = t.repl
+
+let set_repl t repl = t.repl <- Some repl
+
+let close_repl t = t.repl <- None
 
 let open_terminal sandbox =
   let terminal = Terminal_sandbox.create sandbox in

--- a/src/extension_instance.mli
+++ b/src/extension_instance.mli
@@ -19,3 +19,9 @@ val start_language_server : t -> unit Promise.t
 val open_terminal : Sandbox.t -> unit
 
 val disposable : t -> Disposable.t
+
+val repl : t -> Terminal_sandbox.t option
+
+val set_repl : t -> Terminal.t -> unit
+
+val close_repl : t -> unit

--- a/src/platform.ml
+++ b/src/platform.ml
@@ -29,6 +29,35 @@ module Map = struct
     | Other -> other
 end
 
+type arch =
+  | Arm
+  | Arm64
+  | Ia32
+  | Mips
+  | Mipsel
+  | Ppc
+  | Ppc64
+  | S390
+  | S390x
+  | X32
+  | X64
+
+let arch_of_string = function
+  | "arm" -> Arm
+  | "arm64" -> Arm64
+  | "ia32" -> Ia32
+  | "mips" -> Mips
+  | "mipsel" -> Mipsel
+  | "ppc" -> Ppc
+  | "ppc64" -> Ppc64
+  | "s390" -> S390
+  | "s390x" -> S390x
+  | "x32" -> X32
+  | "x64" -> X64
+  | _ -> assert false
+
+let arch = Node.Process.arch |> arch_of_string
+
 type shell =
   | Sh of Path.t
   | PowerShell of Path.t

--- a/src/platform.mli
+++ b/src/platform.mli
@@ -20,6 +20,21 @@ module Map : sig
 end
 with type platform := t
 
+type arch =
+  | Arm
+  | Arm64
+  | Ia32
+  | Mips
+  | Mipsel
+  | Ppc
+  | Ppc64
+  | S390
+  | S390x
+  | X32
+  | X64
+
+val arch : arch
+
 type shell =
   | Sh of Path.t
   | PowerShell of Path.t

--- a/src/repl.ml
+++ b/src/repl.ml
@@ -1,6 +1,6 @@
 open Import
 
-module ReplPath = struct
+module Repl_path = struct
   type t = string option
 
   let of_json json =
@@ -16,7 +16,7 @@ module ReplPath = struct
   let t = Settings.create ~scope:Global ~key ~of_json ~to_json
 end
 
-module ReplArgs = struct
+module Repl_args = struct
   type t = string list option
 
   let of_json json =
@@ -33,10 +33,10 @@ module ReplArgs = struct
 end
 
 let get_repl_path () =
-  Option.join (Settings.get ~section:"ocaml.repl" ReplPath.t)
+  Option.join (Settings.get ~section:"ocaml.repl" Repl_path.t)
 
 let get_repl_args () =
-  Option.join (Settings.get ~section:"ocaml.repl" ReplArgs.t)
+  Option.join (Settings.get ~section:"ocaml.repl" Repl_args.t)
 
 let name = "REPL"
 

--- a/src/repl.ml
+++ b/src/repl.ml
@@ -1,0 +1,191 @@
+open Import
+
+module ReplPath = struct
+  type t = string option
+
+  let of_json json =
+    let open Jsonoo.Decode in
+    nullable string json
+
+  let to_json (t : t) =
+    let open Jsonoo.Encode in
+    nullable string t
+
+  let key = "path"
+
+  let t = Settings.create ~scope:Global ~key ~of_json ~to_json
+end
+
+module ReplArgs = struct
+  type t = string list option
+
+  let of_json json =
+    let open Jsonoo.Decode in
+    nullable (list string) json
+
+  let to_json (t : t) =
+    let open Jsonoo.Encode in
+    nullable (list string) t
+
+  let key = "args"
+
+  let t = Settings.create ~scope:Global ~key ~of_json ~to_json
+end
+
+let get_repl_path () =
+  Option.join (Settings.get ~section:"ocaml.repl" ReplPath.t)
+
+let get_repl_args () =
+  Option.join (Settings.get ~section:"ocaml.repl" ReplArgs.t)
+
+let name = "REPL"
+
+let has_utop sandbox =
+  let open Promise.Syntax in
+  let cmd = Sandbox.get_command sandbox "utop" [ "-version" ] in
+  let+ result = Cmd.output cmd in
+  match result with
+  | Error _ -> false
+  | Ok _ -> true
+
+let can_build sandbox =
+  let open Promise.Syntax in
+  let excludes =
+    (* ignoring dune files from _build, _opam, _esy *)
+    `String "{**/_*}"
+  in
+  let includes = `String "**/{dune-project}" in
+  let* dunes = Workspace.findFiles ~includes ~excludes () in
+  match dunes with
+  | [] -> Promise.return false
+  | _ :: _ :: _ ->
+    (* If the workspace contains several dune-project, we don't know how to
+       build it. *)
+    Promise.return false
+  | el :: _ -> (
+    let cwd = Filename.dirname (Uri.fsPath el) |> Path.of_string in
+    let cmd = Sandbox.get_command sandbox "dune" [ "build" ] in
+    let+ result = Cmd.output ~cwd cmd in
+    match result with
+    | Error _ -> false
+    | Ok _ -> true )
+
+let default_repl sandbox =
+  let open Promise.Syntax in
+  let* has_utop = has_utop sandbox in
+  let+ can_build = can_build sandbox in
+  match (has_utop, can_build) with
+  | true, true -> Sandbox.get_command sandbox "dune" [ "utop" ]
+  | true, false -> Sandbox.get_command sandbox "utop" []
+  | false, _ -> Sandbox.get_command sandbox "ocaml" []
+
+let create_terminal instance sandbox =
+  match Extension_instance.repl instance with
+  | Some term ->
+    Terminal_sandbox.show term;
+    Promise.return (Ok term)
+  | None -> (
+    let open Promise.Syntax in
+    let* cmd =
+      match (get_repl_path (), get_repl_args ()) with
+      | Some bin, Some args ->
+        Sandbox.get_command sandbox bin args |> Promise.return
+      | Some bin, None -> Sandbox.get_command sandbox bin [] |> Promise.return
+      | None, _ -> default_repl sandbox
+    in
+    let* result = Cmd.check cmd in
+    match result with
+    | Error err -> Promise.return (Error err)
+    | Ok (Shell _) ->
+      Promise.return
+        (Error "Running a REPL from a Shell command is not supported")
+    | Ok (Spawn cmd) -> (
+      let term = Terminal_sandbox.create ~name ~command:cmd sandbox in
+      Terminal_sandbox.show term;
+      (* Wait for UTop or OCaml REPL to be initialized before sending text to
+         the terminal.
+
+         That's hacky, buy hey, if vscode-python does it, so can we...
+         https://github.com/microsoft/vscode-python/blob/main/src/client/terminals/codeExecution/terminalCodeExecution.ts#L54 *)
+      let+ _ =
+        Promise.make (fun ~resolve ~reject:_ ->
+            let (_ : Node.Timeout.t) =
+              Node.setTimeout (fun () -> resolve true) 2500
+            in
+            ())
+      in
+      match Terminal.exitStatus term with
+      | Some _ -> Error "The REPL terminal could not be open"
+      | None ->
+        Extension_instance.set_repl instance term;
+        Ok term ) )
+
+let get_code text_editor =
+  let selection = Vscode.TextEditor.selection text_editor in
+  let start_line = Vscode.Selection.start selection |> Vscode.Position.line in
+  let end_line = Vscode.Selection.end_ selection |> Vscode.Position.line in
+  let start_char =
+    Vscode.Selection.start selection |> Vscode.Position.character
+  in
+  let end_char = Vscode.Selection.end_ selection |> Vscode.Position.character in
+  if start_line = end_line && start_char = end_char then
+    let document = Vscode.TextEditor.document text_editor in
+    let line = Vscode.TextDocument.lineAt document ~line:start_line in
+    Vscode.TextLine.text line
+  else
+    let document = Vscode.TextEditor.document text_editor in
+    Vscode.TextDocument.getText document ~range:(selection :> Vscode.Range.t) ()
+
+let prepare_code code =
+  if String.is_suffix code ~suffix:";;" then
+    code
+  else
+    code ^ ";;"
+
+module Command = struct
+  let _open_repl =
+    let handler (instance : Extension_instance.t) ~args:_ =
+      let (_ : unit Promise.t) =
+        let open Promise.Syntax in
+        let sandbox = Extension_instance.sandbox instance in
+        let+ (result : (Terminal.t, string) result) =
+          create_terminal instance sandbox
+        in
+        let (_ : (Terminal.t, unit) result) =
+          Result.map_error result ~f:(fun err -> log "%s" err)
+        in
+        ()
+      in
+      ()
+    in
+    Extension_commands.register ~id:Extension_consts.Commands.open_repl handler
+
+  let _evaluate_selection =
+    let handler (instance : Extension_instance.t) ~textEditor ~edit:_ ~args:_ =
+      let (_ : unit Promise.t) =
+        let open Promise.Syntax in
+        let sandbox = Extension_instance.sandbox instance in
+        let+ term = create_terminal instance sandbox in
+        match term with
+        | Error err -> show_message `Error "Could not start the REPL: %s" err
+        | Ok term ->
+          let code = get_code textEditor in
+          if String.length code > 0 then
+            let code = prepare_code code in
+            Terminal_sandbox.send term code
+      in
+      ()
+    in
+    Extension_commands.register_text_editor
+      ~id:Extension_consts.Commands.evaluate_selection handler
+end
+
+let register extension instance =
+  let disposable =
+    Vscode.Window.onDidCloseTerminal ()
+      ~listener:(fun terminal ->
+        if String.equal (Vscode.Terminal.name terminal) name then
+          Extension_instance.close_repl instance)
+      ()
+  in
+  Vscode.ExtensionContext.subscribe extension ~disposable

--- a/src/repl.ml
+++ b/src/repl.ml
@@ -128,12 +128,11 @@ let get_code text_editor =
     Vscode.Selection.start selection |> Vscode.Position.character
   in
   let end_char = Vscode.Selection.end_ selection |> Vscode.Position.character in
+  let document = Vscode.TextEditor.document text_editor in
   if start_line = end_line && start_char = end_char then
-    let document = Vscode.TextEditor.document text_editor in
     let line = Vscode.TextDocument.lineAt document ~line:start_line in
     Vscode.TextLine.text line
   else
-    let document = Vscode.TextEditor.document text_editor in
     Vscode.TextDocument.getText document ~range:(selection :> Vscode.Range.t) ()
 
 let prepare_code code =

--- a/src/repl.mli
+++ b/src/repl.mli
@@ -1,0 +1,1 @@
+val register : Vscode.ExtensionContext.t -> Extension_instance.t -> unit

--- a/src/terminal_sandbox.mli
+++ b/src/terminal_sandbox.mli
@@ -1,7 +1,9 @@
-type t
+type t = Vscode.Terminal.t
 
-val create : Sandbox.t -> t
+val create : ?name:string -> ?command:Cmd.spawn -> Sandbox.t -> t
 
 val dispose : t -> unit
 
 val show : t -> unit
+
+val send : t -> string -> unit

--- a/src/vscode_ocaml_platform.ml
+++ b/src/vscode_ocaml_platform.ml
@@ -1,6 +1,6 @@
 open Import
 
-let suggest_to_pick_sandbox instance =
+let suggest_to_pick_sandbox () =
   let open Promise.Syntax in
   let select_pm_button_text = "Select package manager and sandbox" in
   let+ selection =
@@ -13,7 +13,11 @@ let suggest_to_pick_sandbox instance =
       ()
   in
   Option.iter selection ~f:(fun () ->
-      Extension_commands.select_sandbox.handler instance ~args:[])
+      let (_ : Ojs.t option Promise.t) =
+        Vscode.Commands.executeCommand
+          ~command:Extension_consts.Commands.select_sandbox ~args:[]
+      in
+      ())
 
 let activate (extension : ExtensionContext.t) =
   (* this env var update disables ocaml-lsp's logging to a file because we use
@@ -30,6 +34,7 @@ let activate (extension : ExtensionContext.t) =
   Treeview_sandbox.register extension instance;
   Treeview_commands.register extension;
   Treeview_help.register extension;
+  Repl.register extension instance;
   let sandbox_opt = Sandbox.of_settings_or_detect () in
   let (_ : unit Promise.t) =
     let* sandbox_opt = sandbox_opt in
@@ -44,7 +49,7 @@ let activate (extension : ExtensionContext.t) =
          hanging, so we use fallback; w/ a proper detection mechanism, we would
          redo work in rare cases *)
     then
-      suggest_to_pick_sandbox instance
+      suggest_to_pick_sandbox ()
     else
       Promise.return ()
   in

--- a/vscode/vscode/vscode.ml
+++ b/vscode/vscode/vscode.ml
@@ -278,8 +278,6 @@ module Selection = struct
 
   include Range
 
-  type t = private (* class extends *) Range.t [@@js]
-
   val anchor : t -> Position.t [@@js.get]
 
   val active : t -> Position.t [@@js.get]

--- a/vscode/vscode/vscode.ml
+++ b/vscode/vscode/vscode.ml
@@ -276,6 +276,10 @@ end
 module Selection = struct
   include Class.Extend (Range) ()
 
+  include Range
+
+  type t = private (* class extends *) Range.t [@@js]
+
   val anchor : t -> Position.t [@@js.get]
 
   val active : t -> Position.t [@@js.get]

--- a/vscode/vscode/vscode.mli
+++ b/vscode/vscode/vscode.mli
@@ -262,6 +262,8 @@ end
 module Selection : sig
   include Js.T with type t = private Range.t
 
+  include module type of Range with type t := t
+
   val anchor : t -> Position.t
 
   val active : t -> Position.t

--- a/vscode/vscode/vscode.mli
+++ b/vscode/vscode/vscode.mli
@@ -260,9 +260,7 @@ module ViewColumn : sig
 end
 
 module Selection : sig
-  include Js.T with type t = private Range.t
-
-  include module type of Range with type t := t
+  include module type of Range with type t = private Range.t
 
   val anchor : t -> Position.t
 


### PR DESCRIPTION
This PR adds a code evaluation feature that sends selected expressions to the REPL when pressing `Shift+Enter` (or selecting "Evaluate Expression" in the editor menu).

The REPL is provided with Utop and is instantiated using `dune utop`, so this feature depends on both dune and utop to be available in the user's sandbox.

Closes https://github.com/ocamllabs/vscode-ocaml-platform/issues/452
Closes https://github.com/ocamllabs/vscode-ocaml-platform/issues/490

**TODO**

- [X] Fix code not being evaluated the first time when utop takes too long to be initialized
- [ ] Add popup to install utop if not available in the sandbox (most likely depends on #495 which adds Opam package installation capabilities)
- [x] Document the commands in the readme