### PR TITLE
Ask for confirmation when removing opam packages or switches

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@
 
 - Fix highlighting of float literals with a trailing decimal point (#548)
 
+- Ask for confirmation when removing opam packages or switches (#551)
+
 ## 1.7.0
 
 - Fixed an issue when uninstalled Opam packages still appear in the `roots`

--- a/src/import.ml
+++ b/src/import.ml
@@ -69,11 +69,13 @@ let open_file_in_text_editor target_uri =
   let+ text_editor = Window.showTextDocument ~document:(`TextDocument doc) () in
   text_editor
 
-let ask_confirmation message =
+let with_confirmation message ~yes ?(no = "Cancel") f =
   let open Promise.Syntax in
-  let+ choice =
+  let* choice =
     Vscode.Window.showInformationMessage ~message
-      ~choices:[ ("Yes", true); ("No", false) ]
+      ~choices:[ (yes, true); (no, false) ]
       ()
   in
-  Option.value choice ~default:false
+  match choice with
+  | Some true -> f ()
+  | _ -> Promise.return ()

--- a/src/import.ml
+++ b/src/import.ml
@@ -68,3 +68,12 @@ let open_file_in_text_editor target_uri =
   in
   let+ text_editor = Window.showTextDocument ~document:(`TextDocument doc) () in
   text_editor
+
+let ask_confirmation message =
+  let open Promise.Syntax in
+  let+ choice =
+    Vscode.Window.showInformationMessage ~message
+      ~choices:[ ("Yes", true); ("No", false) ]
+      ()
+  in
+  Option.value choice ~default:false

--- a/src/treeview_sandbox.ml
+++ b/src/treeview_sandbox.ml
@@ -84,27 +84,24 @@ module Command = struct
       let (_ : unit Promise.t) =
         let arg = List.hd_exn args in
         let dep = Dependency.t_of_js arg in
-        let open Promise.Syntax in
-        let* confirmed =
-          ask_confirmation
-          @@ Printf.sprintf "Are you sure you want to uninstall package %s?"
-               (Dependency.label dep)
+        let message =
+          Printf.sprintf "Are you sure you want to uninstall package %s?"
+            (Dependency.label dep)
         in
-        if not confirmed then
-          Promise.return ()
-        else
-          let sandbox = Extension_instance.sandbox instance in
-          Sandbox.focus_on_package_command ~sandbox ();
-          let+ () = Sandbox.uninstall_packages sandbox [ dep ] in
-          let (_ : Ojs.t option Promise.t) =
-            Vscode.Commands.executeCommand
-              ~command:Extension_consts.Commands.refresh_switches ~args:[]
-          in
-          let (_ : Ojs.t option Promise.t) =
-            Vscode.Commands.executeCommand
-              ~command:Extension_consts.Commands.refresh_sandbox ~args:[]
-          in
-          ()
+        with_confirmation message ~yes:"Uninstall package" @@ fun () ->
+        let open Promise.Syntax in
+        let sandbox = Extension_instance.sandbox instance in
+        Sandbox.focus_on_package_command ~sandbox ();
+        let+ () = Sandbox.uninstall_packages sandbox [ dep ] in
+        let (_ : Ojs.t option Promise.t) =
+          Vscode.Commands.executeCommand
+            ~command:Extension_consts.Commands.refresh_switches ~args:[]
+        in
+        let (_ : Ojs.t option Promise.t) =
+          Vscode.Commands.executeCommand
+            ~command:Extension_consts.Commands.refresh_sandbox ~args:[]
+        in
+        ()
       in
       ()
     in

--- a/src/treeview_sandbox.ml
+++ b/src/treeview_sandbox.ml
@@ -85,18 +85,26 @@ module Command = struct
         let arg = List.hd_exn args in
         let dep = Dependency.t_of_js arg in
         let open Promise.Syntax in
-        let sandbox = Extension_instance.sandbox instance in
-        Sandbox.focus_on_package_command ~sandbox ();
-        let+ () = Sandbox.uninstall_packages sandbox [ dep ] in
-        let (_ : Ojs.t option Promise.t) =
-          Vscode.Commands.executeCommand
-            ~command:Extension_consts.Commands.refresh_switches ~args:[]
+        let* confirmed =
+          ask_confirmation
+          @@ Printf.sprintf "Are you sure you want to uninstall package %s?"
+               (Dependency.label dep)
         in
-        let (_ : Ojs.t option Promise.t) =
-          Vscode.Commands.executeCommand
-            ~command:Extension_consts.Commands.refresh_sandbox ~args:[]
-        in
-        ()
+        if not confirmed then
+          Promise.return ()
+        else
+          let sandbox = Extension_instance.sandbox instance in
+          Sandbox.focus_on_package_command ~sandbox ();
+          let+ () = Sandbox.uninstall_packages sandbox [ dep ] in
+          let (_ : Ojs.t option Promise.t) =
+            Vscode.Commands.executeCommand
+              ~command:Extension_consts.Commands.refresh_switches ~args:[]
+          in
+          let (_ : Ojs.t option Promise.t) =
+            Vscode.Commands.executeCommand
+              ~command:Extension_consts.Commands.refresh_sandbox ~args:[]
+          in
+          ()
       in
       ()
     in

--- a/src/treeview_switches.ml
+++ b/src/treeview_switches.ml
@@ -101,31 +101,27 @@ module Command = struct
         | Package _ ->
           Promise.return
           @@ show_message `Warn "The selected item is not an opam switch."
-        | Switch (opam, switch) ->
-          let open Promise.Syntax in
-          let* confirmed =
-            ask_confirmation
-            @@ Printf.sprintf "Are you sure you want to remove switch %s?"
-                 (Dependency.label dep)
+        | Switch (opam, switch) -> (
+          let message =
+            Printf.sprintf "Are you sure you want to remove switch %s?"
+              (Dependency.label dep)
           in
-          if not confirmed then
-            Promise.return ()
-          else (
-            Sandbox.focus_on_package_command ();
-            let+ result = Opam.switch_remove opam switch |> Cmd.output in
-            match result with
-            | Error err -> show_message `Error "%s" err
-            | Ok _ ->
-              let (_ : Ojs.t option Promise.t) =
-                Vscode.Commands.executeCommand
-                  ~command:Extension_consts.Commands.refresh_switches ~args:[]
-              in
-              let (_ : Ojs.t option Promise.t) =
-                Vscode.Commands.executeCommand
-                  ~command:Extension_consts.Commands.refresh_sandbox ~args:[]
-              in
-              show_message `Info "The switch has been removed successfully."
-          )
+          with_confirmation message ~yes:"Remove switch" @@ fun () ->
+          let open Promise.Syntax in
+          Sandbox.focus_on_package_command ();
+          let+ result = Opam.switch_remove opam switch |> Cmd.output in
+          match result with
+          | Error err -> show_message `Error "%s" err
+          | Ok _ ->
+            let (_ : Ojs.t option Promise.t) =
+              Vscode.Commands.executeCommand
+                ~command:Extension_consts.Commands.refresh_switches ~args:[]
+            in
+            let (_ : Ojs.t option Promise.t) =
+              Vscode.Commands.executeCommand
+                ~command:Extension_consts.Commands.refresh_sandbox ~args:[]
+            in
+            show_message `Info "The switch has been removed successfully." )
       in
       ()
     in


### PR DESCRIPTION
Removing a switch or package is currently done without a confirmation box. Users could accidentally uninstall a package or switch and have to wait a long time to reinstall everything they need.

A simple confirmation dialog (using `showInformationMessage`) should be sufficient to avoid accidental removals.