### PR TITLE
Fix highlighting of escaped odoc source code braces

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,10 +22,12 @@
 - Add `ocaml.server.extraEnv` configuration option to pass extra environment
   variables to the language server, i.e., OCaml-LSP (#674)
 
-- Parsetree exploration and development tools. It is now possible to explore
-  the structure of the parsetree in a custom editor. Additionally, it is
-  possible to view preprocessed source of any OCaml source file (when
-  applicable). Full functionality is available only for dune projects. (#666)
+- Parsetree exploration and development tools. It is now possible to explore the
+  structure of the parsetree in a custom editor. Additionally, it is possible to
+  view preprocessed source of any OCaml source file (when applicable). Full
+  functionality is available only for dune projects. (#666)
+
+- Fix highlighting of escaped odoc source code braces (#690)
 
 ## 1.8.4
 

--- a/syntaxes/ocamldoc.json
+++ b/syntaxes/ocamldoc.json
@@ -20,8 +20,8 @@
         },
         {
           "comment": "embedded ocaml source",
-          "begin": "\\[",
-          "end": "\\]",
+          "begin": "(?<!\\\\)\\[",
+          "end": "(?<!\\\\)\\]",
           "contentName": "source.embedded.ocamldoc",
           "patterns": [{ "include": "source.ocaml" }]
         }


### PR DESCRIPTION
Closes #689 

| Before | After |
| - | - |
| ![before](https://user-images.githubusercontent.com/25037249/131042776-ce4c0e84-d9b4-4401-b323-56c818aab51a.png) | ![after](https://user-images.githubusercontent.com/25037249/131042780-d26c79e7-d827-431a-bf09-cc03817e3302.png) |

