### PR TITLE
Fix sourcemap generation

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 build:
-	dune build @all --profile=release
+	dune build src/vscode_ocaml_platform.bc.js --profile=release
 	yarn esbuild _build/default/src/vscode_ocaml_platform.bc.js \
 		--bundle \
 		--external:vscode \
@@ -8,7 +8,8 @@ build:
 		--target=es6 \
 		--minify-whitespace \
 		--minify-syntax \
-		--sourcemap=external
+		--sourcemap \
+		--sources-content=false
 .PHONY: build
 
 watch:
@@ -17,6 +18,7 @@ watch:
 
 clean:
 	dune clean
+	rm -r dist
 .PHONY: clean
 
 test:

--- a/src/dune
+++ b/src/dune
@@ -2,4 +2,6 @@
  (name vscode_ocaml_platform)
  (libraries base gen_js_api js_of_ocaml jsonoo node opam-file-format
    promise_jsoo vscode vscode_languageclient)
- (modes js))
+ (modes js)
+ (js_of_ocaml
+  (flags --source-map --pretty)))


### PR DESCRIPTION
Previously the sources were not mapped correctly in stack traces because sourcemaps are disabled by default in js_of_ocaml release mode.

Changes:
- `dune build src/vscode_ocaml_platform.bc.js` instead of `dune build @all` because `@all` unnecessarily copies the entire directory to `_build`.
- `--sourcemap` instead of `--sourcemap=external` because `external` does not include the `sourceMappingURL` in the generated JS.
- `--sources-content=false` because the generated JS is not being used in a debugger.
-  Clear the dist folder in `make clean`.
- `--source-map` in Js_of_ocaml flags because it is disabled for `--release`.
- `--pretty` so proper function names appear in stack traces.
   It seems that this has to be enabled because other combinations of flags result in `TypeError: s.toUtf16 is not a function` at runtime.


Before this patch:
```
  dist\vscode_ocaml_platform.bc.js      691.3kb
  dist\vscode_ocaml_platform.bc.js.map    1.6mb
```

After:
```
  dist\vscode_ocaml_platform.bc.js      921.8kb
  dist\vscode_ocaml_platform.bc.js.map  549.0kb
```
