### PR TITLE
Support Local mode in Construct - user configuration option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,12 @@
 - Add `ocaml.server.extraEnv` configuration option to pass extra environment
   variables to the language server, i.e., OCaml-LSP (#674)
 
+- Add `ocaml.server.construct.useLocalContext` configuration option to turn
+  on/off use of local context in `Construct an expression` code action. In other
+  words, if turned on, the extension will also construct expressions from
+  currently defined values. Can be used only with OCaml LSP version starting
+  from 1.8.0.
+
 ## 1.8.4
 
 - Fix inclusion of files in extension package

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,8 +25,22 @@
 - Add `ocaml.server.construct.useLocalContext` configuration option to turn
   on/off use of local context in `Construct an expression` code action. In other
   words, if turned on, the extension will also construct expressions from
-  currently defined values. Can be used only with OCaml LSP version starting
-  from 1.8.0.
+  currently defined values.
+
+  Example:
+
+  ```ocaml
+  type t = { name: string }
+
+  let john : t =
+    let doe = { name = "John" } in
+    _ (* <- construct is triggered on this typed hole *)
+  ```
+
+  With `Local` mode _on_, the suggested values will include the _local_ variable
+  `doe` along with other expressions such as `{ name = _ }`.
+
+  Note: Can be used only with OCaml LSP version starting from 1.8.0.
 
 ## 1.8.4
 

--- a/README.md
+++ b/README.md
@@ -91,20 +91,21 @@ esy
 This extension provides options in VSCode's configuration settings. You can find
 the settings under `File > Preferences > Settings`.
 
-| Name                               | Description                                                                                             | Default |
-| ---------------------------------- | ------------------------------------------------------------------------------------------------------- | ------- |
-| `ocaml.sandbox`                    | Determines where to find the sandbox for a given project                                                | `null`  |
-| `ocaml.dune.autoDetect`            | Controls whether dune tasks should be automatically detected.                                           | `true`  |
-| `ocaml.trace.server`               | Controls the logging output of the language server. Valid settings are `off`, `messages`, or `verbose`. | `off`   |
-| `ocaml.useOcamlEnv`                | Controls whether to use ocaml-env for opam commands from OCaml for Windows.                             | `true`  |
-| `ocaml.terminal.shell.linux`       | The path of the shell that the sandbox terminal uses on Linux                                           | `null`  |
-| `ocaml.terminal.shell.osx`         | The path of the shell that the sandbox terminal uses on macOS                                           | `null`  |
-| `ocaml.terminal.shell.windows`     | The path of the shell that the sandbox terminal uses on Windows                                         | `null`  |
-| `ocaml.terminal.shellArgs.linux`   | The command line arguments that the sandbox terminal uses on Linux                                      | `null`  |
-| `ocaml.terminal.shellArgs.osx`     | The command line arguments that the sandbox terminal uses on macOS                                      | `null`  |
-| `ocaml.terminal.shellArgs.windows` | The command line arguments that the sandbox terminal uses on Window                                     | `null`  |
-| `ocaml.repl.path`                  | The path of the REPL that the extension uses                                                            | `null`  |
-| `ocaml.repl.args`                  | The REPL arguments that the extension uses                                                              | `null`  |
+| Name                                     | Description                                                                                             | Default |
+| ---------------------------------------- | ------------------------------------------------------------------------------------------------------- | ------- |
+| `ocaml.sandbox`                          | Determines where to find the sandbox for a given project                                                | `null`  |
+| `ocaml.dune.autoDetect`                  | Controls whether dune tasks should be automatically detected.                                           | `true`  |
+| `ocaml.trace.server`                     | Controls the logging output of the language server. Valid settings are `off`, `messages`, or `verbose`. | `off`   |
+| `ocaml.server.construct.useLocalContext` | Constructing a value by type should use local context.                                                  | `false` |
+| `ocaml.useOcamlEnv`                      | Controls whether to use ocaml-env for opam commands from OCaml for Windows.                             | `true`  |
+| `ocaml.terminal.shell.linux`             | The path of the shell that the sandbox terminal uses on Linux                                           | `null`  |
+| `ocaml.terminal.shell.osx`               | The path of the shell that the sandbox terminal uses on macOS                                           | `null`  |
+| `ocaml.terminal.shell.windows`           | The path of the shell that the sandbox terminal uses on Windows                                         | `null`  |
+| `ocaml.terminal.shellArgs.linux`         | The command line arguments that the sandbox terminal uses on Linux                                      | `null`  |
+| `ocaml.terminal.shellArgs.osx`           | The command line arguments that the sandbox terminal uses on macOS                                      | `null`  |
+| `ocaml.terminal.shellArgs.windows`       | The command line arguments that the sandbox terminal uses on Window                                     | `null`  |
+| `ocaml.repl.path`                        | The path of the REPL that the extension uses                                                            | `null`  |
+| `ocaml.repl.args`                        | The REPL arguments that the extension uses                                                              | `null`  |
 
 If `ocaml.terminal.shell.*` or `ocaml.terminal.shellArgs.*` is `null`, the
 configured VSCode shell and shell arguments will be used instead.

--- a/package.json
+++ b/package.json
@@ -390,6 +390,11 @@
           ],
           "default": "off"
         },
+        "ocaml.server.construct.useLocalContext": {
+          "type": "boolean",
+          "default": false,
+          "markdownDescription": "Constructing a value by type should use local context. Call command \"OCaml: Restart Language Server\" after change."
+        },
         "ocaml.useOcamlEnv": {
           "type": "boolean",
           "default": true,

--- a/src/extension_instance.ml
+++ b/src/extension_instance.ml
@@ -56,7 +56,7 @@ let stop_server t =
       LanguageClient.stop client)
 
 let start_language_server t =
-  stop_server t;
+  stop_server t (* in case we are REstarting the server *);
   let res =
     let open Promise.Result.Syntax in
     let* () =

--- a/vscode/vscode_languageclient/vscode_languageclient.mli
+++ b/vscode/vscode_languageclient/vscode_languageclient.mli
@@ -66,16 +66,24 @@ end
 module ClientOptions : sig
   include Js.T
 
+  type any_or_thunk =
+    [ `Any of Ojs.t
+    | `Thunk of unit -> Ojs.t
+    ]
+
   val documentSelector : t -> DocumentSelector.t option
 
   val outputChannel : t -> Vscode.OutputChannel.t option
 
   val revealOutputChannelOn : t -> RevealOutputChannelOn.t
 
+  val initializationOptions : t -> any_or_thunk or_undefined
+
   val create :
        ?documentSelector:DocumentSelector.t
     -> ?outputChannel:Vscode.OutputChannel.t
     -> ?revealOutputChannelOn:RevealOutputChannelOn.t
+    -> ?initializationOptions:any_or_thunk
     -> unit
     -> t
 end


### PR DESCRIPTION
1. I'm not very sure about how `InitializationOptions` module should look like -- let's see how it evolves, and we'll refactor it perhaps. 
2. Using `InitializationOptions` to compute specific things to pass to the language server vs just passing the OCaml Platform settings section (the whole json representation of ocaml platform related settings) (e.g., Rust Analyzer just takes the settings section `rust-analyzer` and passes it to the language server). I think it's better if we pass to ocaml-lsp only settings that it needs even though that results in extra code to write & maintain. Wdyt? 