### PR TITLE
Add commands to show output for ocaml-lsp, the extension, and commands

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -27,6 +27,10 @@
   view preprocessed source of any OCaml source file (when applicable). Full
   functionality is available only for dune projects. (#666)
 
+- Add commands `Show OCaml Language Server Output`,
+  `Show OCaml Platform Extension Output`, and `Show OCaml Commands Output`.
+  (#745)
+
 - Fix highlighting of escaped odoc source code braces (#690)
 
 ## 1.8.4

--- a/package.json
+++ b/package.json
@@ -233,6 +233,21 @@
         "command": "ocaml.open-pp-editor-and-ast-explorer",
         "category": "OCaml",
         "title": "Open both Preprocessed Document and AST explorer to the side"
+      },
+      {
+        "command": "ocaml.open-ocamllsp-output",
+        "category": "OCaml",
+        "title": "Show OCaml Language Server Output"
+      },
+      {
+        "command": "ocaml.open-ocaml-platform-ext-output",
+        "category": "OCaml",
+        "title": "Show OCaml Platform Extension Output"
+      },
+      {
+        "command": "ocaml.open-ocaml-commands-output",
+        "category": "OCaml",
+        "title": "Show OCaml Commands Output"
       }
     ],
     "keybindings": [

--- a/src/extension_commands.ml
+++ b/src/extension_commands.ml
@@ -133,6 +133,20 @@ let _open_current_dune_file =
   in
   command Extension_consts.Commands.open_current_dune_file handler
 
+let ( _open_ocamllsp_output_pane
+    , _open_ocaml_platform_ext_pane
+    , _open_ocaml_commands_pane ) =
+  let handler output (_instance : Extension_instance.t) ~args:_ =
+    let show_output (lazy output) = OutputChannel.show output () in
+    show_output output
+  in
+  ( command Extension_consts.Commands.open_ocamllsp_output
+      (handler Output.language_server_output_channel)
+  , command Extension_consts.Commands.open_ocaml_platform_ext_output
+      (handler Output.extension_output_channel)
+  , command Extension_consts.Commands.open_ocaml_commands_output
+      (handler Output.command_output_channel) )
+
 module Holes_commands : sig
   val _jump_to_prev_hole : t
 

--- a/src/extension_consts.ml
+++ b/src/extension_consts.ml
@@ -48,6 +48,13 @@ module Commands = struct
 
   let open_pp_editor_and_ast_explorer =
     ocaml_prefixed "open-pp-editor-and-ast-explorer"
+
+  let open_ocamllsp_output = ocaml_prefixed "open-ocamllsp-output"
+
+  let open_ocaml_platform_ext_output =
+    ocaml_prefixed "open-ocaml-platform-ext-output"
+
+  let open_ocaml_commands_output = ocaml_prefixed "open-ocaml-commands-output"
 end
 
 module Command_errors = struct


### PR DESCRIPTION
> Add commands `Show OCaml Language Server Output`,
  `Show OCaml Platform Extension Output`, and `Show OCaml Commands Output`

This should make it easier for users to see problems for themselves and tell us if they see something strange in the output such as exceptions in case of ocaml-lsp. 

The next PR will document these new commands