### PR TITLE
Add comment when inferring interfaces

### DIFF
--- a/src/switch_impl_intf.ml
+++ b/src/switch_impl_intf.ml
@@ -21,6 +21,10 @@ let insert_inferred_intf ~source_uri client text_editor =
   if String.is_suffix source_uri ~suffix:".ml" then
     (* If the source file was a .ml, infer the interface *)
     let+ inferred_intf = send_infer_intf_request client source_uri in
+    let inferred_intf =
+      "(* This interface has been automatically generated with the inferred \
+       interface of the module *)\n\n" ^ inferred_intf
+    in
     let (_ : bool Promise.t) =
       TextEditor.edit text_editor
         ~callback:(fun ~editBuilder ->


### PR DESCRIPTION
With this PR, the inferred interfaces are prepended with a comment when switching to a non-existing file.

![image](https://user-images.githubusercontent.com/6162008/105762316-877deb00-5f54-11eb-933c-19efd1de2646.png)

This addresses user feedback that indicated that switching to the interface of a module was sometimes confusing as users didn't know if the interface had been inferred, or if it already existed.

@rgrinberg At this point, I'm also convinced that this feature has passed the threshold of hacks and complexity. This is my last attempt, but I'll just remove the whole thing if you prefer.