### PR TITLE
Windows case-insensitivity

### DIFF
--- a/DEVELOPING.md
+++ b/DEVELOPING.md
@@ -1,0 +1,23 @@
+# Developing
+
+## Quick Start
+
+FIRST, install the OCaml dependencies and generate the OCaml -> Javascript
+artifacts:
+
+```bash
+opam install . --deps-only --with-test
+make build
+```
+
+SECOND, press F5 in VS Code to launch the "Extension Development Host".
+
+## Code Hygiene
+
+```bash
+esy
+yarn
+opam install ocamlformat
+make fmt
+make test
+```

--- a/src/bindings/node/node.ml
+++ b/src/bindings/node/node.ml
@@ -137,6 +137,8 @@ module Path = struct
     [%js:
     val delimiter : string [@@js.global "path.delimiter"]
 
+    val sep : string [@@js.global "path.sep"]
+
     val basename : string -> string [@@js.global "path.basename"]
 
     val dirname : string -> string [@@js.global "path.dirname"]
@@ -150,6 +152,10 @@ module Path = struct
   let delimiter =
     assert (String.length delimiter = 1);
     delimiter.[0]
+
+  let sep =
+    assert (String.length sep = 1);
+    sep.[0]
 end
 
 module Fs = struct

--- a/src/bindings/node/node.mli
+++ b/src/bindings/node/node.mli
@@ -108,6 +108,8 @@ end
 module Path : sig
   val delimiter : char
 
+  val sep : char
+
   val basename : string -> string
 
   val dirname : string -> string

--- a/src/opam.ml
+++ b/src/opam.ml
@@ -88,10 +88,12 @@ module Switch = struct
     | Named n -> Path.(opam.root / n)
 
   let equal x y =
-    match (x, y) with
-    | Local x, Local y -> Path.equal x y
-    | Named x, Named y -> String.equal x y
-    | _, _ -> false
+    (* Windows paths are case-insensitive *)
+    match (Platform.t, x, y) with
+    | Win32, Local x, Local y -> Path.iequal x y
+    | _, Local x, Local y -> Path.equal x y
+    | _, Named x, Named y -> String.equal x y
+    | _, _, _ -> false
 end
 
 module Switch_state : sig

--- a/src/path.ml
+++ b/src/path.ml
@@ -4,11 +4,15 @@ type t = string
 
 let equal = String.equal
 
+let iequal p0 p1 = String.equal (String.lowercase p0) (String.lowercase p1)
+
 let of_string s = s
 
 let to_string s = s
 
 let delimiter = Node.Path.delimiter
+
+let sep = Node.Path.sep
 
 let is_absolute t = Node.Path.isAbsolute t
 

--- a/src/path.mli
+++ b/src/path.mli
@@ -4,11 +4,17 @@ type t
 
 val equal : t -> t -> bool
 
+(** [iequal p0 p1] is [true] if and only if [p1] and [p2] are equal but case
+    insensitive to any ASCII-uppercase/-lowercase differences. *)
+val iequal : t -> t -> bool
+
 val of_string : string -> t
 
 val to_string : t -> string
 
 val delimiter : char
+
+val sep : char
 
 val is_absolute : t -> bool
 

--- a/src/settings.ml
+++ b/src/settings.ml
@@ -53,8 +53,14 @@ let resolve_workspace_vars setting =
   Interop.Regexp.replace setting ~regexp ~replacer
 
 let substitute_workspace_vars setting =
+  (* Windows paths are case-insensitive *)
+  let folder_replace_all =
+    match Platform.t with
+    | Win32 -> String.Caseless.substr_replace_all
+    | _ -> String.substr_replace_all
+  in
   List.fold (Workspace.workspaceFolders ()) ~init:setting ~f:(fun acc folder ->
-      String.substr_replace_all acc
+      folder_replace_all acc
         ~pattern:(workspace_folder_path folder)
         ~with_:(workspace_folder_var folder))
 


### PR DESCRIPTION
* External Opam switches (aka local switches) often were not visible to
  the extension because of the case mismatch between the switch path as
  reported by `opam switch list` and the workspace folder path reported by
  VS Code
* ${pathSeparator} adds a standard VS Code variable which lets VS Code
  projects open portably on Windows or Unix

---

Also included a DEVELOPING.md containing slightly reverse-engineered instructions.