### PR TITLE
Remove `which` and other cleanups

### DIFF
--- a/src/cmd.ml
+++ b/src/cmd.ml
@@ -1,14 +1,12 @@
 open Import
 
-type shell = string
-
 type spawn =
   { bin : Path.t
   ; args : string list
   }
 
 type t =
-  | Shell of shell
+  | Shell of string
   | Spawn of spawn
 
 type stdout = string

--- a/src/cmd.mli
+++ b/src/cmd.mli
@@ -2,15 +2,13 @@
 
 open Import
 
-type shell = string
-
 type spawn =
   { bin : Path.t
   ; args : string list
   }
 
 type t =
-  | Shell of shell
+  | Shell of string
   | Spawn of spawn
 
 type stdout = string

--- a/src/dune_formatter.ml
+++ b/src/dune_formatter.ml
@@ -13,7 +13,7 @@ let get_formatter instance ~document ~options:_ ~token:_ =
   let document_text = TextDocument.getText document ~range () in
   let command =
     let sandbox = Extension_instance.sandbox instance in
-    Sandbox.get_dune_command sandbox [ "format-dune-file" ]
+    Sandbox.get_command sandbox "dune" [ "format-dune-file" ]
   in
   let output =
     let open Promise.Result.Syntax in

--- a/src/dune_task_provider.ml
+++ b/src/dune_task_provider.ml
@@ -28,8 +28,7 @@ module Setting = struct
 end
 
 let folder_relative_path folders file =
-  List.fold_left
-    ~f:(fun acc (folder : WorkspaceFolder.t) ->
+  List.fold_left ~init:None folders ~f:(fun acc (folder : WorkspaceFolder.t) ->
       match acc with
       | Some _ -> acc
       | None -> (
@@ -37,10 +36,9 @@ let folder_relative_path folders file =
         match String.chop_prefix file ~prefix with
         | None -> acc
         | Some without_prefix -> Some (folder, without_prefix)))
-    ~init:None folders
 
 let get_shell_execution sandbox options =
-  let command = Sandbox.get_dune_command sandbox [ "build" ] in
+  let command = Sandbox.get_command sandbox "dune" [ "build" ] in
   Cmd.log command;
   match command with
   | Shell commandLine -> ShellExecution.makeCommandLine ~commandLine ~options ()

--- a/src/extension_instance.ml
+++ b/src/extension_instance.ml
@@ -31,7 +31,7 @@ let client_options () =
     ~documentSelector ()
 
 let server_options sandbox =
-  let command = Sandbox.get_lsp_command sandbox in
+  let command = Sandbox.get_command sandbox "ocamllsp" [] in
   Cmd.log command;
   match command with
   | Shell command ->

--- a/src/extension_instance.ml
+++ b/src/extension_instance.ml
@@ -52,9 +52,10 @@ let start_language_server t =
   let res =
     let open Promise.Result.Syntax in
     let* () =
+      let cmd = Sandbox.get_command t.sandbox "ocamllsp" [ "--version" ] in
       let open Promise.Syntax in
-      let+ has_command = Sandbox.has_command t.sandbox "ocamllsp" in
-      if has_command then
+      let+ (res : Node.ChildProcess.return) = Cmd.run cmd in
+      if res.exitCode = 0 then
         Ok ()
       else
         Error "Sandbox initialisation failed: ocaml-lsp-server is not installed"

--- a/src/opam.ml
+++ b/src/opam.ml
@@ -246,8 +246,6 @@ let switch_exists t switch =
   let+ switches = switch_list t in
   List.exists switches ~f:(Switch.equal switch)
 
-let switch_path t switch = Switch.path t switch
-
 let equal o1 o2 = Cmd.equal_spawn o1.bin o2.bin && Path.equal o1.root o2.root
 
 let switch_show ?cwd t =

--- a/src/opam.mli
+++ b/src/opam.mli
@@ -62,12 +62,6 @@ val init : t -> Cmd.t
 
 (** {4 Working with switches} *)
 
-(** Path of the switch on the filesystem.
-
-    If the switch is a local switch, the path is [switch_path ^ _opam],
-    otherwise it is the result of [opam var root]. *)
-val switch_path : t -> Switch.t -> Path.t
-
 (** Create a new switch. *)
 val switch_create : t -> name:string -> args:string list -> Cmd.t
 

--- a/src/sandbox.ml
+++ b/src/sandbox.ml
@@ -459,11 +459,6 @@ let has_command sandbox bin =
   | Ok _ -> true
   | Error _ -> false
 
-let get_lsp_command ?(args = []) sandbox : Cmd.t =
-  get_command sandbox "ocamllsp" args
-
-let get_dune_command sandbox args : Cmd.t = get_command sandbox "dune" args
-
 let get_install_command sandbox tools =
   match sandbox with
   | Opam (opam, switch) -> Some (Opam.install opam switch ~packages:tools)

--- a/src/sandbox.ml
+++ b/src/sandbox.ml
@@ -447,18 +447,6 @@ let get_command sandbox bin args : Cmd.t =
     in
     Shell command
 
-let has_command sandbox bin =
-  let open Promise.Syntax in
-  let cmd =
-    match Platform.t with
-    | Win32 -> get_command sandbox "cmd" [ "/c"; "where"; bin ]
-    | _ -> get_command sandbox "which" [ bin ]
-  in
-  let+ result = Cmd.output cmd in
-  match result with
-  | Ok _ -> true
-  | Error _ -> false
-
 let get_install_command sandbox tools =
   match sandbox with
   | Opam (opam, switch) -> Some (Opam.install opam switch ~packages:tools)

--- a/src/sandbox.mli
+++ b/src/sandbox.mli
@@ -67,12 +67,6 @@ val has_command : t -> string -> bool Promise.t
 (** Extract command to run with the sandbox *)
 val get_command : t -> string -> string list -> Cmd.t
 
-(** Extract lsp command and arguments *)
-val get_lsp_command : ?args:string list -> t -> Cmd.t
-
-(** Extract a dune command *)
-val get_dune_command : t -> string list -> Cmd.t
-
 (** Command to install dependencies in the sandbox *)
 val get_install_command : t -> string list -> Cmd.t option
 

--- a/src/sandbox.mli
+++ b/src/sandbox.mli
@@ -62,8 +62,6 @@ val select_sandbox : unit -> t option Promise.t
 
 (* Helper utils *)
 
-val has_command : t -> string -> bool Promise.t
-
 (** Extract command to run with the sandbox *)
 val get_command : t -> string -> string list -> Cmd.t
 


### PR DESCRIPTION
* Tweaks to simplify the API and keep our mli's tidier
* Removal of `which`. It is not guaranteed to exist in minimal environments such
  as nix.