### PR TITLE
Disable dune cache in GitHub Actions workflow

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -28,7 +28,6 @@ jobs:
         uses: actions-ml/setup-ocaml@master
         with:
           ocaml-version: ${{ matrix.ocaml-version }}
-          dune-cache: ${{ matrix.os != 'windows-latest' }}
           opam-depext: false
           opam-pin: false
 


### PR DESCRIPTION
As the title says.