### PR TITLE
Fix command palette keys in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,8 +11,8 @@ _Please report any bugs you encounter._
 1. Install this extension from
    [the VSCode Marketplace](https://marketplace.visualstudio.com/items?itemName=ocamllabs.ocaml-platform)
    (or by entering `ext install ocamllabs.ocaml-platform` at the command palette
-   <kbd>Ctrl</kbd>+<kbd>P</kbd> (<kbd>Cmd</kbd>+<kbd>Shift</kbd>+<kbd>P</kbd> on
-   MacOS)
+   <kbd>Ctrl</kbd>+<kbd>Shift</kbd>+<kbd>P</kbd>
+   (<kbd>Cmd</kbd>+<kbd>Shift</kbd>+<kbd>P</kbd> on MacOS)
 2. Open a OCaml/ReasonML project (`File > Add Folder to Workspace...`)
 3. Install [OCaml-LSP](https://github.com/ocaml/ocaml-lsp) with
    [opam](https://github.com/ocaml/opam) or [esy](https://github.com/esy/esy).


### PR DESCRIPTION
The mentioned keyboard shortcut for opening the command palette was missing a `shift`.