### PR TITLE
fix #559

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Change Log
 
+## Unreleased
+
+- Fix switching between implementation/interface (#561)
+
 ## 1.8.1
 
 - Revert automatic installation of platform tools

--- a/src/switch_impl_intf.ml
+++ b/src/switch_impl_intf.ml
@@ -1,7 +1,7 @@
 open Import
 
 let send_switch_impl_intf_request client uri : string array Promise.t =
-  let data = Jsonoo.Encode.list Jsonoo.Encode.string [ uri ] in
+  let data = Jsonoo.Encode.string uri in
   let open Promise.Syntax in
   let+ response =
     LanguageClient.sendRequest client ~meth:"ocamllsp/switchImplIntf" ~data ()
@@ -9,7 +9,7 @@ let send_switch_impl_intf_request client uri : string array Promise.t =
   Jsonoo.Decode.(array string) response
 
 let send_infer_intf_request client uri : string Promise.t =
-  let data = Jsonoo.Encode.list Jsonoo.Encode.string [ uri ] in
+  let data = Jsonoo.Encode.string uri in
   let open Promise.Syntax in
   let+ response =
     LanguageClient.sendRequest client ~meth:"ocamllsp/inferIntf" ~data ()


### PR DESCRIPTION
The problem was that `Params` was an array of array of string, while the `lsp` server was expecting an array of string.

I fixed it on the extension side, but if we want to keep sending an array of array of string, we can instead adapt the `lsp` as following: 

```diff
diff --git a/ocaml-lsp-server/src/custom_requests/req_switch_impl_intf.ml b/ocaml-lsp-server/src/custom_requests/req_switch_impl_intf.ml
index 15733db..84c24b9 100644
--- a/ocaml-lsp-server/src/custom_requests/req_switch_impl_intf.ml
+++ b/ocaml-lsp-server/src/custom_requests/req_switch_impl_intf.ml
@@ -14,7 +14,8 @@ let switch (param : DocumentUri.t) : (Json.t, Jsonrpc.Response.Error.t) result =
 let on_request ~(params : Jsonrpc.Message.Structured.t option) _ =
   Fiber.return
     ( match params with
-    | Some (`List [ `String (file_uri : DocumentUri.t) ]) -> switch file_uri
+    | Some (`List [ `List [ `String (file_uri : DocumentUri.t) ] ]) ->
+      switch file_uri
     | Some json ->
       Error
         (Jsonrpc.Response.Error.make ~code:InvalidRequest
```

