### PR TITLE
Fix showing error message if ocaml-lsp is missing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Change Log
 
+## Unreleased
+
+- Fix showing error message if ocaml-lsp is missing (#586)
+
 ## 1.8.2
 
 - Fix switching between implementation/interface (#561)

--- a/src/extension_instance.ml
+++ b/src/extension_instance.ml
@@ -51,10 +51,9 @@ let start_language_server t =
   stop_server t;
   let res =
     let open Promise.Result.Syntax in
-    let* _ =
-      let+ has_command =
-        Sandbox.has_command t.sandbox "ocamllsp" |> Promise.map Result.return
-      in
+    let* () =
+      let open Promise.Syntax in
+      let+ has_command = Sandbox.has_command t.sandbox "ocamllsp" in
       if has_command then
         Ok ()
       else


### PR DESCRIPTION
Closes #579 

Using map instead of bind with no type annotation was causing the error message to be ignored. Using a normal promise (not a result promise) is simpler.