### PR TITLE
Pass process environment variables (+ extra) to OCaml-LSP (using a workspace configuration)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,12 @@
   code `match Some 1 with Some _ -> _ | None -> _`. While the first underscore
   is a valid "match-all"/wildcard pattern, the rest of underscores are typed
   holes that one needs to replace with valid OCaml code. These new commands help
-  to navigate easily from one hole to another.
+
+- Rename the extension's section in VS Code Settings from `OCaml configuration`
+  to `OCaml Platform` (#674)
+
+- Add `ocaml.server.extraEnv` configuration option to pass extra environment
+  variables to the language server, i.e., OCaml-LSP (#674)
 
 ## 1.8.4
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
   code `match Some 1 with Some _ -> _ | None -> _`. While the first underscore
   is a valid "match-all"/wildcard pattern, the rest of underscores are typed
   holes that one needs to replace with valid OCaml code. These new commands help
+  to navigate easily from one hole to another (#643)
 
 - Rename the extension's section in VS Code Settings from `OCaml configuration`
   to `OCaml Platform` (#674)

--- a/package.json
+++ b/package.json
@@ -367,6 +367,14 @@
           "default": null,
           "description": "Determines where to find the sandbox for a given project"
         },
+        "ocaml.server.extraEnv": {
+          "type": [
+            "null",
+            "object"
+          ],
+          "default": null,
+          "markdownDescription": "Extra environment variables that will be passed to OCaml LSP executable. Useful for debugging purposes mostly."
+        },
         "ocaml.dune.autoDetect": {
           "type": "boolean",
           "default": true,

--- a/package.json
+++ b/package.json
@@ -360,7 +360,7 @@
       ]
     },
     "configuration": {
-      "title": "OCaml configuration",
+      "title": "OCaml Platform",
       "properties": {
         "ocaml.sandbox": {
           "type": "object",

--- a/src/dune_task_provider.ml
+++ b/src/dune_task_provider.ml
@@ -24,7 +24,8 @@ module Setting = struct
     bool t
 
   let t =
-    Settings.create ~scope:Workspace ~key:"dune.autoDetect" ~of_json ~to_json
+    Settings.create_setting ~scope:Workspace ~key:"dune.autoDetect" ~of_json
+      ~to_json
 end
 
 let folder_relative_path folders file =

--- a/src/extension_instance.ml
+++ b/src/extension_instance.ml
@@ -33,13 +33,21 @@ let client_options () =
 let server_options sandbox =
   let command = Sandbox.get_command sandbox "ocamllsp" [] in
   Cmd.log command;
+  let env =
+    let extra_env_vars =
+      Settings.server_extraEnv () |> Option.value ~default:Interop.Dict.empty
+    in
+    Interop.Dict.union (fun _k _v1 v2 -> Some v2) Process.Env.env extra_env_vars
+  in
   match command with
   | Shell command ->
-    let options = LanguageClient.ExecutableOptions.create ~shell:true () in
+    let options = LanguageClient.ExecutableOptions.create ~env ~shell:true () in
     LanguageClient.Executable.create ~command ~options ()
   | Spawn { bin; args } ->
     let command = Path.to_string bin in
-    let options = LanguageClient.ExecutableOptions.create ~shell:false () in
+    let options =
+      LanguageClient.ExecutableOptions.create ~env ~shell:false ()
+    in
     LanguageClient.Executable.create ~command ~args ~options ()
 
 let stop_server t =

--- a/src/ocaml_windows.ml
+++ b/src/ocaml_windows.ml
@@ -3,7 +3,7 @@ open Import
 let ocaml_env_binary = Path.of_string "ocaml-env"
 
 let ocaml_env_setting =
-  Settings.create ~scope:Global ~key:"ocaml.useOcamlEnv"
+  Settings.create_setting ~scope:Global ~key:"ocaml.useOcamlEnv"
     ~of_json:Jsonoo.Decode.bool ~to_json:Jsonoo.Encode.bool
 
 let use_ocaml_env () =

--- a/src/repl.ml
+++ b/src/repl.ml
@@ -13,7 +13,7 @@ module Repl_path = struct
 
   let key = "path"
 
-  let t = Settings.create ~scope:Global ~key ~of_json ~to_json
+  let t = Settings.create_setting ~scope:Global ~key ~of_json ~to_json
 end
 
 module Repl_args = struct
@@ -29,7 +29,7 @@ module Repl_args = struct
 
   let key = "args"
 
-  let t = Settings.create ~scope:Global ~key ~of_json ~to_json
+  let t = Settings.create_setting ~scope:Global ~key ~of_json ~to_json
 end
 
 let get_repl_path () =

--- a/src/repl.ml
+++ b/src/repl.ml
@@ -107,10 +107,10 @@ let create_terminal instance sandbox =
 
          That's hacky, buy hey, if vscode-python does it, so can we...
          https://github.com/microsoft/vscode-python/blob/main/src/client/terminals/codeExecution/terminalCodeExecution.ts#L54 *)
-      let+ _ =
+      let+ () =
         Promise.make (fun ~resolve ~reject:_ ->
             let (_ : Node.Timeout.t) =
-              Node.setTimeout (fun () -> resolve true) 2500
+              Node.setTimeout (fun () -> resolve ()) 2500
             in
             ())
       in

--- a/src/sandbox.ml
+++ b/src/sandbox.ml
@@ -178,7 +178,8 @@ module Setting = struct
       object_ [ kind; ("switch", encode_vars @@ Opam.Switch.name switch) ]
     | Custom template -> object_ [ kind; ("template", string template) ]
 
-  let t = Settings.create ~scope:Workspace ~key:"sandbox" ~of_json ~to_json
+  let t =
+    Settings.create_setting ~scope:Workspace ~key:"sandbox" ~of_json ~to_json
 end
 
 let available_sandboxes () =

--- a/src/settings.ml
+++ b/src/settings.ml
@@ -57,3 +57,27 @@ let substitute_workspace_vars setting =
       String.substr_replace_all acc
         ~pattern:(workspace_folder_path folder)
         ~with_:(workspace_folder_var folder))
+
+module ExtraEnv = struct
+  let setting =
+    let of_json =
+      let dict_of_hashtbl hashtbl =
+        Stdlib.Hashtbl.to_seq hashtbl |> Interop.Dict.of_seq
+      in
+      Jsonoo.Decode.(
+        map (Option.map ~f:dict_of_hashtbl) (nullable (dict string)))
+    in
+    let to_json =
+      let hashtbl_of_dict json =
+        Interop.Dict.to_seq json |> Stdlib.Hashtbl.of_seq
+      in
+      Jsonoo.Encode.nullable (fun json ->
+          hashtbl_of_dict json |> Jsonoo.Encode.(dict string))
+    in
+    create_setting ~scope:ConfigurationTarget.Workspace
+      ~key:"ocaml.server.extraEnv" ~of_json ~to_json
+
+  let get () = get setting |> Option.join
+end
+
+let server_extraEnv = ExtraEnv.get

--- a/src/settings.mli
+++ b/src/settings.mli
@@ -1,19 +1,31 @@
 open Import
 
-type 'a t
+(** This module is more of a "settings manager", which works with VS Code's
+    [WorkspaceConfiguration] to retrieve and set settings. A setting is
+    represented by ['value setting] type defined below. *)
 
-val get : ?section:string -> 'a t -> 'a option
+(** ['value setting] represents a setting (word used as a singular of
+    "settings"), which has a value of type ['value] *)
+type 'value setting
 
-val set : ?section:string -> 'a t -> 'a -> unit Promise.t
+(* TODO: improve the treatment of "section"
 
-val create :
+   All settings in the extension are defined using a dot-separated path, e.g.,
+   [ocaml.dune.autoDetect]. In some places, we treat [key] as this whole path
+   for the setting, [ocaml.dune.autoDetect], and in some places we use
+   [autoDetect] as the key and [ocaml.dune] as the "section". VS Code allows
+   this, but this non uniform treatment is bad. We should enforce a nicer API. *)
+
+val get : ?section:string -> 'value setting -> 'value option
+
+val set : ?section:string -> 'value setting -> 'value -> unit Promise.t
+
+val create_setting :
      scope:ConfigurationTarget.t
   -> key:string
-  -> of_json:(Jsonoo.t -> 'a)
-  -> to_json:('a -> Jsonoo.t)
-  -> 'a t
-
-val string : scope:ConfigurationTarget.t -> key:string -> string t
+  -> of_json:(Jsonoo.t -> 'value)
+  -> to_json:('value -> Jsonoo.t)
+  -> 'value setting
 
 (** replace ${workspaceFolder:folder_name} variables with workspace folder paths *)
 val resolve_workspace_vars : string -> string

--- a/src/settings.mli
+++ b/src/settings.mli
@@ -32,3 +32,5 @@ val resolve_workspace_vars : string -> string
 
 (** replace workspace folder paths with ${workspaceFolder:folder_name} variables *)
 val substitute_workspace_vars : string -> string
+
+val server_extraEnv : unit -> string Interop.Dict.t option

--- a/src/terminal_sandbox.ml
+++ b/src/terminal_sandbox.ml
@@ -22,7 +22,7 @@ module ShellPath = struct
     in
     Platform.Map.find map Platform.t
 
-  let t = Settings.create ~scope:Global ~key ~of_json ~to_json
+  let t = Settings.create_setting ~scope:Global ~key ~of_json ~to_json
 end
 
 module ShellArgs = struct
@@ -47,7 +47,7 @@ module ShellArgs = struct
     in
     Platform.Map.find map Platform.t
 
-  let t = Settings.create ~scope:Global ~key ~of_json ~to_json
+  let t = Settings.create_setting ~scope:Global ~key ~of_json ~to_json
 end
 
 let get_shell_path () =


### PR DESCRIPTION
Main goal of the PR: 

- Pass `process.env` to ocamllsp
- Add a user config to indicate "extra" environment variables to pass to ocamllsp on launch; this should be helpful to tweak (ocamllsp/merlin) log/profiling/memtrace file configs. (such a config also exists in `Rust Analyzer` for similar purposes)
  
  I used this configuration to play with [landmarks](https://github.com/LexiFi/landmarks) to profile ocamllsp. Click on `Details` to read more about this.

<details>

I used the following config

```
"ocaml.server.extraEnv": {
    "OCAML_LANDMARKS": "on,auto,allocation,output=./ocaml_lsp.profiling_data"
  },
```

for the extension. 

One also needs to pin `landmarks` master and `make install` ocamllsp with env `OCAML_LANDMARKS=auto` (see the landmarks docs for more info -- this is my first time using that lib anyway :p) 

Profiling data:

```
Call graph 'ocamllsp':
----------------------
[   76.74G cycles in   1 calls ]     - 100.00% : load(main)
[   76.74G cycles in   1 calls ]     |   - 100.00% : Main.run
[   76.74G cycles in   1 calls ]     |   |   - 100.00% : [1;31mOcaml_lsp_server.run[0m

Note: Nodes accounting for less than 1.00% of their parent have been ignored.

Aggregated table:
----------------
                                              Name;                                                       Filename;    Calls;     Time; Allocated bytes
                                              ROOT;                                                src/landmark.ml;        0;   76.75G; 82685720
                                        load(main);                                 ocaml-lsp-server/src/main.ml:1;        1;   76.74G; 81915448
                                          Main.run;                                 ocaml-lsp-server/src/main.ml:1;        1;   76.74G; 81908400
                              Ocaml_lsp_server.run;                  ocaml-lsp-server/src/ocaml_lsp_server.ml:1184;        1;   76.74G; 81907680
                              Document.make_config;                           ocaml-lsp-server/src/document.ml:130;        2;  100.29M;    70112
                            Document.with_pipeline;                           ocaml-lsp-server/src/document.ml:116;       59;    6.53M;  1317136
                             Document.dispatch_exn;                           ocaml-lsp-server/src/document.ml:180;       42;    5.25M;  1267008
                        Document.with_pipeline_exn;                           ocaml-lsp-server/src/document.ml:121;       43;    5.21M;  1252336
                    Ocamlformat_rpc.Process.create;                     ocaml-lsp-server/src/ocamlformat_rpc.ml:73;        1;    4.69M;      680
                  Action_refactor_open.code_action;    ocaml-lsp-server/src/code_actions/action_refactor_open.ml:3;       16;    2.39M;   404984
                                      Range.of_loc;                               ocaml-lsp-server/src/range.ml:21;      515;    1.72M;   754112
                  Ocaml_lsp_server.document_symbol;                   ocaml-lsp-server/src/ocaml_lsp_server.ml:791;        8;    1.71M;   624776
                               Document_symbol.run;                     ocaml-lsp-server/src/document_symbol.ml:40;        8;    1.61M;   612696
       Action_type_annotate.check_typeable_context;    ocaml-lsp-server/src/code_actions/action_type_annotate.ml:5;        8;    1.48M;    92064
                            Document_symbol.symbol;                     ocaml-lsp-server/src/document_symbol.ml:17;      132;    1.42M;   614040
                        Ocaml_lsp_server.highlight;                   ocaml-lsp-server/src/ocaml_lsp_server.ml:773;        4;    1.14M;   241512
                      Position.of_lexical_position;                            ocaml-lsp-server/src/position.ml:10;     1036;    1.10M;   458512
                             Document_symbol.range;                     ocaml-lsp-server/src/document_symbol.ml:15;      254;    1.04M;   443128
                  Action_type_annotate.code_action;   ocaml-lsp-server/src/code_actions/action_type_annotate.ml:43;        8;  929.52K;    82656
                       Ocaml_lsp_server.on_request;                   ocaml-lsp-server/src/ocaml_lsp_server.ml:934;       31;  785.02K;    48152
                       Action_destruct.code_action;        ocaml-lsp-server/src/code_actions/action_destruct.ml:26;        8;  651.30K;    33800
                                 Document.dispatch;                           ocaml-lsp-server/src/document.ml:177;        8;  497.06K;    13424
                               Ocamlformat_rpc.run;                    ocaml-lsp-server/src/ocamlformat_rpc.ml:219;        1;  387.78K;     1320
                      Action_construct.code_action;        ocaml-lsp-server/src/code_actions/action_construct.ml:5;        8;  338.60K;    24568
                                 Position.is_dummy;                             ocaml-lsp-server/src/position.ml:6;     1036;  291.87K;   124320
                                     Document.kind;                            ocaml-lsp-server/src/document.ml:95;       28;  276.79K;    29792
                                     Document.make;                           ocaml-lsp-server/src/document.ml:161;        2;  188.90K;     4256
                            Document.make_pipeline;                           ocaml-lsp-server/src/document.ml:144;        2;  183.22K;     2984
               Ocaml_lsp_server.text_document_lens;                   ocaml-lsp-server/src/ocaml_lsp_server.ml:527;        4;  178.86K;    18816
                                   Document.syntax;                            ocaml-lsp-server/src/document.ml:97;       36;  162.11K;    16824
                            Ocaml_lsp_server.hover;                   ocaml-lsp-server/src/ocaml_lsp_server.ml:425;        5;  161.25K;    24240
Action_type_annotate.code_action_of_type_enclosing;   ocaml-lsp-server/src/code_actions/action_type_annotate.ml:24;        3;  137.44K;    21240
                                Document_store.get;                      ocaml-lsp-server/src/document_store.ml:11;       29;  106.08K;     3944
                                    Document.await;                           ocaml-lsp-server/src/document.ml:103;       61;   98.90K;    26352
                       Ocaml_lsp_server.query_type;                   ocaml-lsp-server/src/ocaml_lsp_server.ml:415;        5;   92.96K;    13768
                                  Diagnostics.send;                         ocaml-lsp-server/src/diagnostics.ml:64;        3;   85.58K;    12008
                              Ocamlformat_rpc.stop;                    ocaml-lsp-server/src/ocamlformat_rpc.ml:181;        1;   84.10K;      880
                  Ocaml_lsp_server.on_notification;                   ocaml-lsp-server/src/ocaml_lsp_server.ml:977;        5;   80.97K;     6688
                  Action_inferred_intf.code_action;   ocaml-lsp-server/src/code_actions/action_inferred_intf.ml:22;        8;   77.38K;    11736
                      Ocaml_lsp_server.code_action;                   ocaml-lsp-server/src/ocaml_lsp_server.ml:262;        8;   75.15K;     5448
              Action_type_annotate.get_source_text;   ocaml-lsp-server/src/code_actions/action_type_annotate.ml:15;        3;   71.34K;     9560
                      Document_symbol.outline_kind;                      ocaml-lsp-server/src/document_symbol.ml:3;      254;   70.80K;    30480
                        Ocaml_lsp_server.query_doc;                   ocaml-lsp-server/src/ocaml_lsp_server.ml:405;        5;   69.74K;    13728
                    Document.Syntax.of_language_id;                            ocaml-lsp-server/src/document.ml:66;       36;   69.09K;     4896
                 Ocaml_lsp_server.ocaml_on_request;                   ocaml-lsp-server/src/ocaml_lsp_server.ml:800;       31;   66.07K;     8768
                          Compl.prefix_of_position;                               ocaml-lsp-server/src/compl.ml:30;        8;   65.64K;     2208
                 Ocamlformat_rpc.Process.configure;                     ocaml-lsp-server/src/ocamlformat_rpc.ml:49;        1;   37.72K;      816
                            Document_store.get_opt;                       ocaml-lsp-server/src/document_store.ml:9;       29;   36.94K;     4640
                            load(ocaml_lsp_server);                     ocaml-lsp-server/src/ocaml_lsp_server.ml:1;        1;   33.77K;     2528
                  Ocaml_lsp_server.format_contents;                   ocaml-lsp-server/src/ocaml_lsp_server.ml:379;        5;   32.05K;     5336
                  Ocaml_lsp_server.set_diagnostics;                   ocaml-lsp-server/src/ocaml_lsp_server.ml:153;        2;   31.62K;     5168
              Ocaml_lsp_server.client_capabilities;                     ocaml-lsp-server/src/ocaml_lsp_server.ml:8;       13;   30.88K;     6224
                            Document.Kind.of_fname;                             ocaml-lsp-server/src/document.ml:8;       28;   30.15K;     6048
                                  Position.logical;                            ocaml-lsp-server/src/position.ml:52;       63;   26.18K;    10584
                                Document_store.put;                       ocaml-lsp-server/src/document_store.ml:7;        2;   20.33K;     1352
                    Document_store.remove_document;                      ocaml-lsp-server/src/document_store.ml:21;        2;   19.88K;     1800
                 Ocaml_lsp_server.markdown_support;                   ocaml-lsp-server/src/ocaml_lsp_server.ml:330;        5;   18.33K;      880
                            Ocaml_lsp_server.start;                  ocaml-lsp-server/src/ocaml_lsp_server.ml:1049;        1;   17.22K;     4032
                                      Document.uri;                            ocaml-lsp-server/src/document.ml:93;       32;   14.87K;     3840
                                   Diagnostics.set;                         ocaml-lsp-server/src/diagnostics.ml:80;        1;   14.01K;      192
                                Diagnostics.remove;                         ocaml-lsp-server/src/diagnostics.ml:91;        2;   13.66K;      320
                                         load(bin);                                  ocaml-lsp-server/src/bin.ml:1;        1;   12.71K;     1664
                                   Document.source;                           ocaml-lsp-server/src/document.ml:101;       14;   11.33K;     1680
                       Ocamlformat_rpc.format_type;                    ocaml-lsp-server/src/ocamlformat_rpc.ml:151;        5;   11.09K;     3480
                      Ocaml_lsp_server.init_params;                     ocaml-lsp-server/src/ocaml_lsp_server.ml:3;       13;   10.04K;     1560
                                        load(dune);                                 ocaml-lsp-server/src/dune.ml:1;        1;    9.75K;     2288
                                    Document.close;                           ocaml-lsp-server/src/document.ml:184;        2;    8.87K;      512
                  Ocaml_lsp_server.task_if_running;                    ocaml-lsp-server/src/ocaml_lsp_server.ml:82;        8;    8.72K;     2304
                                 load(diagnostics);                          ocaml-lsp-server/src/diagnostics.ml:1;        1;    7.59K;     7888
                                Diagnostics.create;                         ocaml-lsp-server/src/diagnostics.ml:36;        1;    7.29K;     4928
                    Ocamlformat_rpc.Process.client;                     ocaml-lsp-server/src/ocamlformat_rpc.ml:32;        5;    6.55K;      600
                            Ocamlformat_rpc.create;                    ocaml-lsp-server/src/ocamlformat_rpc.ml:172;        1;    6.17K;     1008
                              Document_store.close;                      ocaml-lsp-server/src/document_store.ml:31;        1;    4.80K;      448
               Ocamlformat_rpc.Process.pick_client;                     ocaml-lsp-server/src/ocamlformat_rpc.ml:36;        1;    4.76K;      808
                      Ocamlformat_rpc.create_state;                    ocaml-lsp-server/src/ocamlformat_rpc.ml:168;        1;    4.57K;      272
                                    load(document);                             ocaml-lsp-server/src/document.ml:1;        1;    4.25K;      592
                                        Fmt.create;                                 ocaml-lsp-server/src/fmt.ml:15;        1;    4.14K;     1744
                                      load(client);                               ocaml-lsp-server/src/client.ml:1;        1;    3.90K;      224
                            Typed_hole.can_be_hole;                           ocaml-lsp-server/src/typed_hole.ml:3;        8;    3.86K;      960
                       Ocamlformat_rpc.get_process;                    ocaml-lsp-server/src/ocamlformat_rpc.ml:136;        5;    3.58K;     1040
                    Ocaml_lsp_server.on_initialize;                   ocaml-lsp-server/src/ocaml_lsp_server.ml:252;        1;    3.27K;      336
                     Document.Syntax.markdown_name;                            ocaml-lsp-server/src/document.ml:80;        5;    3.15K;      600
                   Configuration.diagnostics_delay;                        ocaml-lsp-server/src/configuration.ml:7;        2;    2.79K;      240
                Diagnostics.dune_status_diagnostic;                         ocaml-lsp-server/src/diagnostics.ml:52;        3;    2.66K;      360
                                    Document.timer;                            ocaml-lsp-server/src/document.ml:99;        2;    2.63K;      240
                                  Document.version;                           ocaml-lsp-server/src/document.ml:128;        3;    2.32K;      360
                                 Lazy_fiber.create;                           ocaml-lsp-server/src/lazy_fiber.ml:8;        4;    1.48K;      896
                               Document_store.make;                       ocaml-lsp-server/src/document_store.ml:5;        1;    1.44K;     2752
                    Ocamlformat_rpc.Process.thread;                     ocaml-lsp-server/src/ocamlformat_rpc.ml:30;        5;    1.44K;      600
                                      load(import);                               ocaml-lsp-server/src/import.ml:1;        1;    1.38K;      120
                       Ocamlformat_rpc.Process.run;                    ocaml-lsp-server/src/ocamlformat_rpc.ml:118;        1;    1.18K;      416
                                   load(doc_to_md);                            ocaml-lsp-server/src/doc_to_md.ml:1;        1;  908.00 ;      288
                           Ocamlformat_rpc.run_rpc;                    ocaml-lsp-server/src/ocamlformat_rpc.ml:195;        1;  684.00 ;      304
                                       Version.get;                              ocaml-lsp-server/src/version.ml:1;        2;  648.00 ;      240
                            load(workspace_symbol);                    ocaml-lsp-server/src/workspace_symbol.ml:27;        1;  604.00 ;      696
                                       load(compl);                                ocaml-lsp-server/src/compl.ml:1;        1;  540.00 ;      520
                                         load(fmt);                                  ocaml-lsp-server/src/fmt.ml:1;        1;  508.00 ;      352
                             load(ocamlformat_rpc);                      ocaml-lsp-server/src/ocamlformat_rpc.ml:1;        1;  482.00 ;      456
                                    load(position);                             ocaml-lsp-server/src/position.ml:1;        1;  416.00 ;      232
                       Ocamlformat_rpc.Process.pid;                     ocaml-lsp-server/src/ocamlformat_rpc.ml:28;        1;  374.00 ;      120
                             load(req_typed_holes);      ocaml-lsp-server/src/custom_requests/req_typed_holes.ml:1;        1;  306.00 ;      200
                        load(action_type_annotate);    ocaml-lsp-server/src/code_actions/action_type_annotate.ml:1;        1;  300.00 ;      184
                             load(document_symbol);                      ocaml-lsp-server/src/document_symbol.ml:1;        1;  284.00 ;      216
                            load(action_construct);        ocaml-lsp-server/src/code_actions/action_construct.ml:1;        1;  268.00 ;      136
                                       load(range);                                ocaml-lsp-server/src/range.ml:1;        1;  266.00 ;      168
                                       load(state);                                ocaml-lsp-server/src/state.ml:1;        1;  264.00 ;      136
                                   load(inference);                            ocaml-lsp-server/src/inference.ml:1;        1;  256.00 ;      184
                              load(document_store);                       ocaml-lsp-server/src/document_store.ml:1;        1;  244.00 ;      232
                                    load(progress);                             ocaml-lsp-server/src/progress.ml:1;        1;  240.00 ;      232
                              load(req_infer_intf);       ocaml-lsp-server/src/custom_requests/req_infer_intf.ml:1;        1;  230.00 ;      136
                        load(req_switch_impl_intf); ocaml-lsp-server/src/custom_requests/req_switch_impl_intf.ml:1;        1;  220.00 ;      152
                                     load(version);                              ocaml-lsp-server/src/version.ml:1;        1;  216.00 ;      136
                             load(action_destruct);         ocaml-lsp-server/src/code_actions/action_destruct.ml:1;        1;  216.00 ;      152
                               load(configuration);                        ocaml-lsp-server/src/configuration.ml:1;        1;  214.00 ;      168
                        load(action_inferred_intf);    ocaml-lsp-server/src/code_actions/action_inferred_intf.ml:1;        1;  214.00 ;      152
                        load(action_refactor_open);    ocaml-lsp-server/src/code_actions/action_refactor_open.ml:1;        1;  208.00 ;      296
                                  load(typed_hole);                           ocaml-lsp-server/src/typed_hole.ml:1;        1;  206.00 ;      152
                                  load(lazy_fiber);                           ocaml-lsp-server/src/lazy_fiber.ml:1;        1;  200.00 ;      152
                                 load(code_action);             ocaml-lsp-server/src/code_actions/code_action.ml:1;        1;  192.00 ;      120
```

</details>

Some other things accomplished with this PR: 

- Rename OCaml Platform's settings section in vscode settings to `OCaml Platform`:

  1. `OCaml configuration` is a misnomer since we're not configuring `OCaml` really
  2. Naming the settings same as the extension name leads to easier finding;
this is practiced by `Rust Analyzer` and `Metals` vscode extensions

- does some simplification & renaming refactoring for better understandability
