### PR TITLE
Bump ocamlformat version from 0.18.0 to 0.19.0

### DIFF
--- a/.ocamlformat
+++ b/.ocamlformat
@@ -1,4 +1,4 @@
-version=0.18.0
+version=0.19.0
 profile=conventional
 break-separators=before
 dock-collection-brackets=false

--- a/fixtures/sample-esy/bin/SampleEsyApp.ml
+++ b/fixtures/sample-esy/bin/SampleEsyApp.ml
@@ -1,4 +1,3 @@
-;;
 print_endline "Hello"
 
 let blah () =

--- a/src/cmd.ml
+++ b/src/cmd.ml
@@ -113,7 +113,8 @@ let log ?(result : ChildProcess.return option) (t : t) =
     match t with
     | Spawn { bin; args } ->
       ("bin", string (Path.to_string bin))
-      :: ("args", list string args) :: fields
+      :: ("args", list string args)
+      :: fields
     | Shell command_line -> ("shell", string command_line) :: fields
   in
   match result with

--- a/src/sandbox.ml
+++ b/src/sandbox.ml
@@ -391,7 +391,7 @@ let sandbox_candidates ~workspace_folders =
   in
 
   let+ esy, opam = Promise.all2 (esy, opam) in
-  global :: custom :: esy @ opam
+  (global :: custom :: esy) @ opam
 
 let select_sandbox () =
   let open Promise.Syntax in

--- a/src/settings.mli
+++ b/src/settings.mli
@@ -14,7 +14,8 @@ type 'value setting
    [ocaml.dune.autoDetect]. In some places, we treat [key] as this whole path
    for the setting, [ocaml.dune.autoDetect], and in some places we use
    [autoDetect] as the key and [ocaml.dune] as the "section". VS Code allows
-   this, but this non uniform treatment is bad. We should enforce a nicer API. *)
+   this, but this non uniform treatment is bad. We should enforce a nicer
+   API. *)
 
 val get : ?section:string -> 'value setting -> 'value option
 
@@ -27,10 +28,12 @@ val create_setting :
   -> to_json:('value -> Jsonoo.t)
   -> 'value setting
 
-(** replace ${workspaceFolder:folder_name} variables with workspace folder paths *)
+(** replace ${workspaceFolder:folder_name} variables with workspace folder
+    paths *)
 val resolve_workspace_vars : string -> string
 
-(** replace workspace folder paths with ${workspaceFolder:folder_name} variables *)
+(** replace workspace folder paths with ${workspaceFolder:folder_name}
+    variables *)
 val substitute_workspace_vars : string -> string
 
 val server_extraEnv : unit -> string Interop.Dict.t option


### PR DESCRIPTION
This PR is related to #666, since it introduces `ppxlib`. 

This change will be needed since `ocamlformat.0.18.0` used `ocaml-migrate-parsetree` in pair with `ppxlib`s' internal API (`Ppxlib_ast__.Versions.OCaml_408`) that will change in the the upcoming release of `ppxlib` making it incompatible. 

The `0.19.0` [drops](https://github.com/ocaml-ppx/ocamlformat/commit/448ac7c1496e2a6e83d63a7bcd9cf4e35bb2b1fb) the dependency and is therefore compatible.
