### PR TITLE
Add some bindings to vscode diagnostics manipulation

### DIFF
--- a/src/vscode_ocaml_platform.ml
+++ b/src/vscode_ocaml_platform.ml
@@ -38,7 +38,7 @@ let activate (extension : ExtensionContext.t) =
   let sandbox_opt = Sandbox.of_settings_or_detect () in
   let (_ : unit Promise.t) =
     let* sandbox_opt = sandbox_opt in
-    let is_fallback = Option.is_empty sandbox_opt in
+    let is_fallback = Option.is_none sandbox_opt in
     if
       is_fallback
       (* if the sandbox we just set up is a fallback sandbox, we create a pop-up

--- a/vscode/vscode/vscode.ml
+++ b/vscode/vscode/vscode.ml
@@ -2753,7 +2753,7 @@ module Languages = struct
     val getDiagnostics : Uri.t -> Diagnostic.t list
       [@@js.global "vscode.languages.getDiagnostics"]
 
-    val get_diagnostics_all : unit -> (Uri.t * Diagnostic.t list) list
+    val getDiagnostics_all : unit -> (Uri.t * Diagnostic.t list) list
       [@@js.global "vscode.languages.getDiagnostics"]]
 end
 

--- a/vscode/vscode/vscode.ml
+++ b/vscode/vscode/vscode.ml
@@ -1212,7 +1212,7 @@ module DiagnosticTag = struct
 end
 
 module Diagnostic = struct
-  include Interface.Make ()
+  include Class.Make ()
 
   type string_or_int =
     ([ `String of string

--- a/vscode/vscode/vscode.ml
+++ b/vscode/vscode/vscode.ml
@@ -107,60 +107,6 @@ module Range = struct
       [@@js.call]]
 end
 
-module DiagnosticSeverity = struct
-  type t =
-    | Error [@js 0]
-    | Hint [@js 1]
-    | Information [@js 2]
-    | Warning [@js 3]
-  [@@js.enum] [@@js]
-end
-
-module Diagnostic = struct
-  include Interface.Make ()
-
-  type code =
-    ([ `String of string
-     | `Int of int
-     ]
-    [@js.union])
-  [@@js]
-
-  let code_of_js js_val =
-    (* [code?: string | number | {target: Uri, value: string | number}]
-
-       The latter is not supported at the moment *)
-    match Ojs.type_of js_val with
-    | "string" -> `String ([%js.to: string] js_val)
-    | "number" -> `Int ([%js.to: int] js_val)
-    | type_s ->
-      failwith
-      @@ "Diagnostic.code is supported only of types [string] and [number] but \
-          not " ^ type_s
-
-  include
-    [%js:
-    val message : t -> string [@@js.get]
-
-    val range : t -> Range.t [@@js.get]
-
-    val severity : t -> DiagnosticSeverity.t [@@js.get]
-
-    val source : t -> string or_undefined [@@js.get]
-
-    val code : t -> code or_undefined [@@js.get]
-
-    val make :
-         range:Range.t
-      -> message:string
-      -> ?severity:DiagnosticSeverity.t
-      -> unit
-      -> t
-      [@@js.new "vscode.Diagnostic"]]
-
-  let make ?severity ~message range = make ~range ~message ?severity ()
-end
-
 module TextLine = struct
   include Interface.Make ()
 
@@ -1234,6 +1180,73 @@ module ProgressOptions = struct
     val create :
       location:location -> ?title:string -> ?cancellable:bool -> unit -> t
       [@@js.builder]]
+end
+
+module DiagnosticSeverity = struct
+  type t =
+    | Error [@js 0]
+    | Hint [@js 1]
+    | Information [@js 2]
+    | Warning [@js 3]
+  [@@js.enum] [@@js]
+end
+
+module Diagnostic = struct
+  include Interface.Make ()
+
+  type string_or_int =
+    ([ `String of string
+     | `Int of int
+     ]
+    [@js.union])
+  [@@js]
+
+  let string_or_int_of_js js_val =
+    match Ojs.type_of js_val with
+    | "string" -> `String ([%js.to: string] js_val)
+    | "number" -> `Int ([%js.to: int] js_val)
+    | _ -> assert false
+
+  type code_target =
+    { value : string_or_int
+    ; target : Uri.t
+    }
+  [@@js]
+
+  type code =
+    ([ `String of string
+     | `Int of int
+     | `Targeted of code_target
+     ]
+    [@js.union])
+  [@@js]
+
+  let code_of_js js_val =
+    match Ojs.type_of js_val with
+    | "object" -> `Targeted ([%js.to: code_target] js_val)
+    | _ -> string_or_int_of_js js_val
+
+  include
+    [%js:
+    val message : t -> string [@@js.get]
+
+    val range : t -> Range.t [@@js.get]
+
+    val severity : t -> DiagnosticSeverity.t [@@js.get]
+
+    val source : t -> string or_undefined [@@js.get]
+
+    val code : t -> code or_undefined [@@js.get]
+
+    val make :
+         range:Range.t
+      -> message:string
+      -> ?severity:DiagnosticSeverity.t
+      -> unit
+      -> t
+      [@@js.new "vscode.Diagnostic"]]
+
+  let make ?severity ~message range = make ~range ~message ?severity ()
 end
 
 module TextDocumentShowOptions = struct

--- a/vscode/vscode/vscode.ml
+++ b/vscode/vscode/vscode.ml
@@ -1191,6 +1191,26 @@ module DiagnosticSeverity = struct
   [@@js.enum] [@@js]
 end
 
+module DiagnosticRelatedInformation = struct
+  include Class.Make ()
+
+  include
+    [%js:
+    val location : t -> Location.t [@@js.get]
+
+    val message : t -> string [@@js.get]
+
+    val make : location:Location.t -> message:string -> t
+      [@@js.new "vscode.DiagnosticRelatedInformation"]]
+end
+
+module DiagnosticTag = struct
+  type t =
+    | Unnecessary [@js 1]
+    | Deprecated [@js 2]
+  [@@js.enum] [@@js]
+end
+
 module Diagnostic = struct
   include Interface.Make ()
 
@@ -1237,6 +1257,12 @@ module Diagnostic = struct
     val source : t -> string or_undefined [@@js.get]
 
     val code : t -> code or_undefined [@@js.get]
+
+    val relatedInformation :
+      t -> DiagnosticRelatedInformation.t list or_undefined
+      [@@js.get]
+
+    val tags : t -> DiagnosticTag.t list or_undefined [@@js.get]
 
     val make :
          range:Range.t

--- a/vscode/vscode/vscode.mli
+++ b/vscode/vscode/vscode.mli
@@ -923,6 +923,22 @@ module DiagnosticSeverity : sig
     | Warning
 end
 
+module DiagnosticRelatedInformation : sig
+  include Js.T
+
+  val location : t -> Location.t
+
+  val message : t -> string
+
+  val make : location:Location.t -> message:string -> t
+end
+
+module DiagnosticTag : sig
+  type t =
+    | Unnecessary
+    | Deprecated
+end
+
 module Diagnostic : sig
   include Js.T
 
@@ -946,6 +962,10 @@ module Diagnostic : sig
   val source : t -> string option
 
   val code : t -> code option
+
+  val relatedInformation : t -> DiagnosticRelatedInformation.t list option
+
+  val tags : t -> DiagnosticTag.t list option
 
   val make : ?severity:DiagnosticSeverity.t -> message:string -> Range.t -> t
 end

--- a/vscode/vscode/vscode.mli
+++ b/vscode/vscode/vscode.mli
@@ -86,35 +86,6 @@ module Range : sig
   val with_ : t -> ?start:Position.t -> ?end_:Position.t -> unit -> t
 end
 
-module DiagnosticSeverity : sig
-  type t =
-    | Error
-    | Hint
-    | Information
-    | Warning
-end
-
-module Diagnostic : sig
-  include Js.T
-
-  type code =
-    [ `String of string
-    | `Int of int
-    ]
-
-  val message : t -> string
-
-  val range : t -> Range.t
-
-  val severity : t -> DiagnosticSeverity.t
-
-  val source : t -> string or_undefined
-
-  val code : t -> code or_undefined
-
-  val make : ?severity:DiagnosticSeverity.t -> message:string -> Range.t -> t
-end
-
 module TextLine : sig
   include Js.T
 
@@ -944,6 +915,41 @@ module ProgressOptions : sig
     location:location -> ?title:string -> ?cancellable:bool -> unit -> t
 end
 
+module DiagnosticSeverity : sig
+  type t =
+    | Error
+    | Hint
+    | Information
+    | Warning
+end
+
+module Diagnostic : sig
+  include Js.T
+
+  type code_target =
+    { value : [ `String of string | `Int of int ]
+    ; target : Uri.t
+    }
+
+  type code =
+    [ `String of string
+    | `Int of int
+    | `Targeted of code_target
+    ]
+
+  val message : t -> string
+
+  val range : t -> Range.t
+
+  val severity : t -> DiagnosticSeverity.t
+
+  val source : t -> string option
+
+  val code : t -> code option
+
+  val make : ?severity:DiagnosticSeverity.t -> message:string -> Range.t -> t
+end
+
 module TextDocumentShowOptions : sig
   include Js.T
 
@@ -1168,7 +1174,7 @@ end
 module SecretStorage : sig
   include Js.T
 
-  val get : t -> key:string -> string or_undefined Promise.t
+  val get : t -> key:string -> string option Promise.t
 
   val store : t -> key:string -> value:string -> Promise.void
 

--- a/vscode/vscode/vscode.mli
+++ b/vscode/vscode/vscode.mli
@@ -2031,7 +2031,7 @@ module Languages : sig
 
   val getDiagnostics : Uri.t -> Diagnostic.t list
 
-  val get_diagnostics_all : unit -> (Uri.t * Diagnostic.t list) list
+  val getDiagnostics_all : unit -> (Uri.t * Diagnostic.t list) list
 end
 
 module Tasks : sig

--- a/vscode/vscode/vscode.mli
+++ b/vscode/vscode/vscode.mli
@@ -86,6 +86,35 @@ module Range : sig
   val with_ : t -> ?start:Position.t -> ?end_:Position.t -> unit -> t
 end
 
+module DiagnosticSeverity : sig
+  type t =
+    | Error
+    | Hint
+    | Information
+    | Warning
+end
+
+module Diagnostic : sig
+  include Js.T
+
+  type code =
+    [ `String of string
+    | `Int of int
+    ]
+
+  val message : t -> string
+
+  val range : t -> Range.t
+
+  val severity : t -> DiagnosticSeverity.t
+
+  val source : t -> string or_undefined
+
+  val code : t -> code or_undefined
+
+  val make : ?severity:DiagnosticSeverity.t -> message:string -> Range.t -> t
+end
+
 module TextLine : sig
   include Js.T
 
@@ -1973,6 +2002,10 @@ module Languages : sig
        selector:DocumentSelector.t
     -> provider:DocumentFormattingEditProvider.t
     -> Disposable.t
+
+  val getDiagnostics : Uri.t -> Diagnostic.t list
+
+  val get_diagnostics_all : unit -> (Uri.t * Diagnostic.t list) list
 end
 
 module Tasks : sig


### PR DESCRIPTION
I had this commit as part of #640 , but since I'm not sure we're going further with the approach of #640, decided to create another PR. 

The bindings aren't full, but were somewhat tricky to get right (at least for me as a newbie to ojs). 

Fixed a "deprecated" warning along the way.