### PR TITLE
Improve working with REPL

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -56,18 +56,31 @@
 
   - Improved workflow for opening a terminal:
 
-    If the `ocaml.repl.path` and `ocaml.repl.args` configuration options are
-    given, then they are used to open a terminal and launch a REPL.
+    - Picking which REPL to use
 
-    Otherwise, the user is prompted to write a string command to launch the REPL
-    in an input box; for example, `dune utop my_library`.
+      If the `ocaml.repl.path` and `ocaml.repl.args` configuration options are
+      given, then they are used to open a terminal and launch a REPL.
 
-    If the user doesn't enter anything, a default (\*) REPL is created:
+      Otherwise, the user is prompted to write a string command to launch the
+      REPL in an input box; for example, `dune utop my_library`.
 
-    - If you have both `dune` and `utop` and the project _seems_ "buildable",
-      use `dune utop` command to create a REPL;
-    - If only `utop` is installed, then use command `utop` to launch REPL;
-    - Else, use the default OCaml REPL `ocaml`.
+      If the user doesn't enter anything, a default (\*) REPL is created:
+
+      - If you have both `dune` and `utop` and the project _seems_ "buildable",
+        use `dune utop` command to create a REPL;
+      - If only `utop` is installed, then use command `utop` to launch REPL;
+      - Else, use the default OCaml REPL `ocaml`.
+
+    - Picking to launch REPL in a new terminal or existing
+
+      When the extension figures out which command to use for launching a REPL
+      (from user config, explicit command provided in the input box mentioned,
+      or a default REPL), the user is prompted to pick whether they want the
+      REPL to be in a newly created terminal or an existing one.
+
+      One can avoid picking whether to use a new or existing terminal each time,
+      by providing a setting `ocaml.repl.terminal`: always create a new
+      terminal, always use an existing one, always pick which to use.
 
 - Rename the extension's section in VS Code Settings from `OCaml configuration`
   to `OCaml Platform` (#674)

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -16,6 +16,59 @@
   holes that one needs to replace with valid OCaml code. These new commands help
   to navigate easily from one hole to another (#643)
 
+- Improve evaluating code in REPL
+
+  - Important: rename `Evaluate Selection` to `Evaluate Expression in REPL`
+    because we now support evaluating not only selections, but expressions
+    depending on the cursor position -- read more below!
+
+    Reminder: you can send an expression (whether by selection or expression
+    enclosing the cursor) via a keyboard shortcut `shift+enter`.
+
+  - Add support for evaluating expressions depending on the cursor position
+
+    - If you explicitly select a piece of code, that code will be evaluated in
+      the REPL
+
+    - BUT if you don't select anything, the closest "toplevel" expression
+      enclosing the cursor will be evaluated. Let's see some examples (`<n>` is
+      cursor position for example number `n`)
+
+      ```ocaml
+      let k = <1> 1
+      <2>
+      module M = struct<3>
+        let a =
+          let <4> b = 1 in
+          b + 1
+        <5>
+        let u = ()
+      end
+      ```
+
+      | Your cursor | Evaluated expression        | Rationale                                                                                        |
+      | ----------- | --------------------------- | ------------------------------------------------------------------------------------------------ |
+      | <1>         | `let k = 1`                 | Toplevel expression under cursor                                                                 |
+      | <2>         | whole code block            | Cursor is in-between, so whole "file" is evaluated                                               |
+      | <3>         | `module M = ... end`        | Cursor is on the module definition                                                               |
+      | <4>         | `let a = let b = 1 in b + 1 | "Toplevel" expression for the cursor; it's used because it's "closer" than the module definition |
+      | <5>         | `let a = ... let u = ()`    | It's often useful to have module's definitions in the REPL environment                           |
+
+  - Improved workflow for opening a terminal:
+
+    If the `ocaml.repl.path` and `ocaml.repl.args` configuration options are
+    given, then they are used to open a terminal and launch a REPL.
+
+    Otherwise, the user is prompted to write a string command to launch the REPL
+    in an input box; for example, `dune utop my_library`.
+
+    If the user doesn't enter anything, a default (\*) REPL is created:
+
+    - If you have both `dune` and `utop`, use `dune utop` command to create a
+      REPL;
+    - If only `utop`, then `utop`;
+    - Else, `ocaml`.
+
 - Rename the extension's section in VS Code Settings from `OCaml configuration`
   to `OCaml Platform` (#674)
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -64,10 +64,10 @@
 
     If the user doesn't enter anything, a default (\*) REPL is created:
 
-    - If you have both `dune` and `utop`, use `dune utop` command to create a
-      REPL;
-    - If only `utop`, then `utop`;
-    - Else, `ocaml`.
+    - If you have both `dune` and `utop` and the project _seems_ "buildable",
+      use `dune utop` command to create a REPL;
+    - If only `utop` is installed, then use command `utop` to launch REPL;
+    - Else, use the default OCaml REPL `ocaml`.
 
 - Rename the extension's section in VS Code Settings from `OCaml configuration`
   to `OCaml Platform` (#674)

--- a/README.md
+++ b/README.md
@@ -172,20 +172,21 @@ esy
 This extension provides options in VSCode's configuration settings. You can find
 the settings under `File > Preferences > Settings`.
 
-| Name                               | Description                                                                                             | Default |
-| ---------------------------------- | ------------------------------------------------------------------------------------------------------- | ------- |
-| `ocaml.sandbox`                    | Determines where to find the sandbox for a given project                                                | `null`  |
-| `ocaml.dune.autoDetect`            | Controls whether dune tasks should be automatically detected.                                           | `true`  |
-| `ocaml.trace.server`               | Controls the logging output of the language server. Valid settings are `off`, `messages`, or `verbose`. | `off`   |
-| `ocaml.useOcamlEnv`                | Controls whether to use ocaml-env for opam commands from OCaml for Windows.                             | `true`  |
-| `ocaml.terminal.shell.linux`       | The path of the shell that the sandbox terminal uses on Linux                                           | `null`  |
-| `ocaml.terminal.shell.osx`         | The path of the shell that the sandbox terminal uses on macOS                                           | `null`  |
-| `ocaml.terminal.shell.windows`     | The path of the shell that the sandbox terminal uses on Windows                                         | `null`  |
-| `ocaml.terminal.shellArgs.linux`   | The command line arguments that the sandbox terminal uses on Linux                                      | `null`  |
-| `ocaml.terminal.shellArgs.osx`     | The command line arguments that the sandbox terminal uses on macOS                                      | `null`  |
-| `ocaml.terminal.shellArgs.windows` | The command line arguments that the sandbox terminal uses on Window                                     | `null`  |
-| `ocaml.repl.path`                  | The path of the REPL that the extension uses                                                            | `null`  |
-| `ocaml.repl.args`                  | The REPL arguments that the extension uses                                                              | `null`  |
+| Name                               | Description                                                                                             | Default      |
+| ---------------------------------- | ------------------------------------------------------------------------------------------------------- | ------------ |
+| `ocaml.sandbox`                    | Determines where to find the sandbox for a given project                                                | `null`       |
+| `ocaml.dune.autoDetect`            | Controls whether dune tasks should be automatically detected.                                           | `true`       |
+| `ocaml.trace.server`               | Controls the logging output of the language server. Valid settings are `off`, `messages`, or `verbose`. | `off`        |
+| `ocaml.useOcamlEnv`                | Controls whether to use ocaml-env for opam commands from OCaml for Windows.                             | `true`       |
+| `ocaml.terminal.shell.linux`       | The path of the shell that the sandbox terminal uses on Linux                                           | `null`       |
+| `ocaml.terminal.shell.osx`         | The path of the shell that the sandbox terminal uses on macOS                                           | `null`       |
+| `ocaml.terminal.shell.windows`     | The path of the shell that the sandbox terminal uses on Windows                                         | `null`       |
+| `ocaml.terminal.shellArgs.linux`   | The command line arguments that the sandbox terminal uses on Linux                                      | `null`       |
+| `ocaml.terminal.shellArgs.osx`     | The command line arguments that the sandbox terminal uses on macOS                                      | `null`       |
+| `ocaml.terminal.shellArgs.windows` | The command line arguments that the sandbox terminal uses on Window                                     | `null`       |
+| `ocaml.repl.path`                  | The path of the REPL that the extension uses                                                            | `null`       |
+| `ocaml.repl.args`                  | The REPL arguments that the extension uses                                                              | `null`       |
+| `ocaml.repl.terminal`              | Pick which terminal to launch REPL in: a new or existing terminal, or always ask before                 | `Always ask` |
 
 If `ocaml.terminal.shell.*` or `ocaml.terminal.shellArgs.*` is `null`, the
 configured VSCode shell and shell arguments will be used instead.

--- a/README.md
+++ b/README.md
@@ -221,7 +221,10 @@ prefix `OCaml:`:
 | `ocaml.current-dune-file`    | Open Dune File (located in the same folder) |                    |
 | `ocaml.switch-impl-intf`     | Switch implementation/interface             | `Alt+O`            |
 | `ocaml.open-repl`            | Open REPL                                   |                    |
-| `ocaml.evaluate-selection`   | Evaluate Selection                          | `Shift+Enter`      |
+| `ocaml.evaluate-expression`  | Evaluate Expression in REPL                 | `Shift+Enter`      |
+
+Note: `ocaml.evaluate-expression` was previously named
+`ocaml.evaluate-selection`.
 
 ## FAQ
 

--- a/README.md
+++ b/README.md
@@ -213,16 +213,18 @@ prefix `OCaml:`:
 
 ![commands](./doc/commands.png)
 
-| Name                         | Description                                 | Keyboard Shortcuts |
-| ---------------------------- | ------------------------------------------- | ------------------ |
-| `ocaml.select-sandbox`       | Select sandbox for this workspace           |                    |
-| `ocaml.server.restart`       | Restart language server                     |                    |
-| `ocaml.open-terminal`        | Open a terminal (current sandbox)           |                    |
-| `ocaml.open-terminal-select` | Open a terminal (select a sandbox)          |                    |
-| `ocaml.current-dune-file`    | Open Dune File (located in the same folder) |                    |
-| `ocaml.switch-impl-intf`     | Switch implementation/interface             | `Alt+O`            |
-| `ocaml.open-repl`            | Open REPL                                   |                    |
-| `ocaml.evaluate-expression`  | Evaluate Expression in REPL                 | `Shift+Enter`      |
+| Name                            | Description                                 | Keyboard Shortcuts |
+| ------------------------------- | ------------------------------------------- | ------------------ |
+| `ocaml.select-sandbox`          | Select sandbox for this workspace           |                    |
+| `ocaml.server.restart`          | Restart language server                     |                    |
+| `ocaml.open-terminal`           | Open a terminal (current sandbox)           |                    |
+| `ocaml.open-terminal-select`    | Open a terminal (select a sandbox)          |                    |
+| `ocaml.current-dune-file`       | Open Dune File (located in the same folder) |                    |
+| `ocaml.switch-impl-intf`        | Switch implementation/interface             | `Alt+O`            |
+| `ocaml.open-repl`               | Open REPL                                   |                    |
+| `ocaml.evaluate-expression`     | Evaluate Expression in REPL                 | `Shift+Enter`      |
+| `ocaml.evaluate-file`           | Evaluate Current File in REPL               |                    |
+| `ocaml.evaluate-file-as-module` | Evaluate Current File as a Module           |                    |
 
 Note: `ocaml.evaluate-expression` was previously named
 `ocaml.evaluate-selection`.

--- a/package.json
+++ b/package.json
@@ -205,9 +205,9 @@
         "title": "Open REPL"
       },
       {
-        "command": "ocaml.evaluate-selection",
+        "command": "ocaml.evaluate-expression",
         "category": "OCaml",
-        "title": "Evaluate Selection"
+        "title": "Evaluate Expression in REPL"
       },
       {
         "command": "ocaml.open-ast-explorer-to-the-side",
@@ -281,7 +281,7 @@
         "when": "editorLangId == ocaml.interface || editorLangId == reason"
       },
       {
-        "command": "ocaml.evaluate-selection",
+        "command": "ocaml.evaluate-expression",
         "key": "Shift+Enter",
         "when": "editorTextFocus && editorLangId == ocaml || editorTextFocus && editorLangId == ocaml.interface || editorTextFocus && editorLangId == reason || editorTextFocus && editorLangId == ocaml.ocamllex || editorTextFocus && editorLangId == ocaml.menhir"
       },
@@ -309,7 +309,7 @@
     "menus": {
       "editor/context": [
         {
-          "command": "ocaml.evaluate-selection",
+          "command": "ocaml.evaluate-expression",
           "group": "OCaml",
           "when": "editorTextFocus && editorLangId == ocaml || editorTextFocus && editorLangId == ocaml.interface || editorTextFocus && editorLangId == reason || editorTextFocus && editorLangId == ocaml.ocamllex || editorTextFocus && editorLangId == ocaml.menhir"
         },

--- a/package.json
+++ b/package.json
@@ -521,6 +521,16 @@
           ],
           "items": "string",
           "default": null
+        },
+        "ocaml.repl.terminal": {
+          "markdownDescription": "Pick whether terminal should always open in a new/existing terminal, or should ask every time.",
+          "type": "string",
+          "default": "Always ask",
+          "enum": [
+            "Always existing terminal",
+            "Always create new terminal",
+            "Always ask"
+          ]
         }
       }
     },

--- a/package.json
+++ b/package.json
@@ -210,6 +210,16 @@
         "title": "Evaluate Expression in REPL"
       },
       {
+        "command": "ocaml.evaluate-file",
+        "category": "OCaml",
+        "title": "Evaluate Current File in REPL"
+      },
+      {
+        "command": "ocaml.evaluate-file-as-module",
+        "category": "OCaml",
+        "title": "Evaluate Current File as a Module in REPL"
+      },
+      {
         "command": "ocaml.open-ast-explorer-to-the-side",
         "category": "OCaml",
         "title": "Open AST explorer"
@@ -331,6 +341,18 @@
         {
           "command": "ocaml.prev-hole",
           "when": "editorLangId == ocaml || editorLangId == ocaml.interface || editorLangId == reason || editorLangId == ocaml.ocamllex"
+        },
+        {
+          "command": "ocaml.evaluate-expression",
+          "when": "editorLangId == ocaml"
+        },
+        {
+          "command": "ocaml.evaluate-file",
+          "when": "editorLangId == ocaml"
+        },
+        {
+          "command": "ocaml.evaluate-file-as-module",
+          "when": "editorLangId == ocaml"
         },
         {
           "command": "ocaml.refresh-switches",

--- a/src-bindings/node/node.ml
+++ b/src-bindings/node/node.ml
@@ -26,6 +26,11 @@ include
 
   val setTimeout : (unit -> unit) -> int -> Timeout.t [@@js.global]]
 
+let setTimeoutPromise ~(milliseconds : int) =
+  Promise.make (fun ~resolve ~reject:_ ->
+      let (_ : Timeout.t) = setTimeout resolve milliseconds in
+      ())
+
 module Process = struct
   include
     [%js:

--- a/src-bindings/node/node.mli
+++ b/src-bindings/node/node.mli
@@ -20,6 +20,8 @@ val setInterval : (unit -> unit) -> int -> Timeout.t
 
 val setTimeout : (unit -> unit) -> int -> Timeout.t
 
+val setTimeoutPromise : milliseconds:int -> unit Promise.t
+
 module Process : sig
   val cwd : unit -> string
 

--- a/src-bindings/vscode/vscode.ml
+++ b/src-bindings/vscode/vscode.ml
@@ -1475,6 +1475,11 @@ module Terminal = struct
     val dispose : t -> unit [@@js.call]]
 
   let disposable this = Disposable.make ~dispose:(fun () -> dispose this)
+
+  let exit_status t =
+    match exitStatus t with
+    | None -> `Not_exited_yet
+    | Some s -> `Exit_status s
 end
 
 module OutputChannel = struct

--- a/src-bindings/vscode/vscode.ml
+++ b/src-bindings/vscode/vscode.ml
@@ -324,6 +324,8 @@ module Selection = struct
       -> t
       [@@js.new "vscode.Selection"]
 
+    val isEmpty : t -> bool [@@js.get]
+
     val isReversed : t -> bool [@@js.get]]
 end
 

--- a/src-bindings/vscode/vscode.ml
+++ b/src-bindings/vscode/vscode.ml
@@ -1434,7 +1434,7 @@ module TerminalExitStatus = struct
 
   include
     [%js:
-    val code : t -> int [@@js.get]
+    val code : t -> int or_undefined [@@js.get]
 
     val create : code:int -> t [@@js.builder]]
 end

--- a/src-bindings/vscode/vscode.mli
+++ b/src-bindings/vscode/vscode.mli
@@ -1119,6 +1119,9 @@ module Terminal : sig
   val dispose : t -> unit
 
   val disposable : t -> Disposable.t
+
+  val exit_status :
+    t -> [ `Exit_status of TerminalExitStatus.t | `Not_exited_yet ]
 end
 
 module OutputChannel : sig

--- a/src-bindings/vscode/vscode.mli
+++ b/src-bindings/vscode/vscode.mli
@@ -277,6 +277,8 @@ module Selection : sig
     -> activeCharacter:int
     -> t
 
+  val isEmpty : t -> bool
+
   val isReversed : t -> bool
 end
 

--- a/src-bindings/vscode/vscode.mli
+++ b/src-bindings/vscode/vscode.mli
@@ -1089,7 +1089,7 @@ end
 module TerminalExitStatus : sig
   include Js.T
 
-  val code : t -> int
+  val code : t -> int or_undefined
 
   val create : code:int -> t
 end

--- a/src/custom_requests.ml
+++ b/src/custom_requests.ml
@@ -10,12 +10,42 @@ end = struct
   let meth = ocamllsp_prefixed "typedHoles"
 
   let encode_params uri =
+    (* TODO: this param exists as a defined type in LSP [TextDocumentIdentifier]
+       (?) *)
     Jsonoo.Encode.(object_ [ ("uri", string @@ Uri.toString uri ()) ])
 
   let decode_response json = Jsonoo.Decode.list Range.t_of_json json
 
   let send_request client ~for_doc:uri =
     let data = encode_params uri in
+    let open Promise.Syntax in
+    let+ response = LanguageClient.sendRequest client ~meth ~data () in
+    decode_response response
+end
+
+module Wrapping_ast_node : sig
+  (** [send_request client ~for_doc] will fetch ranges of holes in the file at
+      the URI [for_doc] *)
+  val send_request :
+       LanguageClient.t
+    -> doc:Uri.t
+    -> position:Position.t
+    -> Range.t option Promise.t
+end = struct
+  let meth = ocamllsp_prefixed "wrappingAstNode"
+
+  let encode_params uri position =
+    (* TODO: these params exist as a defined type in LSP *)
+    Jsonoo.Encode.(
+      object_
+        [ ("uri", string @@ Uri.toString uri ())
+        ; ("position", Position.json_of_t position)
+        ])
+
+  let decode_response json = Jsonoo.Decode.try_optional Range.t_of_json json
+
+  let send_request client ~doc:uri ~position =
+    let data = encode_params uri position in
     let open Promise.Syntax in
     let+ response = LanguageClient.sendRequest client ~meth ~data () in
     decode_response response

--- a/src/extension_consts.ml
+++ b/src/extension_consts.ml
@@ -31,6 +31,10 @@ module Commands = struct
 
   let evaluate_expression = ocaml_prefixed "evaluate-expression"
 
+  let evaluate_file = ocaml_prefixed "evaluate-file"
+
+  let evaluate_file_as_module = ocaml_prefixed "evaluate-file-as-module"
+
   let open_repl = ocaml_prefixed "open-repl"
 
   let next_hole = ocaml_prefixed "next-hole"

--- a/src/extension_consts.ml
+++ b/src/extension_consts.ml
@@ -29,7 +29,7 @@ module Commands = struct
 
   let open_current_dune_file = ocaml_prefixed "current-dune-file"
 
-  let evaluate_selection = ocaml_prefixed "evaluate-selection"
+  let evaluate_expression = ocaml_prefixed "evaluate-expression"
 
   let open_repl = ocaml_prefixed "open-repl"
 

--- a/src/extension_instance.ml
+++ b/src/extension_instance.ml
@@ -144,9 +144,7 @@ let set_sandbox t new_sandbox =
 
 let repl t = t.repl
 
-let set_repl t repl = t.repl <- Some repl
-
-let close_repl t = t.repl <- None
+let set_repl t repl = t.repl <- repl
 
 let open_terminal sandbox =
   let terminal = Terminal_sandbox.create sandbox in

--- a/src/extension_instance.mli
+++ b/src/extension_instance.mli
@@ -22,8 +22,6 @@ val disposable : t -> Disposable.t
 
 val repl : t -> Terminal_sandbox.t option
 
-val set_repl : t -> Terminal.t -> unit
-
-val close_repl : t -> unit
+val set_repl : t -> Terminal.t option -> unit
 
 val ast_editor_state : t -> Ast_editor_state.t

--- a/src/import.ml
+++ b/src/import.ml
@@ -193,3 +193,14 @@ module Range = struct
 end
 
 let sprintf = Printf.sprintf
+
+module Node = struct
+  let set_timeout milliseconds =
+    Promise.make (fun ~resolve ~reject:_ ->
+        let (_ : Node.Timeout.t) =
+          Node.setTimeout (fun () -> resolve ()) milliseconds
+        in
+        ())
+
+  include Node
+end

--- a/src/import.ml
+++ b/src/import.ml
@@ -142,6 +142,18 @@ module Position = struct
     let character = Position.character t in
     Jsonoo.Encode.(object_ [ ("line", int line); ("character", int character) ])
 
+  type position =
+    { line : int
+    ; character : int
+    }
+
+  let position_of_t t =
+    let line = Position.line t in
+    let character = Position.character t in
+    { line; character }
+
+  let t_of_position { line; character } = Position.make ~line ~character
+
   include Vscode.Position
 end
 
@@ -161,6 +173,21 @@ module Range = struct
     let start = Range.start t |> Position.json_of_t in
     let end_ = Range.end_ t |> Position.json_of_t in
     Jsonoo.Encode.(object_ [ ("start", start); ("end", end_) ])
+
+  type range =
+    { start : Position.position
+    ; end_ : Position.position
+    }
+
+  let range_of_t t =
+    let start = Range.start t |> Position.position_of_t in
+    let end_ = Range.end_ t |> Position.position_of_t in
+    { start; end_ }
+
+  let t_of_range { start; end_ } =
+    let start = Position.t_of_position start in
+    let end_ = Position.t_of_position end_ in
+    Range.makePositions ~start ~end_
 
   include Vscode.Range
 end

--- a/src/import.ml
+++ b/src/import.ml
@@ -174,21 +174,6 @@ module Range = struct
     let end_ = Range.end_ t |> Position.json_of_t in
     Jsonoo.Encode.(object_ [ ("start", start); ("end", end_) ])
 
-  type range =
-    { start : Position.position
-    ; end_ : Position.position
-    }
-
-  let range_of_t t =
-    let start = Range.start t |> Position.position_of_t in
-    let end_ = Range.end_ t |> Position.position_of_t in
-    { start; end_ }
-
-  let t_of_range { start; end_ } =
-    let start = Position.t_of_position start in
-    let end_ = Position.t_of_position end_ in
-    Range.makePositions ~start ~end_
-
   include Vscode.Range
 end
 

--- a/src/ocaml_lsp.ml
+++ b/src/ocaml_lsp.ml
@@ -5,6 +5,7 @@ type t =
   ; handleSwitchImplIntf : bool
   ; handleInferIntf : bool
   ; handleTypedHoles : bool
+  ; handleWrappingAstNode : bool
   }
 
 let default =
@@ -12,6 +13,7 @@ let default =
   ; handleSwitchImplIntf = false
   ; handleInferIntf = false
   ; handleTypedHoles = false
+  ; handleWrappingAstNode = false
   }
 
 let default_field key decode default json =
@@ -35,10 +37,15 @@ let of_json (json : Jsonoo.t) =
     let handleTypedHoles =
       default_field "handleTypedHoles" bool default.handleTypedHoles json
     in
+    let handleWrappingAstNode =
+      default_field "handleWrappingAstNode" bool default.handleWrappingAstNode
+        json
+    in
     { interfaceSpecificLangId
     ; handleSwitchImplIntf
     ; handleInferIntf
     ; handleTypedHoles
+    ; handleWrappingAstNode
     }
   with
   | Jsonoo.Decode_error _ ->
@@ -63,3 +70,5 @@ let can_handle_switch_impl_intf t = t.handleSwitchImplIntf
 let can_handle_infer_intf t = t.handleSwitchImplIntf
 
 let can_handle_typed_holes t = t.handleTypedHoles
+
+let can_handle_wrapping_ast_node t = t.handleWrappingAstNode

--- a/src/ocaml_lsp.mli
+++ b/src/ocaml_lsp.mli
@@ -11,3 +11,5 @@ val can_handle_switch_impl_intf : t -> bool
 val can_handle_infer_intf : t -> bool
 
 val can_handle_typed_holes : t -> bool
+
+val can_handle_wrapping_ast_node : t -> bool

--- a/src/repl.ml
+++ b/src/repl.ml
@@ -219,11 +219,7 @@ let open_terminal instance sandbox : Terminal.t Or_error.t Promise.t =
 let get_selected_code text_editor =
   let selection = TextEditor.selection text_editor in
   let document = TextEditor.document text_editor in
-  if
-    Position.isEqual
-      (Selection.start selection)
-      ~other:(Selection.end_ selection)
-  then
+  if Selection.isEmpty selection then
     None
   else
     let selected_text =

--- a/src/repl.ml
+++ b/src/repl.ml
@@ -121,19 +121,17 @@ let create_terminal instance sandbox =
         Ok term))
 
 let get_code text_editor =
-  let selection = Vscode.TextEditor.selection text_editor in
-  let start_line = Vscode.Selection.start selection |> Vscode.Position.line in
-  let end_line = Vscode.Selection.end_ selection |> Vscode.Position.line in
-  let start_char =
-    Vscode.Selection.start selection |> Vscode.Position.character
-  in
-  let end_char = Vscode.Selection.end_ selection |> Vscode.Position.character in
-  let document = Vscode.TextEditor.document text_editor in
+  let selection = TextEditor.selection text_editor in
+  let start_line = Selection.start selection |> Position.line in
+  let end_line = Selection.end_ selection |> Position.line in
+  let start_char = Selection.start selection |> Position.character in
+  let end_char = Selection.end_ selection |> Position.character in
+  let document = TextEditor.document text_editor in
   if start_line = end_line && start_char = end_char then
-    let line = Vscode.TextDocument.lineAt document ~line:start_line in
-    Vscode.TextLine.text line
+    let line = TextDocument.lineAt document ~line:start_line in
+    TextLine.text line
   else
-    Vscode.TextDocument.getText document ~range:(selection :> Vscode.Range.t) ()
+    TextDocument.getText document ~range:(selection :> Range.t) ()
 
 let prepare_code code =
   if String.is_suffix code ~suffix:";;" then

--- a/src/repl.ml
+++ b/src/repl.ml
@@ -208,11 +208,11 @@ let open_terminal instance sandbox : Terminal.t Or_error.t Promise.t =
          That's hacky, buy hey, if vscode-python does it, so can we...
          https://github.com/microsoft/vscode-python/blob/main/src/client/terminals/codeExecution/terminalCodeExecution.ts#L54 *)
       let+ () = Node.set_timeout 1500 in
-      match Terminal.exitStatus terminal with
-      | None ->
+      match Terminal.exit_status terminal with
+      | `Not_exited_yet ->
         Extension_instance.set_repl instance (Some terminal);
         Ok terminal
-      | Some exit_status -> err_msg_of_terminal_exit_status exit_status))
+      | `Exit_status s -> Error (err_msg_of_terminal_exit_status s)))
 
 (** returns selected code; returns [None] if nothing is selected, i.e.,
     selection start and end are same *)

--- a/src/repl.ml
+++ b/src/repl.ml
@@ -3,40 +3,34 @@ open Import
 module Repl_path = struct
   type t = string option
 
-  let of_json json =
-    let open Jsonoo.Decode in
-    nullable string json
+  let of_json json = Jsonoo.Decode.(nullable string) json
 
-  let to_json (t : t) =
-    let open Jsonoo.Encode in
-    nullable string t
+  let to_json (t : t) = Jsonoo.Encode.(nullable string) t
 
-  let key = "path"
+  let key = "ocaml.repl.path"
 
-  let t = Settings.create_setting ~scope:Global ~key ~of_json ~to_json
+  let t =
+    Settings.create_setting ~scope:ConfigurationTarget.Workspace ~key ~of_json
+      ~to_json
 end
 
 module Repl_args = struct
   type t = string list option
 
-  let of_json json =
-    let open Jsonoo.Decode in
-    nullable (list string) json
+  let of_json json = Jsonoo.Decode.(nullable (list string)) json
 
-  let to_json (t : t) =
-    let open Jsonoo.Encode in
-    nullable (list string) t
+  let to_json (t : t) = Jsonoo.Encode.(nullable (list string)) t
 
-  let key = "args"
+  let key = "ocaml.repl.args"
 
-  let t = Settings.create_setting ~scope:Global ~key ~of_json ~to_json
+  let t =
+    Settings.create_setting ~scope:ConfigurationTarget.Workspace ~key ~of_json
+      ~to_json
 end
 
-let get_repl_path () =
-  Option.join (Settings.get ~section:"ocaml.repl" Repl_path.t)
+let get_repl_path () = Settings.get Repl_path.t |> Option.join
 
-let get_repl_args () =
-  Option.join (Settings.get ~section:"ocaml.repl" Repl_args.t)
+let get_repl_args () = Settings.get Repl_args.t |> Option.join
 
 let name = "REPL"
 

--- a/src/repl.ml
+++ b/src/repl.ml
@@ -1,37 +1,5 @@
 open Import
 
-module Repl_path = struct
-  type t = string option
-
-  let of_json json = Jsonoo.Decode.(nullable string) json
-
-  let to_json (t : t) = Jsonoo.Encode.(nullable string) t
-
-  let key = "ocaml.repl.path"
-
-  let t =
-    Settings.create_setting ~scope:ConfigurationTarget.Workspace ~key ~of_json
-      ~to_json
-end
-
-module Repl_args = struct
-  type t = string list option
-
-  let of_json json = Jsonoo.Decode.(nullable (list string)) json
-
-  let to_json (t : t) = Jsonoo.Encode.(nullable (list string)) t
-
-  let key = "ocaml.repl.args"
-
-  let t =
-    Settings.create_setting ~scope:ConfigurationTarget.Workspace ~key ~of_json
-      ~to_json
-end
-
-let get_repl_path () = Settings.get Repl_path.t |> Option.join
-
-let get_repl_args () = Settings.get Repl_args.t |> Option.join
-
 let name = "REPL"
 
 let has_utop sandbox =
@@ -99,9 +67,9 @@ let open_terminal instance sandbox =
             | [] -> None
             | bin :: args -> Some (Sandbox.get_command sandbox bin args)))
       in
-      match get_repl_path () with
+      match Settings.repl_path () with
       | Some bin ->
-        let args = Option.value (get_repl_args ()) ~default:[] in
+        let args = Option.value (Settings.repl_args ()) ~default:[] in
         Sandbox.get_command sandbox bin args |> Promise.return
       | None -> (
         let* cmd_from_inputbox = get_cmd_from_inputbox () in

--- a/src/repl.ml
+++ b/src/repl.ml
@@ -79,7 +79,9 @@ let default_repl sandbox =
   | true, false -> Sandbox.get_command sandbox "utop" []
   | false, _ -> Sandbox.get_command sandbox "ocaml" []
 
-let create_terminal instance sandbox =
+(** opens a terminal containing the REPL either by creating a new terminal or
+    showing the existing one *)
+let open_terminal instance sandbox =
   match Extension_instance.repl instance with
   | Some term ->
     Terminal_sandbox.show term;
@@ -150,7 +152,7 @@ module Command = struct
         let open Promise.Syntax in
         let sandbox = Extension_instance.sandbox instance in
         let+ (result : (Terminal.t, string) result) =
-          create_terminal instance sandbox
+          open_terminal instance sandbox
         in
         let (_ : (Terminal.t, unit) result) =
           Result.map_error result ~f:(fun err -> log "%s" err)
@@ -166,7 +168,7 @@ module Command = struct
       let (_ : unit Promise.t) =
         let open Promise.Syntax in
         let sandbox = Extension_instance.sandbox instance in
-        let* term = create_terminal instance sandbox in
+        let* term = open_terminal instance sandbox in
         match term with
         | Error err ->
           show_message `Error "Could not start the REPL: %s" err;

--- a/src/repl.ml
+++ b/src/repl.ml
@@ -89,11 +89,11 @@ let open_terminal instance sandbox =
   | None -> (
     let open Promise.Syntax in
     let* cmd =
-      match (get_repl_path (), get_repl_args ()) with
-      | Some bin, Some args ->
+      match get_repl_path () with
+      | Some bin ->
+        let args = Option.value (get_repl_args ()) ~default:[] in
         Sandbox.get_command sandbox bin args |> Promise.return
-      | Some bin, None -> Sandbox.get_command sandbox bin [] |> Promise.return
-      | None, _ -> default_repl sandbox
+      | None -> default_repl sandbox
     in
     let* result = Cmd.check cmd in
     match result with

--- a/src/repl.ml
+++ b/src/repl.ml
@@ -248,10 +248,7 @@ module Command = struct
         let+ (result : (Terminal.t, string) result) =
           open_terminal instance sandbox
         in
-        let (_ : (Terminal.t, unit) result) =
-          Result.map_error result ~f:(fun err -> log "%s" err)
-        in
-        ()
+        Result.iter_error result ~f:(fun err -> log "%s" err)
       in
       ()
     in
@@ -270,10 +267,10 @@ module Command = struct
         | Ok term -> (
           match get_selected_code textEditor with
           | Some code ->
-            Promise.return
-              (if String.length code > 0 then
-                let code = preformat_code code in
-                Terminal_sandbox.send term code)
+            (if String.length code > 0 then
+              let code = preformat_code code in
+              Terminal_sandbox.send term code);
+            Promise.return ()
           | None -> (
             let open Promise.Syntax in
             match Extension_instance.lsp_client instance with

--- a/src/repl.ml
+++ b/src/repl.ml
@@ -162,7 +162,6 @@ let open_terminal instance sandbox : Terminal.t Or_error.t Promise.t =
       Promise.return
         (Error "Running a REPL from a Shell command is not supported")
     | Ok (Spawn command) -> (
-      (* TODO: add a setting: always new / always reuse / pickable *)
       let* pick =
         match Settings.repl_terminal () with
         | Settings.Repl_terminal.Always_create_new_terminal ->
@@ -178,7 +177,7 @@ let open_terminal instance sandbox : Terminal.t Or_error.t Promise.t =
         | `Existing_terminal terminal ->
           open_repl_in_existing_terminal terminal command
       in
-      Terminal_sandbox.show terminal;
+      Terminal_sandbox.show ~preserveFocus:true terminal;
       (* Wait for UTop or OCaml REPL to be initialized before sending text to
          the terminal.
 

--- a/src/repl.ml
+++ b/src/repl.ml
@@ -108,7 +108,7 @@ let open_terminal instance sandbox =
       match Terminal.exitStatus term with
       | Some _ -> Error "The REPL terminal could not be open"
       | None ->
-        Extension_instance.set_repl instance term;
+        Extension_instance.set_repl instance (Some term);
         Ok term))
 
 (** returns selected code; returns [None] if nothing is selected, i.e.,
@@ -223,7 +223,7 @@ let register extension instance =
     Vscode.Window.onDidCloseTerminal ()
       ~listener:(fun terminal ->
         if String.equal (Vscode.Terminal.name terminal) name then
-          Extension_instance.close_repl instance)
+          Extension_instance.set_repl instance None)
       ()
   in
   Vscode.ExtensionContext.subscribe extension ~disposable

--- a/src/repl.ml
+++ b/src/repl.ml
@@ -202,10 +202,10 @@ let open_terminal instance sandbox : Terminal.t Or_error.t Promise.t =
           open_repl_in_existing_terminal terminal command
       in
       Terminal_sandbox.show ~preserveFocus:true terminal;
-      (* Wait for UTop or OCaml REPL to be initialized before sending text to
-         the terminal.
-
-         That's hacky, buy hey, if vscode-python does it, so can we...
+      (* With the current vscode API we can't check if there's a process running
+         in the foreground or whether the REPL is ready to evaluate code (eg
+         it's setting up env), so we wait for the init to happen. So does python
+         extension:
          https://github.com/microsoft/vscode-python/blob/main/src/client/terminals/codeExecution/terminalCodeExecution.ts#L54 *)
       let+ () = Node.set_timeout 1500 in
       match Terminal.exit_status terminal with

--- a/src/repl.ml
+++ b/src/repl.ml
@@ -124,16 +124,29 @@ let user_picks_terminal ~include_create_new_terminal () =
   in
   Window.showQuickPickItems ~choices ~options ()
 
-let explain_unix_shell_exit_code ?command ~code () : string option =
-  let fmted_cmd =
-    Option.value_map command ~default:"" ~f:(fun c -> Printf.sprintf "'%s' " c)
-  in
-  let fmted_msg msg = Some (Printf.sprintf msg fmted_cmd) in
-  match code with
-  | 126 -> fmted_msg "Command %scannot execute"
-  | 127 -> fmted_msg "Command %snot found"
-  | 130 -> fmted_msg "Command %sterminated by 'control+c'"
-  | _ -> None
+(* TODO: use [?command] *)
+let err_msg_of_terminal_exit_status ?command exit_status =
+  let default_err = "a terminal for REPL could not be open for some reason" in
+  match Platform.t with
+  | Platform.Win32
+  | Other ->
+    default_err
+  | Darwin
+  | Linux -> (
+    match TerminalExitStatus.code exit_status with
+    | None -> default_err
+    | Some 0 -> default_err
+    | Some code -> (
+      let fmted_cmd =
+        Option.value_map command ~default:"" ~f:(fun c ->
+            Printf.sprintf "'%s' " c)
+      in
+      let fmted_msg msg = Printf.sprintf msg fmted_cmd in
+      match code with
+      | 126 -> fmted_msg "Command %scannot execute"
+      | 127 -> fmted_msg "Command %snot found"
+      | 130 -> fmted_msg "Command %sterminated by 'control+c'"
+      | _ -> default_err))
 
 (** opens a terminal containing the REPL either by creating a new terminal or
     showing the existing one *)
@@ -199,24 +212,7 @@ let open_terminal instance sandbox : Terminal.t Or_error.t Promise.t =
       | None ->
         Extension_instance.set_repl instance (Some terminal);
         Ok terminal
-      | Some exit_status -> (
-        let default_err =
-          Error "a terminal for REPL could not be open for some reason"
-        in
-        match Platform.t with
-        | Platform.Win32
-        | Other ->
-          default_err
-        | Darwin
-        | Linux -> (
-          match TerminalExitStatus.code exit_status with
-          | None -> default_err
-          | Some 0 -> default_err
-          | Some code ->
-            (* TODO: add ~command to [explain] fn *)
-            Option.map (explain_unix_shell_exit_code ~code ()) ~f:(fun e ->
-                Error e)
-            |> Option.value ~default:default_err))))
+      | Some exit_status -> err_msg_of_terminal_exit_status exit_status))
 
 (** returns selected code; returns [None] if nothing is selected, i.e.,
     selection start and end are same *)

--- a/src/repl.ml
+++ b/src/repl.ml
@@ -103,8 +103,7 @@ let open_terminal instance sandbox =
           | cmd -> (
             match String.split cmd ~on:' ' with
             | [] -> None
-            | bin :: args -> Some (Cmd.Spawn { bin = Path.of_string bin; args })
-            ))
+            | bin :: args -> Some (Sandbox.get_command sandbox bin args)))
       in
       match get_repl_path () with
       | Some bin ->

--- a/src/repl.ml
+++ b/src/repl.ml
@@ -194,7 +194,7 @@ let open_terminal instance sandbox : Terminal.t Or_error.t Promise.t =
 
          That's hacky, buy hey, if vscode-python does it, so can we...
          https://github.com/microsoft/vscode-python/blob/main/src/client/terminals/codeExecution/terminalCodeExecution.ts#L54 *)
-      let+ () = Node.set_timeout 2500 in
+      let+ () = Node.set_timeout 1500 in
       match Terminal.exitStatus terminal with
       | None ->
         Extension_instance.set_repl instance (Some terminal);

--- a/src/repl.ml
+++ b/src/repl.ml
@@ -92,10 +92,10 @@ let open_terminal instance sandbox =
       let get_cmd_from_inputbox () =
         let options =
           InputBoxOptions.create ~title:"Command to launch REPL"
-            ~prompt:
-              "dune utop my_library (* note: [dune utop my_executable] isn't \
-               supported *)"
             ~placeHolder:"dune utop " ()
+            ~prompt:
+              "For example (without backticks): `dune utop my_library`. If not \
+               provided, a default REPL will open."
         in
         let+ (cmd : string option) = Window.showInputBox ~options () in
         Option.bind cmd ~f:(function

--- a/src/repl.ml
+++ b/src/repl.ml
@@ -218,8 +218,7 @@ let open_terminal instance sandbox : Terminal.t Or_error.t Promise.t =
            longer time, while calling [utop] or [ocaml] doesn't need much wait
            time before sending the command *)
         let wait_time =
-          if String.is_suffix (Path.to_string command.Cmd.bin) ~suffix:"dune"
-          then (
+          if List.exists command.Cmd.args ~f:(String.equal "dune") then (
             show_message `Info
               "Calling `dune utop ...` builds code, so that may take more time \
                than we expect before sending the code to the terminal. If we \

--- a/src/repl.ml
+++ b/src/repl.ml
@@ -47,7 +47,7 @@ let default_repl sandbox =
 let repl_from_inputbox sandbox =
   let options =
     InputBoxOptions.create ~title:"Command to launch REPL"
-      ~placeHolder:"example: dune utop" ()
+      ~placeHolder:"example: utop" ()
       ~prompt:"If not provided, a default REPL will open."
   in
   let open Promise.Syntax in

--- a/src/repl.ml
+++ b/src/repl.ml
@@ -122,13 +122,11 @@ let create_terminal instance sandbox =
 
 let get_code text_editor =
   let selection = TextEditor.selection text_editor in
-  let start_line = Selection.start selection |> Position.line in
-  let end_line = Selection.end_ selection |> Position.line in
-  let start_char = Selection.start selection |> Position.character in
-  let end_char = Selection.end_ selection |> Position.character in
+  let start = Selection.start selection in
+  let end_ = Selection.end_ selection in
   let document = TextEditor.document text_editor in
-  if start_line = end_line && start_char = end_char then
-    let line = TextDocument.lineAt document ~line:start_line in
+  if Position.isEqual start ~other:end_ then
+    let line = TextDocument.lineAt document ~line:(Position.line start) in
     TextLine.text line
   else
     TextDocument.getText document ~range:(selection :> Range.t) ()

--- a/src/repl.ml
+++ b/src/repl.ml
@@ -207,7 +207,7 @@ let open_terminal instance sandbox : Terminal.t Or_error.t Promise.t =
          it's setting up env), so we wait for the init to happen. So does python
          extension:
          https://github.com/microsoft/vscode-python/blob/main/src/client/terminals/codeExecution/terminalCodeExecution.ts#L54 *)
-      let+ () = Node.set_timeout 1500 in
+      let+ () = Node.setTimeoutPromise ~milliseconds:1500 in
       match Terminal.exit_status terminal with
       | `Not_exited_yet ->
         Extension_instance.set_repl instance (Some terminal);

--- a/src/repl.ml
+++ b/src/repl.ml
@@ -84,7 +84,7 @@ let default_repl sandbox =
 let open_terminal instance sandbox =
   match Extension_instance.repl instance with
   | Some term ->
-    Terminal_sandbox.show term;
+    Terminal_sandbox.show ~preserveFocus:true term;
     Promise.return (Ok term)
   | None -> (
     let open Promise.Syntax in

--- a/src/repl.ml
+++ b/src/repl.ml
@@ -222,8 +222,12 @@ let register extension instance =
   let disposable =
     Vscode.Window.onDidCloseTerminal ()
       ~listener:(fun terminal ->
-        if String.equal (Vscode.Terminal.name terminal) name then
-          Extension_instance.set_repl instance None)
+        match Extension_instance.repl instance with
+        | Some t when phys_equal terminal t ->
+          Extension_instance.set_repl instance None
+        | Some _
+        | None ->
+          ())
       ()
   in
   Vscode.ExtensionContext.subscribe extension ~disposable

--- a/src/repl.ml
+++ b/src/repl.ml
@@ -104,13 +104,7 @@ let open_terminal instance sandbox =
 
          That's hacky, buy hey, if vscode-python does it, so can we...
          https://github.com/microsoft/vscode-python/blob/main/src/client/terminals/codeExecution/terminalCodeExecution.ts#L54 *)
-      let+ () =
-        Promise.make (fun ~resolve ~reject:_ ->
-            let (_ : Node.Timeout.t) =
-              Node.setTimeout (fun () -> resolve ()) 2500
-            in
-            ())
-      in
+      let+ () = Node.set_timeout 2500 in
       match Terminal.exitStatus term with
       | Some _ -> Error "The REPL terminal could not be open"
       | None ->

--- a/src/repl.ml
+++ b/src/repl.ml
@@ -184,7 +184,7 @@ module Command = struct
     in
     Extension_commands.register ~id:Extension_consts.Commands.open_repl handler
 
-  let _evaluate_selection =
+  let _evaluate_expression =
     let handler (instance : Extension_instance.t) ~textEditor ~edit:_ ~args:_ =
       let (_ : unit Promise.t) =
         let open Promise.Syntax in
@@ -241,7 +241,7 @@ module Command = struct
       ()
     in
     Extension_commands.register_text_editor
-      ~id:Extension_consts.Commands.evaluate_selection handler
+      ~id:Extension_consts.Commands.evaluate_expression handler
 end
 
 let register extension instance =

--- a/src/settings.ml
+++ b/src/settings.ml
@@ -121,3 +121,35 @@ module Repl_args = struct
 end
 
 let repl_args = Repl_args.get
+
+module Repl_terminal = struct
+  type t =
+    | Always_existing_terminal
+    | Always_create_new_terminal
+    | Always_ask
+
+  let setting =
+    let of_json json =
+      Jsonoo.Decode.string json |> function
+      | "Always existing terminal" -> Always_existing_terminal
+      | "Always create new terminal" -> Always_create_new_terminal
+      | "Always ask" -> Always_ask
+      | _ -> assert false
+    in
+    let to_json t =
+      let s =
+        match t with
+        | Always_existing_terminal -> "Always existing terminal"
+        | Always_create_new_terminal -> "Always create new terminal"
+        | Always_ask -> "Always ask"
+      in
+      Jsonoo.Encode.string s
+    in
+    create_setting ~scope:ConfigurationTarget.Workspace
+      ~key:"ocaml.repl.terminal" ~to_json ~of_json
+
+  let get () = Option.value_exn (get setting)
+  (* [_exn] because we have a default value *)
+end
+
+let repl_terminal = Repl_terminal.get

--- a/src/settings.ml
+++ b/src/settings.ml
@@ -87,3 +87,37 @@ module ExtraEnv = struct
 end
 
 let server_extraEnv = ExtraEnv.get
+
+module Repl_path = struct
+  type t = string option
+
+  let of_json json = Jsonoo.Decode.(nullable string) json
+
+  let to_json (t : t) = Jsonoo.Encode.(nullable string) t
+
+  let key = "ocaml.repl.path"
+
+  let setting =
+    create_setting ~scope:ConfigurationTarget.Workspace ~key ~of_json ~to_json
+
+  let get () = get setting |> Option.join
+end
+
+let repl_path = Repl_path.get
+
+module Repl_args = struct
+  type t = string list option
+
+  let of_json json = Jsonoo.Decode.(nullable (list string)) json
+
+  let to_json (t : t) = Jsonoo.Encode.(nullable (list string)) t
+
+  let key = "ocaml.repl.args"
+
+  let setting =
+    create_setting ~scope:ConfigurationTarget.Workspace ~key ~of_json ~to_json
+
+  let get () = get setting |> Option.join
+end
+
+let repl_args = Repl_args.get

--- a/src/settings.mli
+++ b/src/settings.mli
@@ -37,3 +37,7 @@ val resolve_workspace_vars : string -> string
 val substitute_workspace_vars : string -> string
 
 val server_extraEnv : unit -> string Interop.Dict.t option
+
+val repl_path : unit -> string option
+
+val repl_args : unit -> string list option

--- a/src/settings.mli
+++ b/src/settings.mli
@@ -41,3 +41,12 @@ val server_extraEnv : unit -> string Interop.Dict.t option
 val repl_path : unit -> string option
 
 val repl_args : unit -> string list option
+
+module Repl_terminal : sig
+  type t =
+    | Always_existing_terminal
+    | Always_create_new_terminal
+    | Always_ask
+end
+
+val repl_terminal : unit -> Repl_terminal.t

--- a/src/terminal_sandbox.ml
+++ b/src/terminal_sandbox.ml
@@ -91,7 +91,7 @@ let create ?name ?command sandbox =
 
 let dispose = Terminal.dispose
 
-let show t = Terminal.show t ()
+let show ?preserveFocus t = Terminal.show ?preserveFocus t ()
 
 let send t text =
   let addNewLine = not (String.is_suffix text ~suffix:"\n") in

--- a/src/terminal_sandbox.mli
+++ b/src/terminal_sandbox.mli
@@ -4,6 +4,6 @@ val create : ?name:string -> ?command:Cmd.spawn -> Sandbox.t -> t
 
 val dispose : t -> unit
 
-val show : t -> unit
+val show : ?preserveFocus:bool -> t -> unit
 
 val send : t -> string -> unit


### PR DESCRIPTION
This PR has several improvements to how we work with REPLs: 

1. Improved workflow - now if the user doesn't have indicated `ocaml.repl.path` and `ocaml.repl.args`, we don't launch a default REPL, but prompt the user to enter a command to launch the REPL, e.g., `dune utop my_library -- -implicit-bindings`, which is more useful than the default `dune utop`. Read more about workflow improvement in the Changelog (and code). Update: user now can also pick to launch the REPL either in a new terminal or an existing one.
2. Add support for evaluating "toplevel" expression enclosing the cursor. See the Changelog for a detailed description of how that works. Internally, it uses a custom request `ocamllsp/wrappingAstNode` implemented in (https://github.com/ocaml/ocaml-lsp/pull/482). (closes #535) 
3. Rename the command `Evaluate Selection` to `Evaluate Expression in REPL`:
- because of (2), we now evaluate not only a selection, but also expressions enclosing the cursor 
- indicates that the evaluation happens in a REPL
4. Now evaluation doesn't steal focus from the editor to the REPL

_How to review_ 

Commits following logical steps, but sometimes a later commit overwrites a part of what a previous one did. So commit-by-commit review should be easier but may be more time-consuming. Any comment/feedback is welcome because I took some liberty in making changes that are not directly related to the goal of this PR -- I wouldn't call those changes cosmetic, but they just move around code (though make code easier IMHO)

_TODO_

- [x] improve prompt in inputbox to launch REPL
- [x] needs a fix in utop: when passing a large piece of code parts of the code are repeated -- needs investigation & a fix preferably
    - entering a large piece of code results in duplication, so that should be fixed in utop 
- [x] support opening the REPL in an existing terminal (important)
- [x] add support for "evaluate a file" (should this happen in another PR?)
- [ ] clean up code
- [ ] determine whether `Exit` cmd works in windows shell

Should this PR be broken into several? 