### PR TITLE
Fix highlighting of float literals with a trailing decimal point

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@
   automatically focused when running a package management command from the OCaml
   activity tab (#541)
 
+- Fix highlighting of float literals with a trailing decimal point (#548)
+
 ## 1.7.0
 
 - Fixed an issue when uninstalled Opam packages still appear in the `roots`

--- a/syntaxes/ocaml.json
+++ b/syntaxes/ocaml.json
@@ -522,7 +522,7 @@
         {
           "comment": "floating point decimal literal",
           "name": "constant.numeric.decimal.float.ocaml",
-          "match": "\\b([[:digit:]][[:digit:]_]*\\.[[:digit:]_]*[g-zG-Z]?)\\b"
+          "match": "\\b([[:digit:]][[:digit:]_]*)(\\.[[:digit:]_]*[g-zG-Z]?\\b|\\.)"
         },
         {
           "comment": "floating point hexadecimal literal with exponent part",
@@ -532,7 +532,7 @@
         {
           "comment": "floating point hexadecimal literal",
           "name": "constant.numeric.hexadecimal.float.ocaml",
-          "match": "\\b((0x|0X)[[:xdigit:]][[:xdigit:]_]*\\.[[:xdigit:]_]*[g-zG-Z]?)\\b"
+          "match": "\\b((0x|0X)[[:xdigit:]][[:xdigit:]_]*)(\\.[[:xdigit:]_]*[g-zG-Z]?\\b|\\.)"
         },
 
         {


### PR DESCRIPTION
Previously, float literals with a trailing decimal point were highlighted as integers and a field accessor. 

| Before | After |
| - | - |
| ![before](https://user-images.githubusercontent.com/25037249/110253351-ba95a000-7f3e-11eb-91f4-b511072c6edd.png) | ![after](https://user-images.githubusercontent.com/25037249/110253364-c41f0800-7f3e-11eb-8473-cf71e783c0e1.png) |

