### PR TITLE
Implement `Jump to Next/Previous Typed Hole` commands

### DIFF
--- a/package.json
+++ b/package.json
@@ -186,6 +186,11 @@
         "title": "Jump to Next Typed Hole"
       },
       {
+        "command": "ocaml.prev-hole",
+        "category": "OCaml",
+        "title": "Jump to Previous Typed Hole"
+      },
+      {
         "command": "ocaml.current-dune-file",
         "category": "OCaml",
         "title": "Open Dune File (located in the same folder)"
@@ -232,6 +237,11 @@
         "command": "ocaml.next-hole",
         "key": "Alt+L",
         "when": "editorLangId == ocaml || editorLangId == ocaml.interface || editorLangId == reason || editorLangId == ocaml.ocamllex || editorLangId == ocaml.menhir"
+      },
+      {
+        "command": "ocaml.prev-hole",
+        "key": "Shift+Alt+L",
+        "when": "editorLangId == ocaml || editorLangId == ocaml.interface || editorLangId == reason || editorLangId == ocaml.ocamllex || editorLangId == ocaml.menhir"
       }
     ],
     "menus": {
@@ -249,6 +259,10 @@
         },
         {
           "command": "ocaml.next-hole",
+          "when": "editorLangId == ocaml || editorLangId == ocaml.interface || editorLangId == reason || editorLangId == ocaml.ocamllex || editorLangId == ocaml.menhir"
+        },
+        {
+          "command": "ocaml.prev-hole",
           "when": "editorLangId == ocaml || editorLangId == ocaml.interface || editorLangId == reason || editorLangId == ocaml.ocamllex || editorLangId == ocaml.menhir"
         },
         {

--- a/package.json
+++ b/package.json
@@ -181,6 +181,11 @@
         }
       },
       {
+        "command": "ocaml.next-hole",
+        "category": "OCaml",
+        "title": "Jump to Next Typed Hole"
+      },
+      {
         "command": "ocaml.current-dune-file",
         "category": "OCaml",
         "title": "Open Dune File (located in the same folder)"
@@ -222,6 +227,11 @@
         "command": "ocaml.evaluate-selection",
         "key": "Shift+Enter",
         "when": "editorTextFocus && editorLangId == ocaml || editorTextFocus && editorLangId == ocaml.interface || editorTextFocus && editorLangId == reason || editorTextFocus && editorLangId == ocaml.ocamllex || editorTextFocus && editorLangId == ocaml.menhir"
+      },
+      {
+        "command": "ocaml.next-hole",
+        "key": "Alt+L",
+        "when": "editorLangId == ocaml || editorLangId == ocaml.interface || editorLangId == reason || editorLangId == ocaml.ocamllex || editorLangId == ocaml.menhir"
       }
     ],
     "menus": {
@@ -236,6 +246,10 @@
         {
           "command": "ocaml.current-dune-file",
           "when": "editorIsOpen"
+        },
+        {
+          "command": "ocaml.next-hole",
+          "when": "editorLangId == ocaml || editorLangId == ocaml.interface || editorLangId == reason || editorLangId == ocaml.ocamllex || editorLangId == ocaml.menhir"
         },
         {
           "command": "ocaml.refresh-switches",

--- a/src/extension_commands.ml
+++ b/src/extension_commands.ml
@@ -112,10 +112,12 @@ let _open_current_dune_file =
     | None ->
       (* this command is available (in the command palette) only when a file is
          open *)
-      show_message `Error
-        "The command \"OCaml: Open Dune File\" should be run only with a file \
-         open in the editor, so the command can look for a dune file in the \
-         same folder as the open file."
+      show_message `Error "%s"
+      @@ Extension_consts.Command_errors.text_editor_must_be_active
+           "Open Dune File"
+           ~expl:
+             "The command can look for a dune file in the same folder as the \
+              open file."
     | Some text_editor ->
       let doc = TextEditor.document text_editor in
       let uri = TextDocument.uri doc in

--- a/src/extension_consts.ml
+++ b/src/extension_consts.ml
@@ -33,6 +33,9 @@ module Commands = struct
 
   let open_repl = ocaml_prefixed "open-repl"
 
+  let next_hole = ocaml_prefixed "next-hole"
+end
+
 module Command_errors = struct
   let text_editor_must_be_active ~expl cmd_name =
     Printf.sprintf

--- a/src/extension_consts.ml
+++ b/src/extension_consts.ml
@@ -32,6 +32,13 @@ module Commands = struct
   let evaluate_selection = ocaml_prefixed "evaluate-selection"
 
   let open_repl = ocaml_prefixed "open-repl"
+
+module Command_errors = struct
+  let text_editor_must_be_active ~expl cmd_name =
+    Printf.sprintf
+      "The command \"OCaml: %s\" should be run only with a file open in the \
+       editor. %s"
+      cmd_name expl
 end
 
 (* TODO: Refactor the code so that we don't need any "constants" module *)

--- a/src/extension_consts.ml
+++ b/src/extension_consts.ml
@@ -34,6 +34,8 @@ module Commands = struct
   let open_repl = ocaml_prefixed "open-repl"
 
   let next_hole = ocaml_prefixed "next-hole"
+
+  let prev_hole = ocaml_prefixed "prev-hole"
 end
 
 module Command_errors = struct

--- a/src/import.ml
+++ b/src/import.ml
@@ -86,3 +86,27 @@ let with_confirmation message ~yes ?(no = "Cancel") f =
   match choice with
   | Some true -> f ()
   | _ -> Promise.return ()
+
+(** Builds application-specific functionality around [Vscode.Position] *)
+module Position = struct
+  include Vscode.Position
+
+  let compare p1 p2 =
+    let r = Vscode.Position.compareTo p1 ~other:p2 in
+    if r < 0 then
+      Ordering.Less
+    else if r = 0 then
+      Equal
+    else
+      Greater
+end
+
+(** Build application-specific functionality around [Vscode.Range] *)
+module Range = struct
+  include Vscode.Range
+
+  let compare r1 r2 =
+    match Position.compare (Vscode.Range.start r1) (Vscode.Range.start r2) with
+    | (Ordering.Less | Greater) as r -> r
+    | Equal -> Position.compare (Vscode.Range.end_ r1) (Vscode.Range.end_ r2)
+end

--- a/vscode/vscode/vscode.ml
+++ b/vscode/vscode/vscode.ml
@@ -690,6 +690,8 @@ module TextEditor = struct
 
     val selection : t -> Selection.t [@@js.get]
 
+    val set_selection : t -> Selection.t -> unit [@@js.set "selection"]
+
     val selections : t -> Selection.t list [@@js.get]
 
     val visibleRanges : t -> Range.t list [@@js.get]

--- a/vscode/vscode/vscode.ml
+++ b/vscode/vscode/vscode.ml
@@ -107,6 +107,60 @@ module Range = struct
       [@@js.call]]
 end
 
+module DiagnosticSeverity = struct
+  type t =
+    | Error [@js 0]
+    | Hint [@js 1]
+    | Information [@js 2]
+    | Warning [@js 3]
+  [@@js.enum] [@@js]
+end
+
+module Diagnostic = struct
+  include Interface.Make ()
+
+  type code =
+    ([ `String of string
+     | `Int of int
+     ]
+    [@js.union])
+  [@@js]
+
+  let code_of_js js_val =
+    (* [code?: string | number | {target: Uri, value: string | number}]
+
+       The latter is not supported at the moment *)
+    match Ojs.type_of js_val with
+    | "string" -> `String ([%js.to: string] js_val)
+    | "number" -> `Int ([%js.to: int] js_val)
+    | type_s ->
+      failwith
+      @@ "Diagnostic.code is supported only of types [string] and [number] but \
+          not " ^ type_s
+
+  include
+    [%js:
+    val message : t -> string [@@js.get]
+
+    val range : t -> Range.t [@@js.get]
+
+    val severity : t -> DiagnosticSeverity.t [@@js.get]
+
+    val source : t -> string or_undefined [@@js.get]
+
+    val code : t -> code or_undefined [@@js.get]
+
+    val make :
+         range:Range.t
+      -> message:string
+      -> ?severity:DiagnosticSeverity.t
+      -> unit
+      -> t
+      [@@js.new "vscode.Diagnostic"]]
+
+  let make ?severity ~message range = make ~range ~message ?severity ()
+end
+
 module TextLine = struct
   include Interface.Make ()
 
@@ -2657,7 +2711,13 @@ module Languages = struct
          selector:DocumentSelector.t
       -> provider:DocumentFormattingEditProvider.t
       -> Disposable.t
-      [@@js.global "vscode.languages.registerDocumentFormattingEditProvider"]]
+      [@@js.global "vscode.languages.registerDocumentFormattingEditProvider"]
+
+    val getDiagnostics : Uri.t -> Diagnostic.t list
+      [@@js.global "vscode.languages.getDiagnostics"]
+
+    val get_diagnostics_all : unit -> (Uri.t * Diagnostic.t list) list
+      [@@js.global "vscode.languages.getDiagnostics"]]
 end
 
 module Tasks = struct

--- a/vscode/vscode/vscode.mli
+++ b/vscode/vscode/vscode.mli
@@ -86,6 +86,35 @@ module Range : sig
   val with_ : t -> ?start:Position.t -> ?end_:Position.t -> unit -> t
 end
 
+module DiagnosticSeverity : sig
+  type t =
+    | Error
+    | Hint
+    | Information
+    | Warning
+end
+
+module Diagnostic : sig
+  include Js.T
+
+  type code =
+    [ `String of string
+    | `Int of int
+    ]
+
+  val message : t -> string
+
+  val range : t -> Range.t
+
+  val severity : t -> DiagnosticSeverity.t
+
+  val source : t -> string or_undefined
+
+  val code : t -> code or_undefined
+
+  val make : ?severity:DiagnosticSeverity.t -> message:string -> Range.t -> t
+end
+
 module TextLine : sig
   include Js.T
 
@@ -1975,6 +2004,10 @@ module Languages : sig
        selector:DocumentSelector.t
     -> provider:DocumentFormattingEditProvider.t
     -> Disposable.t
+
+  val getDiagnostics : Uri.t -> Diagnostic.t list
+
+  val get_diagnostics_all : unit -> (Uri.t * Diagnostic.t list) list
 end
 
 module Tasks : sig

--- a/vscode/vscode/vscode.mli
+++ b/vscode/vscode/vscode.mli
@@ -550,6 +550,8 @@ module TextEditor : sig
 
   val selection : t -> Selection.t
 
+  val set_selection : t -> Selection.t -> unit
+
   val selections : t -> Selection.t list
 
   val visibleRanges : t -> Range.t list


### PR DESCRIPTION
Alternative implementation to #637 based on jumping through error diagnostics for typed holes sent from ocaml-lsp. The error diagnostics are sent in ocaml-lsp PR https://github.com/ocaml/ocaml-lsp/pull/466.