### PR TITLE
Remove node_modules from vscodeignore

### DIFF
--- a/.vscodeignore
+++ b/.vscodeignore
@@ -7,7 +7,6 @@ _opam/
 esy.lock/
 fixtures/
 lib/
-node_modules/
 src/
 test/
 
@@ -17,9 +16,3 @@ test/
 azure-pipelines.yaml
 esy.json
 Makefile
-
-!node_modules/semver/**
-!node_modules/vscode-jsonrpc/**
-!node_modules/vscode-languageclient/**
-!node_modules/vscode-languageserver-protocol/**
-!node_modules/vscode-languageserver-types/**


### PR DESCRIPTION
Closes #549 

The last update to the `vscode-languageclient` dependency added transitive dependencies which were being ignore by `vsce package`, breaking the extension at runtime.

I was originally going to update the `.vscodeignore` exclusions with the following:
<details>
<summary>node_modules exclusions</summary>

```
!node_modules/balanced-match/**
!node_modules/brace-expansion/**
!node_modules/concat-map/**
!node_modules/lru-cache/**
!node_modules/minimatch/**
!node_modules/semver/**
!node_modules/vscode-jsonrpc/**
!node_modules/vscode-languageclient/**
!node_modules/vscode-languageserver-protocol/**
!node_modules/vscode-languageserver-types/**
!node_modules/yallist/**
````

</details>

but after further investigation it seems that `vsce` already removes dev dependencies from node_modules, making it redundant. Removing it completely prevents this problem from happening again if more transitive dependencies are added.