### PR TITLE
Makefile for faster development

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -58,7 +58,7 @@ jobs:
         run: yarn fmt:check
 
       - name: Build extension
-        run: opam exec -- make build
+        run: opam exec -- make release-build
 
       - name: Package extension
         run: yarn package
@@ -143,7 +143,7 @@ jobs:
 
       - run: opam install . --deps-only
 
-      - run: opam exec -- make build
+      - run: opam exec -- make release-build
 
       - run: opam exec -- opam-dune-lint
 

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,15 @@
 build:
+	dune build src/vscode_ocaml_platform.bc.js
+	yarn esbuild _build/default/src/vscode_ocaml_platform.bc.js \
+		--bundle \
+		--external:vscode \
+		--outdir=dist \
+		--platform=node \
+		--target=es6 \
+		--sourcemap
+.PHONY: build
+
+release-build:
 	dune build src/vscode_ocaml_platform.bc.js --profile=release
 	yarn esbuild _build/default/src/vscode_ocaml_platform.bc.js \
 		--bundle \
@@ -10,10 +21,10 @@ build:
 		--minify-syntax \
 		--sourcemap \
 		--sources-content=false
-.PHONY: build
+.PHONY: release-build
 
 watch:
-	dune build @all -w
+	dune build @all -w --terminal-persistence=clear-on-rebuild
 .PHONY: watch
 
 clean:


### PR DESCRIPTION
separate `make build` and `make release-build` to 
- get faster builds and `make install`
- get warnings as errors

I grepped `release` to see whether releasing code relies on `build` target but couldn't figure out for sure, so if I'm missing something let me know.