### PR TITLE
Stop automatically highlighting META.* files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 - Fix switching between implementation/interface (#561)
 
+- Stop automatically highlighting suffixed META files (#565)
+
 ## 1.8.1
 
 - Revert automatic installation of platform tools

--- a/package.json
+++ b/package.json
@@ -577,9 +577,6 @@
         "filenames": [
           "META"
         ],
-        "filenamePatterns": [
-          "META.*"
-        ],
         "configuration": "./languages/META.json"
       },
       {


### PR DESCRIPTION
Closes #564

The META.* pattern interfered with syntax highlighting for other file types.