### PR TITLE
Display shell command output 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@
 
 - Highlight OCaml source code inside Cinaps comments (#547)
 
+- Show the output of shell commands in an output channel. The output channel is
+  automatically focused when running a package management command from the OCaml
+  activity tab (#541)
+
 ## 1.7.0
 
 - Fixed an issue when uninstalled Opam packages still appear in the `roots`

--- a/src/cmd.ml
+++ b/src/cmd.ml
@@ -79,8 +79,9 @@ let check ?env t =
 
 let run ?cwd ?env ?stdin cmd =
   let cwd = Option.map cwd ~f:Path.to_string in
-  let (lazy output) = Output.command_output_channel in
-  let logger = function
+  let logger event =
+    let (lazy output) = Output.command_output_channel in
+    match event with
     | ChildProcess.Spawned ->
       Vscode.OutputChannel.appendLine output ~value:("$ " ^ to_string cmd)
     | Stdout data

--- a/src/cmd.ml
+++ b/src/cmd.ml
@@ -15,6 +15,17 @@ type stdout = string
 
 type stderr = string
 
+let quote str =
+  if String.contains str ' ' then
+    "\"" ^ str ^ "\""
+  else
+    str
+
+let to_string = function
+  | Shell cmd -> cmd
+  | Spawn { bin; args } ->
+    Path.to_string bin :: args |> List.map ~f:quote |> String.concat ~sep:" "
+
 let path_missing_from_env = "'PATH' variable not found in the environment"
 
 let append { bin; args = args1 } args2 = { bin; args = args1 @ args2 }
@@ -66,15 +77,23 @@ let check ?env t =
     let+ s = check_spawn ?env spawn in
     Spawn s
 
-let run ?cwd ?env ?stdin =
+let run ?cwd ?env ?stdin cmd =
   let cwd = Option.map cwd ~f:Path.to_string in
-  function
+  let (lazy output) = Output.command_output_channel in
+  let logger = function
+    | ChildProcess.Spawned ->
+      Vscode.OutputChannel.appendLine output ~value:("$ " ^ to_string cmd)
+    | Stdout data
+    | Stderr data ->
+      Vscode.OutputChannel.append output ~value:data
+    | Closed -> Vscode.OutputChannel.appendLine output ~value:""
+  in
+  let options = ChildProcess.Options.create ?cwd ?env () in
+  match cmd with
   | Spawn { bin; args } ->
-    ChildProcess.spawn (Path.to_string bin) (Array.of_list args) ?stdin
-      (ChildProcess.Options.create ?cwd ?env ())
-  | Shell command_line ->
-    ChildProcess.exec command_line ?stdin
-      (ChildProcess.Options.create ?cwd ?env ())
+    ChildProcess.spawn (Path.to_string bin) (Array.of_list args) ~logger ?stdin
+      ~options
+  | Shell command_line -> ChildProcess.exec command_line ~logger ?stdin ~options
 
 let log ?(result : ChildProcess.return option) (t : t) =
   let open Jsonoo.Encode in

--- a/src/cmd.mli
+++ b/src/cmd.mli
@@ -17,6 +17,9 @@ type stdout = string
 
 type stderr = string
 
+(* surround a string with quotes if it has spaces *)
+val quote : string -> string
+
 val append : spawn -> string list -> spawn
 
 val check_spawn :

--- a/src/output.ml
+++ b/src/output.ml
@@ -3,3 +3,6 @@ let language_server_output_channel =
 
 let extension_output_channel =
   lazy (Vscode.Window.createOutputChannel ~name:"OCaml Platform Extension")
+
+let command_output_channel =
+  lazy (Vscode.Window.createOutputChannel ~name:"OCaml Commands")

--- a/src/output.mli
+++ b/src/output.mli
@@ -5,3 +5,7 @@ val language_server_output_channel : Vscode.OutputChannel.t Lazy.t
 (** [extension_output_channel] is the output channel that should be used for
     logs by the extension *)
 val extension_output_channel : Vscode.OutputChannel.t Lazy.t
+
+(** [command_output_channel] is the output channel for user-friendly logs of
+    shell commands *)
+val command_output_channel : Vscode.OutputChannel.t Lazy.t

--- a/src/sandbox.ml
+++ b/src/sandbox.ml
@@ -438,15 +438,9 @@ let get_command sandbox bin args : Cmd.t =
   | Esy (esy, manifest) -> Esy.exec esy manifest ~args:(bin :: args)
   | Global -> Spawn { bin = Path.of_string bin; args }
   | Custom template ->
-    let bin =
-      if String.contains bin ' ' then
-        "\"" ^ bin ^ "\""
-      else
-        bin
-    in
     let command =
       template
-      |> String.substr_replace_all ~pattern:"$prog" ~with_:bin
+      |> String.substr_replace_all ~pattern:"$prog" ~with_:(Cmd.quote bin)
       |> String.substr_replace_all ~pattern:"$args"
            ~with_:(String.concat ~sep:" " args)
       |> String.strip

--- a/src/sandbox.ml
+++ b/src/sandbox.ml
@@ -627,3 +627,11 @@ let upgrade_packages t =
     let open Promise.Syntax in
     let+ _ = Vscode.Window.withProgress (module Ojs) ~options ~task in
     ()
+
+let focus_on_package_command ?sandbox () =
+  match sandbox with
+  | None
+  | Some (Opam _) ->
+    let (lazy output) = Output.command_output_channel in
+    Vscode.OutputChannel.show output ()
+  | _ -> ()

--- a/src/sandbox.mli
+++ b/src/sandbox.mli
@@ -97,3 +97,7 @@ val upgrade_packages : t -> unit Promise.t
 (** [ocaml_version] returns the version of the ocaml compiler installed in given
     sandbox. *)
 val ocaml_version : t -> (string, string) result Promise.t
+
+(** Focus on the command output channel. If [sandbox] is provided, the output
+    channel will only be focused if the given sandbox supports package commands. *)
+val focus_on_package_command : ?sandbox:t -> unit -> unit

--- a/src/treeview_sandbox.ml
+++ b/src/treeview_sandbox.ml
@@ -86,6 +86,7 @@ module Command = struct
         let dep = Dependency.t_of_js arg in
         let open Promise.Syntax in
         let sandbox = Extension_instance.sandbox instance in
+        Sandbox.focus_on_package_command ~sandbox ();
         let+ () = Sandbox.uninstall_packages sandbox [ dep ] in
         let (_ : Ojs.t option Promise.t) =
           Vscode.Commands.executeCommand
@@ -107,6 +108,7 @@ module Command = struct
       let (_ : unit Promise.t) =
         let open Promise.Syntax in
         let sandbox = Extension_instance.sandbox instance in
+        Sandbox.focus_on_package_command ~sandbox ();
         let+ () = Sandbox.upgrade_packages sandbox in
         let (_ : Ojs.t option Promise.t) =
           Vscode.Commands.executeCommand
@@ -140,6 +142,7 @@ module Command = struct
         | Some package_str ->
           let sandbox = Extension_instance.sandbox instance in
           let packages = String.split package_str ~on:' ' in
+          Sandbox.focus_on_package_command ~sandbox ();
           let+ () = Sandbox.install_packages sandbox packages in
           let (_ : Ojs.t option Promise.t) =
             Vscode.Commands.executeCommand

--- a/src/treeview_switches.ml
+++ b/src/treeview_switches.ml
@@ -103,6 +103,7 @@ module Command = struct
           @@ show_message `Warn "The selected item is not an opam switch."
         | Switch (opam, switch) -> (
           let open Promise.Syntax in
+          Sandbox.focus_on_package_command ();
           let+ result = Opam.switch_remove opam switch |> Cmd.output in
           match result with
           | Error err -> show_message `Error "%s" err


### PR DESCRIPTION
Displays the output of shell commands in a (more) user-friendly way:

<img width="1120" alt="image" src="https://user-images.githubusercontent.com/25037249/110065955-3d431300-7d25-11eb-8da6-f21fbf28deaf.png">

The output channel is updated as the process writes to stdout, unlike the JSON logging which has to wait for the process to complete. 

The package management commands in the activity tab (add/remove package or switch) will automatically focus on the output channel.

The effect of this feature is that users will be able to see the progress of installing/modifying their sandbox, whereas previously there would only be an infinitely-loading notification. This is especially useful when adding packages with a lot of dependencies that take a long time to install.
