### PR TITLE
Jump to holes ocamllsp typed holes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,21 @@
 # Change Log
 
+## Unreleased
+
+- Add commands `Jump to Next Typed Hole` (shortcut: `Alt + L`) and
+  `Jump to Previous Typed Hole` (shortcut: `Alt + Shift + L`)
+
+  _What typed holes are_
+
+  Merlin has a concept of "typed holes" that are syntactically represented as
+  `_`. Files that incorporate typed holes are not considered valid OCaml, but
+  Merlin and OCaml-LSP support them. One example when such typed holes can occur
+  is when one "destructs" a value, e.g., destructing `(Some 1)` will generate
+  code `match Some 1 with Some _ -> _ | None -> _`. While the first underscore
+  is a valid "match-all"/wildcard pattern, the rest of underscores are typed
+  holes that one needs to replace with valid OCaml code. These new commands help
+  to navigate easily from one hole to another.
+
 ## 1.8.4
 
 - Fix inclusion of files in extension package

--- a/package.json
+++ b/package.json
@@ -181,6 +181,16 @@
         }
       },
       {
+        "command": "ocaml.next-hole",
+        "category": "OCaml",
+        "title": "Jump to Next Typed Hole"
+      },
+      {
+        "command": "ocaml.prev-hole",
+        "category": "OCaml",
+        "title": "Jump to Previous Typed Hole"
+      },
+      {
         "command": "ocaml.current-dune-file",
         "category": "OCaml",
         "title": "Open Dune File (located in the same folder)"
@@ -222,6 +232,16 @@
         "command": "ocaml.evaluate-selection",
         "key": "Shift+Enter",
         "when": "editorTextFocus && editorLangId == ocaml || editorTextFocus && editorLangId == ocaml.interface || editorTextFocus && editorLangId == reason || editorTextFocus && editorLangId == ocaml.ocamllex || editorTextFocus && editorLangId == ocaml.menhir"
+      },
+      {
+        "command": "ocaml.next-hole",
+        "key": "Alt+L",
+        "when": "editorLangId == ocaml || editorLangId == ocaml.interface || editorLangId == reason || editorLangId == ocaml.ocamllex"
+      },
+      {
+        "command": "ocaml.prev-hole",
+        "key": "Shift+Alt+L",
+        "when": "editorLangId == ocaml || editorLangId == ocaml.interface || editorLangId == reason || editorLangId == ocaml.ocamllex"
       }
     ],
     "menus": {
@@ -236,6 +256,14 @@
         {
           "command": "ocaml.current-dune-file",
           "when": "editorIsOpen"
+        },
+        {
+          "command": "ocaml.next-hole",
+          "when": "editorLangId == ocaml || editorLangId == ocaml.interface || editorLangId == reason || editorLangId == ocaml.ocamllex"
+        },
+        {
+          "command": "ocaml.prev-hole",
+          "when": "editorLangId == ocaml || editorLangId == ocaml.interface || editorLangId == reason || editorLangId == ocaml.ocamllex"
         },
         {
           "command": "ocaml.refresh-switches",

--- a/src/custom_requests.ml
+++ b/src/custom_requests.ml
@@ -1,0 +1,22 @@
+open Import
+
+let ocamllsp_prefixed s = "ocamllsp/" ^ s
+
+module Typed_holes : sig
+  (** [send_request client ~for_doc] will fetch ranges of holes in the file at
+      the URI [for_doc] *)
+  val send_request : LanguageClient.t -> for_doc:Uri.t -> Range.t list Promise.t
+end = struct
+  let meth = ocamllsp_prefixed "typedHoles"
+
+  let encode_params uri =
+    Jsonoo.Encode.(object_ [ ("uri", string @@ Uri.toString uri ()) ])
+
+  let decode_response json = Jsonoo.Decode.list Range.t_of_json json
+
+  let send_request client ~for_doc:uri =
+    let data = encode_params uri in
+    let open Promise.Syntax in
+    let+ response = LanguageClient.sendRequest client ~meth ~data () in
+    decode_response response
+end

--- a/src/extension_commands.ml
+++ b/src/extension_commands.ml
@@ -112,10 +112,12 @@ let _open_current_dune_file =
     | None ->
       (* this command is available (in the command palette) only when a file is
          open *)
-      show_message `Error
-        "The command \"OCaml: Open Dune File\" should be run only with a file \
-         open in the editor, so the command can look for a dune file in the \
-         same folder as the open file."
+      show_message `Error "%s"
+      @@ Extension_consts.Command_errors.text_editor_must_be_active
+           "Open Dune File"
+           ~expl:
+             "The command can look for a dune file in the same folder as the \
+              open file."
     | Some text_editor ->
       let doc = TextEditor.document text_editor in
       let uri = TextDocument.uri doc in

--- a/src/extension_consts.ml
+++ b/src/extension_consts.ml
@@ -33,6 +33,11 @@ module Commands = struct
 
   let open_repl = ocaml_prefixed "open-repl"
 
+  let next_hole = ocaml_prefixed "next-hole"
+
+  let prev_hole = ocaml_prefixed "prev-hole"
+end
+
 module Command_errors = struct
   let text_editor_must_be_active ~expl cmd_name =
     Printf.sprintf

--- a/src/extension_consts.ml
+++ b/src/extension_consts.ml
@@ -32,6 +32,13 @@ module Commands = struct
   let evaluate_selection = ocaml_prefixed "evaluate-selection"
 
   let open_repl = ocaml_prefixed "open-repl"
+
+module Command_errors = struct
+  let text_editor_must_be_active ~expl cmd_name =
+    Printf.sprintf
+      "The command \"OCaml: %s\" should be run only with a file open in the \
+       editor. %s"
+      cmd_name expl
 end
 
 (* TODO: Refactor the code so that we don't need any "constants" module *)

--- a/src/import.ml
+++ b/src/import.ml
@@ -26,6 +26,28 @@ module Option = struct
   end
 end
 
+module Ordering = struct
+  let is_less = function
+    | Ordering.Less -> true
+    | Greater
+    | Equal ->
+      false
+
+  let is_greater = function
+    | Ordering.Greater -> true
+    | Less
+    | Equal ->
+      false
+
+  let is_equal = function
+    | Ordering.Equal -> true
+    | Less
+    | Greater ->
+      false
+
+  include Ordering
+end
+
 module Or_error = struct
   type 'a t = ('a, string) result
 end

--- a/src/import.ml
+++ b/src/import.ml
@@ -86,3 +86,27 @@ let with_confirmation message ~yes ?(no = "Cancel") f =
   match choice with
   | Some true -> f ()
   | _ -> Promise.return ()
+
+(** Builds application-specific functionality around [Vscode.Position] *)
+module Position = struct
+  let compare p1 p2 =
+    let r = Position.compareTo p1 ~other:p2 in
+    if r < 0 then
+      Ordering.Less
+    else if r = 0 then
+      Equal
+    else
+      Greater
+
+  include Vscode.Position
+end
+
+(** Build application-specific functionality around [Vscode.Range] *)
+module Range = struct
+  let compare r1 r2 =
+    match Position.compare (Range.start r1) (Range.start r2) with
+    | (Ordering.Less | Greater) as r -> r
+    | Equal -> Position.compare (Range.end_ r1) (Range.end_ r2)
+
+  include Vscode.Range
+end

--- a/src/import.ml
+++ b/src/import.ml
@@ -14,6 +14,13 @@ let property_exists json property =
 
 include Base
 
+module List = struct
+  include List
+
+  let sort lst ~compare =
+    List.sort lst ~compare:(fun a b -> compare a b |> Ordering.to_int)
+end
+
 type ('a, 'b) result = ('a, 'b) Result.t
 
 module Option = struct

--- a/src/import.ml
+++ b/src/import.ml
@@ -98,6 +98,16 @@ module Position = struct
     else
       Greater
 
+  let t_of_json json =
+    let line = Jsonoo.Decode.(field "line" int) json in
+    let character = Jsonoo.Decode.(field "character" int) json in
+    Position.make ~line ~character
+
+  let json_of_t t =
+    let line = Position.line t in
+    let character = Position.character t in
+    Jsonoo.Encode.(object_ [ ("line", int line); ("character", int character) ])
+
   include Vscode.Position
 end
 
@@ -107,6 +117,16 @@ module Range = struct
     match Position.compare (Range.start r1) (Range.start r2) with
     | (Ordering.Less | Greater) as r -> r
     | Equal -> Position.compare (Range.end_ r1) (Range.end_ r2)
+
+  let t_of_json json =
+    let start = Jsonoo.Decode.field "start" Position.t_of_json json in
+    let end_ = Jsonoo.Decode.field "end" Position.t_of_json json in
+    Range.makePositions ~start ~end_
+
+  let json_of_t t =
+    let start = Range.start t |> Position.json_of_t in
+    let end_ = Range.end_ t |> Position.json_of_t in
+    Jsonoo.Encode.(object_ [ ("start", start); ("end", end_) ])
 
   include Vscode.Range
 end

--- a/src/ocaml_lsp.ml
+++ b/src/ocaml_lsp.ml
@@ -4,12 +4,14 @@ type t =
   { interfaceSpecificLangId : bool
   ; handleSwitchImplIntf : bool
   ; handleInferIntf : bool
+  ; handleTypedHoles : bool
   }
 
 let default =
   { interfaceSpecificLangId = false
   ; handleSwitchImplIntf = false
   ; handleInferIntf = false
+  ; handleTypedHoles = false
   }
 
 let default_field key decode default json =
@@ -30,7 +32,14 @@ let of_json (json : Jsonoo.t) =
     let handleInferIntf =
       default_field "handleInferIntf" bool default.handleInferIntf json
     in
-    { interfaceSpecificLangId; handleSwitchImplIntf; handleInferIntf }
+    let handleTypedHoles =
+      default_field "handleTypedHoles" bool default.handleTypedHoles json
+    in
+    { interfaceSpecificLangId
+    ; handleSwitchImplIntf
+    ; handleInferIntf
+    ; handleTypedHoles
+    }
   with
   | Jsonoo.Decode_error _ ->
     show_message `Warn
@@ -52,3 +61,5 @@ let has_interface_specific_lang_id t = t.interfaceSpecificLangId
 let can_handle_switch_impl_intf t = t.handleSwitchImplIntf
 
 let can_handle_infer_intf t = t.handleSwitchImplIntf
+
+let can_handle_typed_holes t = t.handleTypedHoles

--- a/src/ocaml_lsp.mli
+++ b/src/ocaml_lsp.mli
@@ -9,3 +9,5 @@ val has_interface_specific_lang_id : t -> bool
 val can_handle_switch_impl_intf : t -> bool
 
 val can_handle_infer_intf : t -> bool
+
+val can_handle_typed_holes : t -> bool

--- a/vscode/vscode/vscode.ml
+++ b/vscode/vscode/vscode.ml
@@ -690,6 +690,8 @@ module TextEditor = struct
 
     val selection : t -> Selection.t [@@js.get]
 
+    val set_selection : t -> Selection.t -> unit [@@js.set "selection"]
+
     val selections : t -> Selection.t list [@@js.get]
 
     val visibleRanges : t -> Range.t list [@@js.get]

--- a/vscode/vscode/vscode.mli
+++ b/vscode/vscode/vscode.mli
@@ -550,6 +550,8 @@ module TextEditor : sig
 
   val selection : t -> Selection.t
 
+  val set_selection : t -> Selection.t -> unit
+
   val selections : t -> Selection.t list
 
   val visibleRanges : t -> Range.t list


### PR DESCRIPTION
Uses a custom request in ocamllsp to jump around holes. This should allow to eliminate too tight coupling with diagnostics, which caused problems when we want to jump to the first hole in a destructed code.