### PR TITLE
switchImplIntf & inferIntf use structured json requests

### DIFF
--- a/src/switch_impl_intf.ml
+++ b/src/switch_impl_intf.ml
@@ -1,7 +1,7 @@
 open Import
 
 let send_switch_impl_intf_request client uri : string array Promise.t =
-  let data = Jsonoo.Encode.string uri in
+  let data = Jsonoo.Encode.list Jsonoo.Encode.string [ uri ] in
   let open Promise.Syntax in
   let+ response =
     LanguageClient.sendRequest client ~meth:"ocamllsp/switchImplIntf" ~data ()
@@ -9,7 +9,7 @@ let send_switch_impl_intf_request client uri : string array Promise.t =
   Jsonoo.Decode.(array string) response
 
 let send_infer_intf_request client uri : string Promise.t =
-  let data = Jsonoo.Encode.string uri in
+  let data = Jsonoo.Encode.list Jsonoo.Encode.string [ uri ] in
   let open Promise.Syntax in
   let+ response =
     LanguageClient.sendRequest client ~meth:"ocamllsp/inferIntf" ~data ()


### PR DESCRIPTION
The extension was failing with `ocaml-lsp` master after `ocaml-lsp` moved to "structured" representation for the request params [PR](https://github.com/ocaml/ocaml-lsp/commit/ad6d413e143e70b57c69660c37ef64119272418e ). 

`switchImplIntf` & `inferIntf` should send `[uri]` (a string list) not `uri` (a string). This PR does exactly that.