### PR TITLE
Offline doc generation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,9 @@
 
 ## 1.9.0
 
+- Add the possibility to generate and show the documentation of an installed
+  package right into VSCode. (#771)
+
 - Dune syntax highlighting fix (#742)
 
   The syntax for dune files has been re-written from scratch for a more correct

--- a/package.json
+++ b/package.json
@@ -1014,7 +1014,7 @@
   },
   "dependencies": {
     "polka": "^1.0.0-next.22",
-    "sirv": "^1.0.19",
+    "sirv": "^2.0.0",
     "vscode-languageclient": "7.0.0"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -376,6 +376,10 @@
         {
           "command": "ocaml.open-sandbox-documentation",
           "when": "false"
+        },
+        {
+          "command": "ocaml.generate-sandbox-documentation",
+          "when": "false"
         }
       ],
       "editor/title": [

--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
     "onCommand:ocaml.open-ast-explorer-to-the-side",
     "onCommand:ocaml.show-preprocessed-document",
     "onCommand:ocaml.open-pp-editor-and-ast-explorer",
+    "onCommand:ocaml.stop-documentation-server",
     "onCustomEditor:ast-editor",
     "onCustomEditor:cm-files-editor",
     "workspaceContains:**/dune-workspace",
@@ -196,6 +197,11 @@
           "light": "assets/document-search-light.svg",
           "dark": "assets/document-search-dark.svg"
         }
+      },
+      {
+        "command": "ocaml.stop-documentation-server",
+        "category": "OCaml",
+        "title": "Stop Documentation Server"
       },
       {
         "command": "ocaml.next-hole",

--- a/package.json
+++ b/package.json
@@ -1014,7 +1014,7 @@
   },
   "dependencies": {
     "polka": "^1.0.0-next.22",
-    "sirv": "^2.0.0",
+    "sirv": "^2.0.2",
     "vscode-languageclient": "7.0.0"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -368,6 +368,10 @@
           "when": "false"
         },
         {
+          "command": "ocaml.stop-documentation-server",
+          "when": "ocaml.documentation-server-on"
+        },
+        {
           "command": "ocaml.upgrade-sandbox",
           "when": "false"
         },

--- a/package.json
+++ b/package.json
@@ -1013,6 +1013,8 @@
     "fmt": "prettier . --write"
   },
   "dependencies": {
+    "polka": "^1.0.0-next.22",
+    "sirv": "^1.0.19",
     "vscode-languageclient": "7.0.0"
   },
   "devDependencies": {

--- a/src-bindings/node/node.ml
+++ b/src-bindings/node/node.ml
@@ -24,7 +24,9 @@ include
   [%js:
   val setInterval : (unit -> unit) -> int -> Timeout.t [@@js.global]
 
-  val setTimeout : (unit -> unit) -> int -> Timeout.t [@@js.global]]
+  val setTimeout : (unit -> unit) -> int -> Timeout.t [@@js.global]
+
+  val clearTimeout : Timeout.t -> unit [@@js.global]]
 
 module Process = struct
   include

--- a/src-bindings/node/node.ml
+++ b/src-bindings/node/node.ml
@@ -175,6 +175,31 @@ module Fs = struct
   let readFile = readFile ~encoding:"utf8"
 end
 
+module Net = struct
+  module Socket = struct
+    include Class.Make ()
+
+    include
+      [%js:
+      val make : unit -> t [@@js.new "net.Socket"]
+
+      val isPaused : t -> bool [@@js.call]
+
+      val destroy : t -> unit [@@js.call]
+
+      val connect : t -> port:int -> host:string -> t [@@js.call]
+
+      val setTimeout : t -> int -> t [@@js.call]
+
+      val on : t -> string -> Ojs.t -> unit [@@js.call]]
+
+    let on t = function
+      | `Connect f -> on t "connect" @@ [%js.of: unit -> unit] f
+      | `Timeout f -> on t "timeout" @@ [%js.of: unit -> unit] f
+      | `Error f -> on t "error" @@ [%js.of: err:JsError.t -> unit] f
+  end
+end
+
 module ChildProcess = struct
   include Class.Make ()
 

--- a/src-bindings/node/node.mli
+++ b/src-bindings/node/node.mli
@@ -20,6 +20,8 @@ val setInterval : (unit -> unit) -> int -> Timeout.t
 
 val setTimeout : (unit -> unit) -> int -> Timeout.t
 
+val clearTimeout : Timeout.t -> unit
+
 module Process : sig
   val cwd : unit -> string
 

--- a/src-bindings/node/node.mli
+++ b/src-bindings/node/node.mli
@@ -133,6 +133,30 @@ module Fs : sig
   val exists : string -> bool Promise.t
 end
 
+module Net : sig
+  module Socket : sig
+    type t
+
+    val make : unit -> t
+
+    val isPaused : t -> bool
+
+    val destroy : t -> unit
+
+    val connect : t -> port:int -> host:string -> t
+
+    val setTimeout : t -> int -> t
+
+    val on :
+         t
+      -> [ `Connect of unit -> unit
+         | `Timeout of unit -> unit
+         | `Error of err:JsError.t -> unit
+         ]
+      -> unit
+  end
+end
+
 module ChildProcess : sig
   module Options : sig
     type t

--- a/src-bindings/node/node_stub.js
+++ b/src-bindings/node/node_stub.js
@@ -12,3 +12,5 @@ joo_global_object.child_process = require("child_process");
 joo_global_object.path = require("path");
 
 joo_global_object.os = require("os");
+
+joo_global_object.net = require("net");

--- a/src-bindings/polka/dune
+++ b/src-bindings/polka/dune
@@ -4,5 +4,5 @@
   (pps gen_js_api.ppx))
  (js_of_ocaml
   (javascript_files polka_stub.js))
- (libraries interop promise_jsoo jsonoo js_of_ocaml gen_js_api)
+ (libraries interop promise_jsoo jsonoo js_of_ocaml gen_js_api node)
  (modes byte))

--- a/src-bindings/polka/dune
+++ b/src-bindings/polka/dune
@@ -1,0 +1,8 @@
+(library
+ (name polka)
+ (preprocess
+  (pps gen_js_api.ppx))
+ (js_of_ocaml
+  (javascript_files polka_stub.js))
+ (libraries interop promise_jsoo jsonoo js_of_ocaml gen_js_api)
+ (modes byte))

--- a/src-bindings/polka/polka.ml
+++ b/src-bindings/polka/polka.ml
@@ -22,11 +22,7 @@ module Server = struct
     | `Error f -> on t "error" @@ [%js.of: err:Node.JsError.t -> unit] f
 end
 
-type polka = Ojs.t
-
-let polka_of_js = Ojs.t_of_js
-
-let polka_to_js = Ojs.t_to_js
+type polka = Ojs.t [@@js]
 
 module Middleware = struct
   module Request = struct

--- a/src-bindings/polka/polka.ml
+++ b/src-bindings/polka/polka.ml
@@ -13,7 +13,7 @@ module Server = struct
     [%js:
     val close : t -> t [@@js.call]
 
-    val address : t -> Address.t [@@js.call]
+    val address : t -> Address.t or_undefined [@@js.call]
 
     val on : t -> string -> Ojs.t -> unit [@@js.call]]
 

--- a/src-bindings/polka/polka.ml
+++ b/src-bindings/polka/polka.ml
@@ -7,7 +7,15 @@ end
 module Server = struct
   include Interface.Make ()
 
-  include [%js: val close : t -> t [@@js.call]]
+  include
+    [%js:
+    val close : t -> t [@@js.call]
+
+    val on : t -> string -> Ojs.t -> unit [@@js.call]]
+
+  let on t = function
+    | `Close f -> on t "close" @@ [%js.of: unit -> unit] f
+    | `Error f -> on t "error" @@ [%js.of: err:Node.JsError.t -> unit] f
 end
 
 module Sirv = struct

--- a/src-bindings/polka/polka.ml
+++ b/src-bindings/polka/polka.ml
@@ -1,0 +1,40 @@
+open Interop
+
+module Middleware = struct
+  include Interface.Make ()
+end
+
+module Server = struct
+  include Interface.Make ()
+
+  include [%js: val close : t -> t [@@js.call]]
+end
+
+module Sirv = struct
+  include
+    [%js:
+    type t = Middleware.t
+
+    val serve : string -> t [@@js.global "sirv"]]
+end
+
+include
+  [%js:
+  type t
+
+  val create : unit -> t [@@js.global "polka"]
+
+  val listen_ : t -> int -> ?callback:(unit -> unit) -> unit -> t
+    [@@js.call "listen"]
+
+  val get_ : t -> string -> (unit -> unit) -> t [@@js.call "get"]
+
+  val use_ : t -> (Middleware.t list[@js.variadic]) -> t [@@js.call "use"]
+
+  val server : t -> Server.t [@@js.get]]
+
+let get path callback t = get_ t path callback
+
+let listen port ?callback t = listen_ t port ?callback
+
+let use middlewares t = use_ t middlewares

--- a/src-bindings/polka/polka.ml
+++ b/src-bindings/polka/polka.ml
@@ -59,7 +59,15 @@ let listen port ?callback t = listen_ t port ?callback
 let use middlewares t = use_ t middlewares
 
 module Sirv = struct
+  module Options = struct
+    include Interface.Make ()
+
+    include [%js: val create : dev:bool -> t [@@js.builder]]
+  end
+
   include
     [%js:
-    val serve : string -> (Middleware.t[@js.dummy]) [@@js.global "sirv"]]
+    val serve :
+      string -> ?options:Options.t -> unit -> (Middleware.t[@js.dummy])
+      [@@js.global "sirv"]]
 end

--- a/src-bindings/polka/polka.ml
+++ b/src-bindings/polka/polka.ml
@@ -7,6 +7,8 @@ module Server = struct
     include Interface.Make ()
 
     include [%js: val port : t -> int [@@js.get]]
+
+    include [%js: val address : t -> string [@@js.get]]
   end
 
   include
@@ -44,7 +46,13 @@ include
   [%js:
   val create : unit -> polka [@@js.global "polka"]
 
-  val listen_ : polka -> int -> ?callback:(unit -> unit) -> unit -> polka
+  val listen_ :
+       polka
+    -> int
+    -> ?hostname:string
+    -> ?callback:(unit -> unit)
+    -> unit
+    -> polka
     [@@js.call "listen"]
 
   val get_ : polka -> string -> (unit -> unit) -> polka [@@js.call "get"]
@@ -56,7 +64,7 @@ include
 
 let get path callback t = get_ t path callback
 
-let listen port ?callback t = listen_ t port ?callback
+let listen port ?hostname ?callback t = listen_ t port ?hostname ?callback
 
 let use middlewares t = use_ t middlewares
 

--- a/src-bindings/polka/polka.ml
+++ b/src-bindings/polka/polka.ml
@@ -11,7 +11,9 @@ module Server = struct
 
   include
     [%js:
-    val close : t -> t [@@js.call]
+    val close :
+      t -> ?callback:(Node.JsError.t or_undefined -> unit) -> unit -> t
+      [@@js.call "close"]
 
     val address : t -> Address.t or_undefined [@@js.call]
 

--- a/src-bindings/polka/polka.ml
+++ b/src-bindings/polka/polka.ml
@@ -3,9 +3,17 @@ open Interop
 module Server = struct
   include Interface.Make ()
 
+  module Address = struct
+    include Interface.Make ()
+
+    include [%js: val port : t -> int [@@js.get]]
+  end
+
   include
     [%js:
     val close : t -> t [@@js.call]
+
+    val address : t -> Address.t [@@js.call]
 
     val on : t -> string -> Ojs.t -> unit [@@js.call]]
 

--- a/src-bindings/polka/polka.mli
+++ b/src-bindings/polka/polka.mli
@@ -5,6 +5,8 @@ module Server : sig
     include Js.T
 
     val port : t -> int
+
+    val address : t -> string
   end
 
   type t
@@ -38,7 +40,8 @@ end
 
 val create : unit -> polka
 
-val listen : int -> ?callback:(unit -> unit) -> polka -> unit -> polka
+val listen :
+  int -> ?hostname:string -> ?callback:(unit -> unit) -> polka -> unit -> polka
 
 val get : string -> (unit -> unit) -> polka -> polka
 

--- a/src-bindings/polka/polka.mli
+++ b/src-bindings/polka/polka.mli
@@ -1,9 +1,17 @@
 open Interop
 
 module Server : sig
+  module Address : sig
+    include Js.T
+
+    val port : t -> int
+  end
+
   type t
 
   val close : t -> t
+
+  val address : t -> Address.t
 
   val on :
        t

--- a/src-bindings/polka/polka.mli
+++ b/src-bindings/polka/polka.mli
@@ -9,7 +9,7 @@ module Server : sig
 
   type t
 
-  val close : t -> t
+  val close : t -> ?callback:(Node.JsError.t or_undefined -> unit) -> unit -> t
 
   val address : t -> Address.t or_undefined
   (* TODO: the return type can also be a string in case the server uses a pipe

--- a/src-bindings/polka/polka.mli
+++ b/src-bindings/polka/polka.mli
@@ -11,7 +11,9 @@ module Server : sig
 
   val close : t -> t
 
-  val address : t -> Address.t
+  val address : t -> Address.t or_undefined
+  (* TODO: the return type can also be a string in case the server uses a pipe
+     or Unix Domain Socket, but we don't handle that case *)
 
   val on :
        t

--- a/src-bindings/polka/polka.mli
+++ b/src-bindings/polka/polka.mli
@@ -47,5 +47,11 @@ val use : Middleware.t list -> polka -> polka
 val server : polka -> Server.t
 
 module Sirv : sig
-  val serve : string -> Middleware.t
+  module Options : sig
+    type t
+
+    val create : dev:bool -> t
+  end
+
+  val serve : string -> ?options:Options.t -> unit -> Middleware.t
 end

--- a/src-bindings/polka/polka.mli
+++ b/src-bindings/polka/polka.mli
@@ -14,6 +14,11 @@ module Server : sig
   type t
 
   val close : t -> t
+
+  val on :
+       t
+    -> [ `Close of unit -> unit | `Error of err:Node.JsError.t -> unit ]
+    -> unit
 end
 
 type t

--- a/src-bindings/polka/polka.mli
+++ b/src-bindings/polka/polka.mli
@@ -1,15 +1,5 @@
 open Interop
 
-module Middleware : sig
-  include Js.T
-end
-
-module Sirv : sig
-  type t = Middleware.t
-
-  val serve : string -> t
-end
-
 module Server : sig
   type t
 
@@ -21,14 +11,31 @@ module Server : sig
     -> unit
 end
 
-type t
+type polka
 
-val create : unit -> t
+module Middleware : sig
+  module Request : sig
+    include Js.T
+  end
 
-val listen : int -> ?callback:(unit -> unit) -> t -> unit -> t
+  module Response : sig
+    include Js.T
+  end
 
-val get : string -> (unit -> unit) -> t -> t
+  type t =
+    request:Request.t -> response:Response.t -> next:(unit -> polka) -> polka
+end
 
-val use : (Middleware.t list[@js.variadic]) -> t -> t
+val create : unit -> polka
 
-val server : t -> Server.t
+val listen : int -> ?callback:(unit -> unit) -> polka -> unit -> polka
+
+val get : string -> (unit -> unit) -> polka -> polka
+
+val use : Middleware.t list -> polka -> polka
+
+val server : polka -> Server.t
+
+module Sirv : sig
+  val serve : string -> Middleware.t
+end

--- a/src-bindings/polka/polka.mli
+++ b/src-bindings/polka/polka.mli
@@ -1,0 +1,29 @@
+open Interop
+
+module Middleware : sig
+  include Js.T
+end
+
+module Sirv : sig
+  type t = Middleware.t
+
+  val serve : string -> t
+end
+
+module Server : sig
+  type t
+
+  val close : t -> t
+end
+
+type t
+
+val create : unit -> t
+
+val listen : int -> ?callback:(unit -> unit) -> t -> unit -> t
+
+val get : string -> (unit -> unit) -> t -> t
+
+val use : (Middleware.t list[@js.variadic]) -> t -> t
+
+val server : t -> Server.t

--- a/src-bindings/polka/polka_stub.js
+++ b/src-bindings/polka/polka_stub.js
@@ -1,0 +1,2 @@
+joo_global_object.polka = require("polka");
+joo_global_object.sirv = require("sirv");

--- a/src-bindings/vscode/vscode.ml
+++ b/src-bindings/vscode/vscode.ml
@@ -1434,8 +1434,6 @@ module Extensions = struct
     [%js:
     val getExtension : string -> Extension.t or_undefined
       [@@js.global "vscode.extensions.getExtension"]]
-
-  let is_extension_installed name = Option.is_some (getExtension name)
 end
 
 module TerminalExitStatus = struct

--- a/src-bindings/vscode/vscode.ml
+++ b/src-bindings/vscode/vscode.ml
@@ -2331,7 +2331,6 @@ module Workspace = struct
          start:int
       -> deleteCount:int or_undefined
       -> workspaceFoldersToAdd:(workspaceFolderToAdd list[@js.variadic])
-      -> unit
       -> bool
       [@@js.global "vscode.workspace.updateWorkspaceFolders"]]
 end

--- a/src-bindings/vscode/vscode.mli
+++ b/src-bindings/vscode/vscode.mli
@@ -1809,7 +1809,6 @@ module Workspace : sig
        start:int
     -> deleteCount:int or_undefined
     -> workspaceFoldersToAdd:(workspaceFolderToAdd list[@js.variadic])
-    -> unit
     -> bool
 end
 

--- a/src-bindings/vscode/vscode.mli
+++ b/src-bindings/vscode/vscode.mli
@@ -1106,8 +1106,6 @@ end
 
 module Extensions : sig
   val getExtension : string -> Extension.t or_undefined
-
-  val is_extension_installed : string -> bool
 end
 
 module TerminalExitStatus : sig

--- a/src/documentation_server.ml
+++ b/src/documentation_server.ml
@@ -28,5 +28,13 @@ let port t =
 let on_close t ~f = Polka.Server.on t (`Close f)
 
 let stop t =
-  let (_ : Polka.Server.t) = Polka.Server.close t in
+  Promise.make @@ fun ~resolve ~reject:_ ->
+  let (_ : Polka.Server.t) =
+    Polka.Server.close t
+      ~callback:(fun error ->
+        match error with
+        | None -> resolve (Ok ())
+        | Some error -> resolve (Error error))
+      ()
+  in
   ()

--- a/src/documentation_server.ml
+++ b/src/documentation_server.ml
@@ -22,11 +22,12 @@ let start ~path ?(port = 0) () =
       (fun () ->
         ignore @@ (Polka.Server.close (Polka.server polka) : Polka.Server.t))
   in
+  let options = Polka.Sirv.Options.create ~dev:true in
   let serve =
     polka
     |> Polka.use
          [ debouncing_server_termination_mdlw
-         ; Polka.Sirv.serve (path |> Path.to_string)
+         ; Polka.Sirv.serve (path |> Path.to_string) ~options ()
          ]
     |> Polka.listen port ~callback:(fun () ->
            let server = Polka.server polka in

--- a/src/documentation_server.ml
+++ b/src/documentation_server.ml
@@ -16,6 +16,7 @@ let debouncing_middleware ~timeout_in_ms f =
 let start ~path ?(port = 0) () =
   Promise.make @@ fun ~resolve ~reject:_ ->
   let polka = Polka.create () in
+  (* Closes the server after some idle time *)
   let debouncing_server_termination_mdlw =
     debouncing_middleware
       ~timeout_in_ms:(60 * 10 * 1000)

--- a/src/documentation_server.ml
+++ b/src/documentation_server.ml
@@ -28,14 +28,16 @@ let port t =
 (* TODO extract this from the server somehow *)
 let host _ = "localhost"
 
-let stop t =
-  Promise.make @@ fun ~resolve ~reject:_ ->
-  let (_ : Polka.Server.t) =
-    Polka.Server.close t
-      ~callback:(fun error ->
-        match error with
-        | None -> resolve (Ok ())
-        | Some error -> resolve (Error error))
-      ()
-  in
-  ()
+let dispose t =
+  Disposable.make ~dispose:(fun () ->
+      let (_ : Polka.Server.t) =
+        Polka.Server.close t
+          ~callback:(fun error ->
+            match error with
+            | None -> ()
+            | Some error ->
+              show_message `Warn "Error closing server: %s"
+                (Ojs.string_of_js (Promise.error_to_js error)))
+          ()
+      in
+      ())

--- a/src/documentation_server.ml
+++ b/src/documentation_server.ml
@@ -1,6 +1,6 @@
 open Import
 
-type t = Polka.Server.t
+type t = Polka.Server.t option ref
 
 let start ~path =
   Promise.make @@ fun ~resolve ~reject:_ ->
@@ -11,14 +11,19 @@ let start ~path =
     |> Polka.use [ Polka.Sirv.serve (path |> Path.to_string) ~options () ]
     |> Polka.listen 0 ~callback:(fun () ->
            let server = Polka.server polka in
-           resolve (Ok server))
+           resolve (Ok (ref (Some server))))
   in
   let polka = serve () in
   let server = Polka.server polka in
   Polka.Server.on server (`Error (fun ~err -> resolve (Error err)))
 
+let get t =
+  match !t with
+  | None -> failwith "document server: already disposed"
+  | Some t -> t
+
 let port t =
-  match Polka.Server.address t with
+  match Polka.Server.address (get t) with
   | None ->
     (* if it's [None], server must not be listening, but we aim to have server
        only if it's listening *)
@@ -26,18 +31,24 @@ let port t =
   | Some a -> Polka.Server.Address.port a
 
 (* TODO extract this from the server somehow *)
-let host _ = "localhost"
+let host t =
+  ignore (get t : Polka.Server.t);
+  "localhost"
 
 let dispose t =
-  Disposable.make ~dispose:(fun () ->
-      let (_ : Polka.Server.t) =
-        Polka.Server.close t
-          ~callback:(fun error ->
-            match error with
-            | None -> ()
-            | Some error ->
-              show_message `Warn "Error closing server: %s"
-                (Ojs.string_of_js (Promise.error_to_js error)))
-          ()
-      in
-      ())
+  match !t with
+  | None -> Disposable.make ~dispose:(fun () -> ())
+  | Some server ->
+    t := None;
+    Disposable.make ~dispose:(fun () ->
+        let (_ : Polka.Server.t) =
+          Polka.Server.close server
+            ~callback:(fun error ->
+              match error with
+              | None -> ()
+              | Some error ->
+                show_message `Warn "Error closing server: %s"
+                  (Ojs.string_of_js (Promise.error_to_js error)))
+            ()
+        in
+        ())

--- a/src/documentation_server.ml
+++ b/src/documentation_server.ml
@@ -1,0 +1,28 @@
+open Import
+
+type t =
+  { server : Polka.Server.t
+  ; port : int
+  }
+
+let start ~port ~path =
+  Promise.make @@ fun ~resolve ~reject:_ ->
+  let polka = Polka.create () in
+  let serve =
+    polka
+    |> Polka.use [ Polka.Sirv.serve (path |> Path.to_string) ]
+    |> Polka.listen port ~callback:(fun () ->
+           resolve (Ok { server = Polka.server polka; port }))
+  in
+  let polka = serve () in
+  let server = Polka.server polka in
+  let () = Polka.Server.on server (`Error (fun ~err -> resolve (Error err))) in
+  ()
+
+let port t = t.port
+
+let on_close t ~f = Polka.Server.on t.server (`Close f)
+
+let stop t =
+  let (_ : Polka.Server.t) = Polka.Server.close t.server in
+  ()

--- a/src/documentation_server.ml
+++ b/src/documentation_server.ml
@@ -25,6 +25,9 @@ let port t =
     assert false
   | Some a -> Polka.Server.Address.port a
 
+(* TODO extract this from the server somehow *)
+let host _ = "localhost"
+
 let stop t =
   Promise.make @@ fun ~resolve ~reject:_ ->
   let (_ : Polka.Server.t) =

--- a/src/documentation_server.ml
+++ b/src/documentation_server.ml
@@ -25,8 +25,6 @@ let port t =
     assert false
   | Some a -> Polka.Server.Address.port a
 
-let on_close t ~f = Polka.Server.on t (`Close f)
-
 let stop t =
   Promise.make @@ fun ~resolve ~reject:_ ->
   let (_ : Polka.Server.t) =

--- a/src/documentation_server.ml
+++ b/src/documentation_server.ml
@@ -2,14 +2,14 @@ open Import
 
 type t = Polka.Server.t
 
-let start ~path ?(port = 0) () =
+let start ~path =
   Promise.make @@ fun ~resolve ~reject:_ ->
   let polka = Polka.create () in
   let options = Polka.Sirv.Options.create ~dev:true in
   let serve =
     polka
     |> Polka.use [ Polka.Sirv.serve (path |> Path.to_string) ~options () ]
-    |> Polka.listen port ~callback:(fun () ->
+    |> Polka.listen 0 ~callback:(fun () ->
            let server = Polka.server polka in
            resolve (Ok server))
   in

--- a/src/documentation_server.ml
+++ b/src/documentation_server.ml
@@ -14,7 +14,7 @@ let start ~path =
   let serve =
     polka
     |> Polka.use [ Polka.Sirv.serve (path |> Path.to_string) ~options () ]
-    |> Polka.listen 0 ~callback:(fun () ->
+    |> Polka.listen 0 ~hostname:"localhost" ~callback:(fun () ->
            let server = Polka.server polka in
            resolve (Ok (ref (Some { server; path }))))
   in
@@ -29,18 +29,17 @@ let get (t : t) =
 
 let path (t : t) = (get t).path
 
-let port t =
+let address t =
   match Polka.Server.address (get t).server with
   | None ->
     (* if it's [None], server must not be listening, but we aim to have server
        only if it's listening *)
     assert false
-  | Some a -> Polka.Server.Address.port a
+  | Some a -> a
 
-(* TODO extract this from the server somehow *)
-let host t =
-  ignore (get t : t');
-  "localhost"
+let port t = Polka.Server.Address.port (address t)
+
+let host t = Polka.Server.Address.address (address t)
 
 let dispose (t : t) =
   match !t with

--- a/src/documentation_server.ml
+++ b/src/documentation_server.ml
@@ -2,34 +2,13 @@ open Import
 
 type t = Polka.Server.t
 
-(** [debouncing_middleware ~timeout_in_ms f] on every request schedules [f] to
-    be run in [timeout_in_ms] milliseconds; on every new request the last
-    scheduled timeout is overridden *)
-let debouncing_middleware ~timeout_in_ms f =
-  let timeout = ref None in
-  Staged.stage (fun ~request:_ ~response:_ ~next ->
-      (* on every request, we clear previous timeout and set a new one *)
-      Option.iter !timeout ~f:Node.clearTimeout;
-      timeout := Some (Node.setTimeout f timeout_in_ms);
-      next ())
-
 let start ~path ?(port = 0) () =
   Promise.make @@ fun ~resolve ~reject:_ ->
   let polka = Polka.create () in
-  (* Closes the server after some idle time *)
-  let debouncing_server_termination_mdlw =
-    debouncing_middleware
-      ~timeout_in_ms:(60 * 10 * 1000)
-      (fun () ->
-        ignore @@ (Polka.Server.close (Polka.server polka) : Polka.Server.t))
-  in
   let options = Polka.Sirv.Options.create ~dev:true in
   let serve =
     polka
-    |> Polka.use
-         [ Staged.unstage debouncing_server_termination_mdlw
-         ; Polka.Sirv.serve (path |> Path.to_string) ~options ()
-         ]
+    |> Polka.use [ Polka.Sirv.serve (path |> Path.to_string) ~options () ]
     |> Polka.listen port ~callback:(fun () ->
            let server = Polka.server polka in
            resolve (Ok server))

--- a/src/documentation_server.ml
+++ b/src/documentation_server.ml
@@ -5,7 +5,7 @@ type t =
   ; port : int
   }
 
-let start ~port ~path =
+let start ~path ?(port = 0) () =
   Promise.make @@ fun ~resolve ~reject:_ ->
   let polka = Polka.create () in
 
@@ -33,7 +33,10 @@ let start ~port ~path =
     |> Polka.use
          [ timeout_middleware; Polka.Sirv.serve (path |> Path.to_string) ]
     |> Polka.listen port ~callback:(fun () ->
-           resolve (Ok { server = Polka.server polka; port }))
+           let server = Polka.server polka in
+           let address = Polka.Server.address server in
+           let port = Polka.Server.Address.port address in
+           resolve (Ok { server; port }))
   in
   let polka = serve () in
   let server = Polka.server polka in

--- a/src/documentation_server.mli
+++ b/src/documentation_server.mli
@@ -1,6 +1,6 @@
 type t
 
-val start : port:int -> path:Path.t -> (t, Promise.error) result Promise.t
+val start : port:int -> path:Path.t -> (t, Node.JsError.t) result Promise.t
 
 val port : t -> int
 

--- a/src/documentation_server.mli
+++ b/src/documentation_server.mli
@@ -1,7 +1,6 @@
 type t
 
-val start :
-  path:Path.t -> ?port:int -> unit -> (t, Node.JsError.t) result Promise.t
+val start : path:Path.t -> (t, Node.JsError.t) result Promise.t
 
 val port : t -> int
 

--- a/src/documentation_server.mli
+++ b/src/documentation_server.mli
@@ -6,4 +6,4 @@ val port : t -> int
 
 val host : t -> string
 
-val stop : t -> (unit, Promise.error) result Promise.t
+val dispose : t -> Vscode.Disposable.t

--- a/src/documentation_server.mli
+++ b/src/documentation_server.mli
@@ -5,5 +5,3 @@ val start : path:Path.t -> (t, Node.JsError.t) result Promise.t
 val port : t -> int
 
 val stop : t -> (unit, Promise.error) result Promise.t
-
-val on_close : t -> f:(unit -> unit) -> unit

--- a/src/documentation_server.mli
+++ b/src/documentation_server.mli
@@ -1,6 +1,7 @@
 type t
 
-val start : port:int -> path:Path.t -> (t, Node.JsError.t) result Promise.t
+val start :
+  path:Path.t -> ?port:int -> unit -> (t, Node.JsError.t) result Promise.t
 
 val port : t -> int
 

--- a/src/documentation_server.mli
+++ b/src/documentation_server.mli
@@ -5,6 +5,6 @@ val start :
 
 val port : t -> int
 
-val stop : t -> unit
+val stop : t -> (unit, Promise.error) result Promise.t
 
 val on_close : t -> f:(unit -> unit) -> unit

--- a/src/documentation_server.mli
+++ b/src/documentation_server.mli
@@ -2,6 +2,8 @@ type t
 
 val start : path:Path.t -> (t, Node.JsError.t) result Promise.t
 
+val path : t -> Path.t
+
 val port : t -> int
 
 val host : t -> string

--- a/src/documentation_server.mli
+++ b/src/documentation_server.mli
@@ -1,0 +1,9 @@
+type t
+
+val start : port:int -> path:Path.t -> (t, Promise.error) result Promise.t
+
+val port : t -> int
+
+val stop : t -> unit
+
+val on_close : t -> f:(unit -> unit) -> unit

--- a/src/documentation_server.mli
+++ b/src/documentation_server.mli
@@ -4,4 +4,6 @@ val start : path:Path.t -> (t, Node.JsError.t) result Promise.t
 
 val port : t -> int
 
+val host : t -> string
+
 val stop : t -> (unit, Promise.error) result Promise.t

--- a/src/dune
+++ b/src/dune
@@ -3,7 +3,7 @@
  (preprocess
   (pps gen_js_api.ppx))
  (libraries base gen_js_api js_of_ocaml jsonoo node ocaml-version
-   opam-file-format promise_jsoo vscode vscode_languageclient ppxlib
+   opam-file-format polka promise_jsoo vscode vscode_languageclient ppxlib
    ppx_tools)
  (modes js)
  (js_of_ocaml

--- a/src/extension_commands.ml
+++ b/src/extension_commands.ml
@@ -83,7 +83,10 @@ let _open_terminal =
 
 let _stop_documentation_server =
   let handler instance ~args:_ =
-    Extension_instance.stop_documentation_server instance
+    let (_ : unit Promise.t) =
+      Extension_instance.stop_documentation_server instance
+    in
+    ()
   in
   command Extension_consts.Commands.stop_documentation_server handler
 

--- a/src/extension_commands.ml
+++ b/src/extension_commands.ml
@@ -83,10 +83,7 @@ let _open_terminal =
 
 let _stop_documentation_server =
   let handler instance ~args:_ =
-    let (_ : unit Promise.t) =
-      Extension_instance.stop_documentation_server instance
-    in
-    ()
+    Extension_instance.stop_documentation_server instance
   in
   command Extension_consts.Commands.stop_documentation_server handler
 

--- a/src/extension_commands.ml
+++ b/src/extension_commands.ml
@@ -81,6 +81,12 @@ let _open_terminal =
   in
   command Extension_consts.Commands.open_terminal handler
 
+let _stop_documentation_server =
+  let handler instance ~args:_ =
+    Extension_instance.stop_documentation_server instance
+  in
+  command Extension_consts.Commands.stop_documentation_server handler
+
 let _switch_impl_intf =
   let handler (instance : Extension_instance.t) ~args:_ =
     let try_switching () =

--- a/src/extension_consts.ml
+++ b/src/extension_consts.ml
@@ -27,6 +27,8 @@ module Commands = struct
 
   let open_sandbox_documentation = ocaml_prefixed "open-sandbox-documentation"
 
+  let stop_documentation_server = ocaml_prefixed "stop-documentation-server"
+
   let generate_sandbox_documentation =
     ocaml_prefixed "generate-sandbox-documentation"
 

--- a/src/extension_instance.ml
+++ b/src/extension_instance.ml
@@ -243,7 +243,9 @@ let start_documentation_server t ~path =
     Ok server
   | Error e ->
     t.documentation_server <- None;
-    Error e
+    log "Error while starting the documentation server: %s"
+      (Node.JsError.message e);
+    Error ()
 
 let repl t = t.repl
 

--- a/src/extension_instance.ml
+++ b/src/extension_instance.ml
@@ -188,6 +188,10 @@ let make () =
 let set_sandbox t new_sandbox =
   Sandbox_info.update t.sandbox_info ~new_sandbox;
   t.sandbox <- new_sandbox;
+  (* Makes sure that a new instance of the documentation server is created next
+     time we show documentation for a package. It avoids reusing an existing
+     server instance that serves the old sandbox packages folder.*)
+  stop_documentation_server t;
   let (_ : Ojs.t option Promise.t) =
     Vscode.Commands.executeCommand
       ~command:Extension_consts.Commands.refresh_sandbox ~args:[]

--- a/src/extension_instance.ml
+++ b/src/extension_instance.ml
@@ -7,7 +7,7 @@ type t =
         (** assumption: it must be set before initializing the language server;
             the lang server initialization needs the ocaml version *)
   ; mutable lsp_client : (LanguageClient.t * Ocaml_lsp.t) option
-  ; mutable documentation_server : Polka.t option
+  ; mutable documentation_server : Documentation_server.t option
   ; sandbox_info : StatusBarItem.t
   ; ast_editor_state : Ast_editor_state.t
   }
@@ -30,14 +30,46 @@ let stop_server t =
       LanguageClient.stop client)
 
 let stop_documentation_server t =
-  Option.iter t.documentation_server ~f:(fun polka ->
+  Option.iter t.documentation_server ~f:(fun server ->
       t.documentation_server <- None;
-      let server = Polka.server polka in
-      let (_ : Polka.Server.t) = Polka.Server.close server in
-      ())
+      Documentation_server.stop server)
 
-let set_documentation_server t documentation_server =
-  t.documentation_server <- Some documentation_server
+let start_documentation_server t ~path =
+  stop_documentation_server t;
+  let find_free_port ~start_port =
+    Promise.make @@ fun ~resolve ~reject:_ ->
+    let open Node.Net in
+    let port = ref start_port in
+    let socket = Socket.make () in
+    let (_ : Socket.t) = Socket.setTimeout socket 500 in
+    Socket.on socket
+      (`Connect
+        (fun () ->
+          Socket.destroy socket;
+          port := port.contents + 1;
+          let (_ : Socket.t) =
+            Socket.connect socket ~port:port.contents ~host:"localhost"
+          in
+          ()));
+    Socket.on socket (`Error (fun ~err:_ -> resolve port.contents));
+    Socket.on socket (`Timeout (fun () -> resolve port.contents));
+    let (_ : Socket.t) =
+      Socket.connect socket ~port:port.contents ~host:"localhost"
+    in
+    ()
+  in
+  let open Promise.Syntax in
+  let* port = find_free_port ~start_port:3000 in
+  let+ server = Documentation_server.start ~port ~path in
+  match server with
+  | Ok server ->
+    t.documentation_server <- Some server;
+    Documentation_server.on_close server ~f:(fun () ->
+        t.documentation_server <- None);
+    Ok server
+  | Error e ->
+    t.documentation_server <- None;
+    Error e
 
 module Language_server_init : sig
   val start_language_server : t -> unit Promise.t

--- a/src/extension_instance.ml
+++ b/src/extension_instance.ml
@@ -133,7 +133,7 @@ include Language_server_init
 module Documentation_server_info : sig
   val make : unit -> StatusBarItem.t
 
-  val update : StatusBarItem.t -> port:int -> unit
+  val update : StatusBarItem.t -> unit
 end = struct
   let make () =
     let status_bar =
@@ -149,9 +149,8 @@ end = struct
     StatusBarItem.set_command status_bar (`Command command);
     status_bar
 
-  let update status_bar ~port =
-    StatusBarItem.set_text status_bar
-      (Printf.sprintf "$(radio-tower) Port: %i" port);
+  let update status_bar =
+    StatusBarItem.set_text status_bar "$(radio-tower) OCaml Documentation";
     StatusBarItem.show status_bar
 end
 
@@ -203,8 +202,7 @@ let set_documentation_server t ~status =
   match status with
   | `Running server ->
     t.documentation_server <- Some server;
-    let port = Documentation_server.port server in
-    Documentation_server_info.update t.documentation_server_info ~port;
+    Documentation_server_info.update t.documentation_server_info;
     let (_ : Ojs.t option Promise.t) = set_context ~running:true in
     ()
   | `Stopped ->

--- a/src/extension_instance.ml
+++ b/src/extension_instance.ml
@@ -194,10 +194,16 @@ let make () =
   ; documentation_server = None
   }
 
+let document_server_on = "ocaml.documentation-server-on"
+
 let stop_documentation_server t =
   Option.iter t.documentation_server ~f:(fun server ->
       t.documentation_server <- None;
       Documentation_server.stop server);
+  let (_ : Ojs.t option Promise.t) =
+    Vscode.Commands.executeCommand ~command:"setContext"
+      ~args:[ Ojs.string_to_js document_server_on; Ojs.bool_to_js false ]
+  in
   StatusBarItem.hide t.documentation_server_info
 
 let set_sandbox t new_sandbox =
@@ -225,6 +231,10 @@ let start_documentation_server t ~path =
     t.documentation_server <- Some server;
     let port = Documentation_server.port server in
     Documentation_server_info.update t.documentation_server_info ~port;
+    let (_ : Ojs.t option Promise.t) =
+      Vscode.Commands.executeCommand ~command:"setContext"
+        ~args:[ Ojs.string_to_js document_server_on; Ojs.bool_to_js true ]
+    in
     Documentation_server.on_close server ~f:(fun () ->
         stop_documentation_server t);
     Ok server

--- a/src/extension_instance.ml
+++ b/src/extension_instance.ml
@@ -202,9 +202,6 @@ let stop_documentation_server t =
 let set_sandbox t new_sandbox =
   Sandbox_info.update t.sandbox_info ~new_sandbox;
   t.sandbox <- new_sandbox;
-  (* Makes sure that a new instance of the documentation server is created next
-     time we show documentation for a package. It avoids reusing an existing
-     server instance that serves the old sandbox packages folder.*)
   stop_documentation_server t;
   let (_ : Ojs.t option Promise.t) =
     Vscode.Commands.executeCommand

--- a/src/extension_instance.ml
+++ b/src/extension_instance.ml
@@ -230,7 +230,7 @@ let start_documentation_server t ~path =
   let open Promise.Syntax in
   let* () = stop_documentation_server t in
   let open Promise.Syntax in
-  let+ server = Documentation_server.start ~path () in
+  let+ server = Documentation_server.start ~path in
   match server with
   | Ok server ->
     t.documentation_server <- Some server;

--- a/src/extension_instance.ml
+++ b/src/extension_instance.ml
@@ -198,13 +198,7 @@ let document_server_on = "ocaml.documentation-server-on"
 
 let stop_documentation_server t =
   Option.iter t.documentation_server ~f:(fun server ->
-      t.documentation_server <- None;
-      Documentation_server.stop server);
-  let (_ : Ojs.t option Promise.t) =
-    Vscode.Commands.executeCommand ~command:"setContext"
-      ~args:[ Ojs.string_to_js document_server_on; Ojs.bool_to_js false ]
-  in
-  StatusBarItem.hide t.documentation_server_info
+      Documentation_server.stop server)
 
 let set_sandbox t new_sandbox =
   Sandbox_info.update t.sandbox_info ~new_sandbox;
@@ -236,7 +230,12 @@ let start_documentation_server t ~path =
         ~args:[ Ojs.string_to_js document_server_on; Ojs.bool_to_js true ]
     in
     Documentation_server.on_close server ~f:(fun () ->
-        stop_documentation_server t);
+        t.documentation_server <- None;
+        let (_ : Ojs.t option Promise.t) =
+          Vscode.Commands.executeCommand ~command:"setContext"
+            ~args:[ Ojs.string_to_js document_server_on; Ojs.bool_to_js false ]
+        in
+        StatusBarItem.hide t.documentation_server_info);
     Ok server
   | Error e ->
     t.documentation_server <- None;

--- a/src/extension_instance.ml
+++ b/src/extension_instance.ml
@@ -311,6 +311,7 @@ let ast_editor_state t = t.ast_editor_state
 let disposable t =
   Disposable.make ~dispose:(fun () ->
       StatusBarItem.dispose t.sandbox_info;
+      StatusBarItem.dispose t.documentation_server_info;
       stop_server t;
       let (_ : unit Promise.t) = stop_documentation_server t in
       ())

--- a/src/extension_instance.ml
+++ b/src/extension_instance.ml
@@ -314,4 +314,3 @@ let disposable t =
       StatusBarItem.dispose t.documentation_server_info;
       stop_server t;
       stop_documentation_server t)
-

--- a/src/extension_instance.mli
+++ b/src/extension_instance.mli
@@ -12,9 +12,10 @@ val language_client : t -> LanguageClient.t option
 
 val ocaml_lsp : t -> Ocaml_lsp.t option
 
-val documentation_server : t -> Polka.t option
+val documentation_server : t -> Documentation_server.t option
 
-val set_documentation_server : t -> Polka.t -> unit
+val start_documentation_server :
+  t -> path:Path.t -> (Documentation_server.t, Promise.error) result Promise.t
 
 val lsp_client : t -> (LanguageClient.t * Ocaml_lsp.t) option
 

--- a/src/extension_instance.mli
+++ b/src/extension_instance.mli
@@ -12,6 +12,10 @@ val language_client : t -> LanguageClient.t option
 
 val ocaml_lsp : t -> Ocaml_lsp.t option
 
+val documentation_server : t -> Polka.t option
+
+val set_documentation_server : t -> Polka.t -> unit
+
 val lsp_client : t -> (LanguageClient.t * Ocaml_lsp.t) option
 
 val ocaml_version_exn : t -> Ocaml_version.t

--- a/src/extension_instance.mli
+++ b/src/extension_instance.mli
@@ -15,7 +15,7 @@ val ocaml_lsp : t -> Ocaml_lsp.t option
 val documentation_server : t -> Documentation_server.t option
 
 val start_documentation_server :
-  t -> path:Path.t -> (Documentation_server.t, Promise.error) result Promise.t
+  t -> path:Path.t -> (Documentation_server.t, unit) result Promise.t
 
 val stop_documentation_server : t -> unit
 

--- a/src/extension_instance.mli
+++ b/src/extension_instance.mli
@@ -17,6 +17,8 @@ val documentation_server : t -> Documentation_server.t option
 val start_documentation_server :
   t -> path:Path.t -> (Documentation_server.t, Promise.error) result Promise.t
 
+val stop_documentation_server : t -> unit
+
 val lsp_client : t -> (LanguageClient.t * Ocaml_lsp.t) option
 
 val ocaml_version_exn : t -> Ocaml_version.t

--- a/src/extension_instance.mli
+++ b/src/extension_instance.mli
@@ -12,8 +12,6 @@ val language_client : t -> LanguageClient.t option
 
 val ocaml_lsp : t -> Ocaml_lsp.t option
 
-val documentation_server : t -> Documentation_server.t option
-
 val start_documentation_server :
   t -> path:Path.t -> (Documentation_server.t, unit) result Promise.t
 

--- a/src/extension_instance.mli
+++ b/src/extension_instance.mli
@@ -17,7 +17,7 @@ val documentation_server : t -> Documentation_server.t option
 val start_documentation_server :
   t -> path:Path.t -> (Documentation_server.t, Promise.error) result Promise.t
 
-val stop_documentation_server : t -> unit Promise.t
+val stop_documentation_server : t -> unit
 
 val lsp_client : t -> (LanguageClient.t * Ocaml_lsp.t) option
 

--- a/src/extension_instance.mli
+++ b/src/extension_instance.mli
@@ -17,7 +17,7 @@ val documentation_server : t -> Documentation_server.t option
 val start_documentation_server :
   t -> path:Path.t -> (Documentation_server.t, Promise.error) result Promise.t
 
-val stop_documentation_server : t -> unit
+val stop_documentation_server : t -> unit Promise.t
 
 val lsp_client : t -> (LanguageClient.t * Ocaml_lsp.t) option
 

--- a/src/odig.ml
+++ b/src/odig.ml
@@ -38,7 +38,7 @@ let odoc_exec t ~package_name =
     | Error _ as e -> Promise.resolve e
     | Ok _ as ok ->
       let html_dir = html_dir t in
-      let package_html_dir = Path.to_string html_dir ^ package_name in
+      let package_html_dir = Path.(html_dir / package_name) |> Path.to_string in
       let open Promise.Syntax in
       let+ dir_exists = Fs.exists package_html_dir in
       if dir_exists then ok

--- a/src/odig.ml
+++ b/src/odig.ml
@@ -6,7 +6,7 @@ type of_opam_error = Odig_not_installed
 
 let of_opam (opam, switch) =
   let open Promise.Syntax in
-  let+ is_installed = Opam.has_package opam switch "odig" in
+  let+ is_installed = Opam.has_package opam switch ~package_name:"odig" in
   if is_installed then
     Ok (opam, switch)
   else
@@ -32,14 +32,14 @@ let html_dir t =
   let+ cache_dir = cache_dir t in
   Path.(cache_dir / "/html/")
 
-let odoc_exec t name =
+let odoc_exec t ~package_name =
   let open Promise.Syntax in
-  let* ouput = cmd_ouput t [ "odig"; "odoc"; name ] in
+  let* ouput = cmd_ouput t [ "odig"; "odoc"; package_name ] in
   let+ result =
     match ouput with
     | Ok _ as ok ->
       let* html_dir = html_dir t in
-      let package_html_dir = Path.to_string html_dir ^ name in
+      let package_html_dir = Path.to_string html_dir ^ package_name in
       let+ dir_exists = Fs.exists package_html_dir in
       if dir_exists then
         ok
@@ -53,7 +53,7 @@ let odoc_exec t name =
   result
   |> Result.map_error ~f:(fun error ->
          let () =
-           log "Failed to generate documentation for package %s. Error: %s" name
-             error
+           log "Failed to generate documentation for package %s. Error: %s"
+             package_name error
          in
          error)

--- a/src/odig.ml
+++ b/src/odig.ml
@@ -8,17 +8,17 @@ type t =
 (** TODO: propose to install odig. See
     https://github.com/ocamllabs/vscode-ocaml-platform/pull/771#discussion_r765297112 *)
 let of_sandbox (sandbox : Sandbox.t) =
-  let cmd = Sandbox.get_command sandbox "which" [ "odig" ] in
+  let make_odig_cmd = Sandbox.get_command sandbox "odig" in
+  let odig_version = make_odig_cmd [ "--version" ] in
   let open Promise.Syntax in
-  let* output = Cmd.output cmd in
+  let* output = Cmd.output odig_version in
   match output with
   | Ok _ -> (
-    let make_cmd = Sandbox.get_command sandbox "odig" in
-    let+ cache_dir = Cmd.output (make_cmd [ "cache"; "path" ]) in
+    let+ cache_dir = Cmd.output (make_odig_cmd [ "cache"; "path" ]) in
     match cache_dir with
     | Ok cache_dir ->
       let cache_dir = cache_dir |> String.strip |> Path.of_string in
-      Ok { make_cmd; cache_dir }
+      Ok { make_cmd = make_odig_cmd; cache_dir }
     | Error _ -> Error "OCaml: Failed to retrieve odig cache_dir")
   | Error _ ->
     Promise.resolve

--- a/src/odig.ml
+++ b/src/odig.ml
@@ -1,47 +1,42 @@
 open Import
 
-type t = Opam.t * Opam.Switch.t
+type t = { make_cmd : string list -> Cmd.t }
 
-let of_opam (opam, switch) =
+let of_sandbox (sandbox : Sandbox.t) =
+  let cmd = Sandbox.get_command sandbox "which" [ "odig" ] in
   let open Promise.Syntax in
-  let+ is_installed = Opam.has_package opam switch ~package_name:"odig" in
-  if is_installed then
-    Ok (opam, switch)
-  else
+  let+ output = Cmd.output cmd in
+  match output with
+  | Ok _ -> Ok { make_cmd = Sandbox.get_command sandbox "odig" }
+  | Error _ ->
     Error
-      "\"OCaml: the package \"odig\" must be installed to generate \
-       documentation."
+      "\"OCaml: the \"odig\" binary must be available in the current sandbox \
+       to generate documentation."
 
-let cmd_ouput (opam, switch) args =
-  let cmd = Opam.exec opam switch ~args in
-  Cmd.output cmd
+let cmd_output { make_cmd } ~args = Cmd.output (make_cmd args)
 
 let cache_dir t =
-  let opam, switch = t in
-  let default_cache_dir =
-    Path.(Opam.Switch.path opam switch / "/var/cache/odig/")
-  in
   let open Promise.Syntax in
-  let+ cache_dir = cmd_ouput t [ "odig"; "cache"; "path" ] in
+  let+ cache_dir = cmd_output t ~args:[ "cache"; "path" ] in
   match cache_dir with
-  | Ok cache_dir -> cache_dir |> String.strip |> Path.of_string
-  | Error e ->
-    let () = log "Failed to retrieve odig cache_dir: %s" e in
-    default_cache_dir
+  | Ok cache_dir -> Ok (cache_dir |> String.strip |> Path.of_string)
+  | Error _ -> Error "OCaml: Failed to retrieve odig cache_dir"
 
 let html_dir t =
-  let open Promise.Syntax in
+  let open Promise.Result.Syntax in
   let+ cache_dir = cache_dir t in
   Path.(cache_dir / "/html/")
 
 let odoc_exec t ~package_name =
   let open Promise.Syntax in
-  let* ouput = cmd_ouput t [ "odig"; "odoc"; package_name ] in
+  let* ouput = cmd_output t ~args:[ "odoc"; package_name ] in
   let+ result =
     match ouput with
     | Ok _ as ok ->
+      let open Promise.Result.Syntax in
       let* html_dir = html_dir t in
       let package_html_dir = Path.to_string html_dir ^ package_name in
+      let open Promise.Syntax in
       let+ dir_exists = Fs.exists package_html_dir in
       if dir_exists then
         ok

--- a/src/odig.ml
+++ b/src/odig.ml
@@ -1,9 +1,6 @@
 open Import
 
-type t =
-  { sandbox : Sandbox.t
-  ; cache_dir : Path.t
-  }
+type t = { cache_dir : Path.t }
 
 let make_odig_cmd sandbox = Sandbox.get_command sandbox "odig"
 
@@ -20,7 +17,7 @@ let of_sandbox (sandbox : Sandbox.t) =
     match cache_dir with
     | Ok cache_dir ->
       let cache_dir = cache_dir |> String.strip |> Path.of_string in
-      Ok { sandbox; cache_dir }
+      Ok { cache_dir }
     | Error _ -> Error "OCaml: Failed to retrieve odig cache_dir")
   | Error _ ->
     Promise.resolve
@@ -28,13 +25,13 @@ let of_sandbox (sandbox : Sandbox.t) =
          "OCaml: the \"odig\" binary must be available in the current sandbox \
           to generate documentation.")
 
-let cmd_output { sandbox; _ } ~args = Cmd.output (make_odig_cmd sandbox args)
+let cmd_output ~sandbox ~args = Cmd.output (make_odig_cmd sandbox args)
 
 let html_dir t = Path.(t.cache_dir / "/html/")
 
-let odoc_exec t ~package_name =
+let odoc_exec t ~sandbox ~package_name =
   let open Promise.Syntax in
-  let* ouput = cmd_output t ~args:[ "odoc"; package_name ] in
+  let* ouput = cmd_output ~sandbox ~args:[ "odoc"; package_name ] in
   let+ result =
     match ouput with
     | Error _ as e -> Promise.resolve e

--- a/src/odig.ml
+++ b/src/odig.ml
@@ -38,12 +38,12 @@ let odoc_exec t ~package_name =
   let+ result =
     match ouput with
     | Error _ as e -> Promise.resolve e
-    | Ok _ as ok ->
+    | Ok _ ->
       let html_dir = html_dir t in
       let package_html_dir = Path.(html_dir / package_name) |> Path.to_string in
       let open Promise.Syntax in
       let+ dir_exists = Fs.exists package_html_dir in
-      if dir_exists then ok
+      if dir_exists then Ok ()
       else
         Error
           (Printf.sprintf

--- a/src/odig.ml
+++ b/src/odig.ml
@@ -23,13 +23,13 @@ let conf t key =
   | Error _ -> None
   | Ok conf ->
     let lines = String.split_lines conf in
+    let is_whitespace_or_single_quote c =
+      Char.equal c '\'' || Char.is_whitespace c
+    in
     List.map lines ~f:(String.rsplit2 ~on:':')
     |> List.filter_opt
     |> List.find_map ~f:(fun (k, v) ->
            if String.equal k key then
-             let is_whitespace_or_single_quote c =
-               Char.equal c '\'' || Char.is_whitespace c
-             in
              Some
                (String.strip v ~drop:is_whitespace_or_single_quote
                |> Path.of_string)

--- a/src/odig.ml
+++ b/src/odig.ml
@@ -2,6 +2,8 @@ open Import
 
 type t = { make_cmd : string list -> Cmd.t }
 
+(** TODO: propose to install odig. See
+    https://github.com/ocamllabs/vscode-ocaml-platform/pull/771#discussion_r765297112 *)
 let of_sandbox (sandbox : Sandbox.t) =
   let cmd = Sandbox.get_command sandbox "which" [ "odig" ] in
   let open Promise.Syntax in

--- a/src/odig.ml
+++ b/src/odig.ml
@@ -1,33 +1,34 @@
 open Import
 
-type t = { make_cmd : string list -> Cmd.t }
+type t =
+  { make_cmd : string list -> Cmd.t
+  ; cache_dir : Path.t
+  }
 
 (** TODO: propose to install odig. See
     https://github.com/ocamllabs/vscode-ocaml-platform/pull/771#discussion_r765297112 *)
 let of_sandbox (sandbox : Sandbox.t) =
   let cmd = Sandbox.get_command sandbox "which" [ "odig" ] in
   let open Promise.Syntax in
-  let+ output = Cmd.output cmd in
+  let* output = Cmd.output cmd in
   match output with
-  | Ok _ -> Ok { make_cmd = Sandbox.get_command sandbox "odig" }
+  | Ok _ -> (
+    let make_cmd = Sandbox.get_command sandbox "odig" in
+    let+ cache_dir = Cmd.output (make_cmd [ "cache"; "path" ]) in
+    match cache_dir with
+    | Ok cache_dir ->
+      let cache_dir = cache_dir |> String.strip |> Path.of_string in
+      Ok { make_cmd; cache_dir }
+    | Error _ -> Error "OCaml: Failed to retrieve odig cache_dir")
   | Error _ ->
-    Error
-      "\"OCaml: the \"odig\" binary must be available in the current sandbox \
-       to generate documentation."
+    Promise.resolve
+      (Error
+         "\"OCaml: the \"odig\" binary must be available in the current \
+          sandbox to generate documentation.")
 
-let cmd_output { make_cmd } ~args = Cmd.output (make_cmd args)
+let cmd_output { make_cmd; _ } ~args = Cmd.output (make_cmd args)
 
-let cache_dir t =
-  let open Promise.Syntax in
-  let+ cache_dir = cmd_output t ~args:[ "cache"; "path" ] in
-  match cache_dir with
-  | Ok cache_dir -> Ok (cache_dir |> String.strip |> Path.of_string)
-  | Error _ -> Error "OCaml: Failed to retrieve odig cache_dir"
-
-let html_dir t =
-  let open Promise.Result.Syntax in
-  let+ cache_dir = cache_dir t in
-  Path.(cache_dir / "/html/")
+let html_dir t = Path.(t.cache_dir / "/html/")
 
 let odoc_exec t ~package_name =
   let open Promise.Syntax in
@@ -35,8 +36,7 @@ let odoc_exec t ~package_name =
   let+ result =
     match ouput with
     | Ok _ as ok ->
-      let open Promise.Result.Syntax in
-      let* html_dir = html_dir t in
+      let html_dir = html_dir t in
       let package_html_dir = Path.to_string html_dir ^ package_name in
       let open Promise.Syntax in
       let+ dir_exists = Fs.exists package_html_dir in

--- a/src/odig.ml
+++ b/src/odig.ml
@@ -2,15 +2,15 @@ open Import
 
 type t = Opam.t * Opam.Switch.t
 
-type of_opam_error = Odig_not_installed
-
 let of_opam (opam, switch) =
   let open Promise.Syntax in
   let+ is_installed = Opam.has_package opam switch ~package_name:"odig" in
   if is_installed then
     Ok (opam, switch)
   else
-    Error Odig_not_installed
+    Error
+      "\"OCaml: the package \"odig\" must be installed to generate \
+       documentation."
 
 let cmd_ouput (opam, switch) args =
   let cmd = Opam.exec opam switch ~args in

--- a/src/odig.ml
+++ b/src/odig.ml
@@ -18,7 +18,9 @@ let cmd_ouput (opam, switch) args =
 
 let cache_dir t =
   let opam, switch = t in
-  let default_cache_dir = Path.(Opam.path opam switch / "/var/cache/odig/") in
+  let default_cache_dir =
+    Path.(Opam.Switch.path opam switch / "/var/cache/odig/")
+  in
   let open Promise.Syntax in
   let+ cache_dir = cmd_ouput t [ "odig"; "cache"; "path" ] in
   match cache_dir with

--- a/src/odig.mli
+++ b/src/odig.mli
@@ -6,6 +6,6 @@ val of_sandbox : Sandbox.t -> (t, string) result Promise.t
 
 (** Generates the odoc API documentation and manual of [package_name]. Interface
     to the [odig odoc package_name] command *)
-val odoc_exec : t -> package_name:string -> (string, string) result Promise.t
+val odoc_exec : t -> package_name:string -> (unit, string) result Promise.t
 
 val html_dir : t -> Path.t

--- a/src/odig.mli
+++ b/src/odig.mli
@@ -8,4 +8,4 @@ val of_sandbox : Sandbox.t -> (t, string) result Promise.t
     to the [odig odoc package_name] command *)
 val odoc_exec : t -> package_name:string -> (string, string) result Promise.t
 
-val html_dir : t -> (Path.t, string) result Promise.t
+val html_dir : t -> Path.t

--- a/src/odig.mli
+++ b/src/odig.mli
@@ -1,8 +1,6 @@
 type t
 
-type of_opam_error = Odig_not_installed
-
-val of_opam : Opam.t * Opam.Switch.t -> (t, of_opam_error) result Promise.t
+val of_opam : Opam.t * Opam.Switch.t -> (t, string) result Promise.t
 
 val odoc_exec : t -> package_name:string -> (string, string) result Promise.t
 

--- a/src/odig.mli
+++ b/src/odig.mli
@@ -1,7 +1,11 @@
+(** Provide an interface to Odig. *)
+
 type t
 
 val of_sandbox : Sandbox.t -> (t, string) result Promise.t
 
+(** Generates the odoc API documentation and manual of [package_name]. Interface
+    to the [odig odoc package_name] command *)
 val odoc_exec : t -> package_name:string -> (string, string) result Promise.t
 
 val html_dir : t -> (Path.t, string) result Promise.t

--- a/src/odig.mli
+++ b/src/odig.mli
@@ -6,6 +6,10 @@ val of_sandbox : Sandbox.t -> (t, string) result Promise.t
 
 (** Generates the odoc API documentation and manual of [package_name]. Interface
     to the [odig odoc package_name] command *)
-val odoc_exec : t -> package_name:string -> (unit, string) result Promise.t
+val odoc_exec :
+     t
+  -> sandbox:Sandbox.t
+  -> package_name:string
+  -> (unit, string) result Promise.t
 
 val html_dir : t -> Path.t

--- a/src/odig.mli
+++ b/src/odig.mli
@@ -1,10 +1,8 @@
 type t
 
-type of_sandbox_error =
-  | Not_supported_sandbox
-  | Odig_not_installed
+type of_opam_error = Odig_not_installed
 
-val of_sandbox : Sandbox.t -> (t, of_sandbox_error) result Promise.t
+val of_opam : Opam.t * Opam.Switch.t -> (t, of_opam_error) result Promise.t
 
 val odoc_exec : t -> string -> (string, string) result Promise.t
 

--- a/src/odig.mli
+++ b/src/odig.mli
@@ -4,7 +4,7 @@ type of_opam_error = Odig_not_installed
 
 val of_opam : Opam.t * Opam.Switch.t -> (t, of_opam_error) result Promise.t
 
-val odoc_exec : t -> string -> (string, string) result Promise.t
+val odoc_exec : t -> package_name:string -> (string, string) result Promise.t
 
 val cache_dir : t -> Path.t Promise.t
 

--- a/src/odig.mli
+++ b/src/odig.mli
@@ -1,9 +1,7 @@
 type t
 
-val of_opam : Opam.t * Opam.Switch.t -> (t, string) result Promise.t
+val of_sandbox : Sandbox.t -> (t, string) result Promise.t
 
 val odoc_exec : t -> package_name:string -> (string, string) result Promise.t
 
-val cache_dir : t -> Path.t Promise.t
-
-val html_dir : t -> Path.t Promise.t
+val html_dir : t -> (Path.t, string) result Promise.t

--- a/src/opam.ml
+++ b/src/opam.ml
@@ -314,4 +314,11 @@ let has_package t switch package_name =
     packages
     |> List.exists ~f:(fun package ->
            String.equal (Package.name package) package_name)
-  | Error _ -> false
+  | Error e ->
+    let () =
+      log
+        "Unable to determine if package %s is installed in the current switch. \
+         Error: %s"
+        package_name e
+    in
+    false

--- a/src/opam.ml
+++ b/src/opam.ml
@@ -300,20 +300,3 @@ let root_packages t switch =
 let package_remove t switch packages =
   let names = List.map ~f:Package.name packages in
   remove t switch names
-
-let has_package t switch ~package_name =
-  let open Promise.Syntax in
-  let+ packages = packages t switch in
-  match packages with
-  | Ok packages ->
-    packages
-    |> List.exists ~f:(fun package ->
-           String.equal (Package.name package) package_name)
-  | Error e ->
-    let () =
-      log
-        "Unable to determine if package %s is installed in the current switch. \
-         Error: %s"
-        package_name e
-    in
-    false

--- a/src/opam.ml
+++ b/src/opam.ml
@@ -306,7 +306,7 @@ let package_remove t switch packages =
   let names = List.map ~f:Package.name packages in
   remove t switch names
 
-let has_package t switch package_name =
+let has_package t switch ~package_name =
   let open Promise.Syntax in
   let+ packages = packages t switch in
   match packages with

--- a/src/opam.ml
+++ b/src/opam.ml
@@ -270,11 +270,6 @@ let upgrade t switch = spawn t [ "upgrade"; switch_arg switch; "-y" ]
 let remove t switch packages =
   spawn t ("remove" :: switch_arg switch :: "-y" :: packages)
 
-let path (opam : t) (switch : Switch.t) =
-  match switch with
-  | Local p -> Path.(p / "_opam")
-  | Named n -> Path.(opam.root / n)
-
 let switch_compiler t switch =
   let open Promise.Syntax in
   let+ switch_state = Switch_state.of_switch t switch in

--- a/src/opam.mli
+++ b/src/opam.mli
@@ -3,12 +3,8 @@
     The functions in this module either use the result of opam commands, or use
     the filesystem to get the state of opam configurations. *)
 
-type t
-
 (** An Opam switch *)
 module Switch : sig
-  type opam := t
-
   type t =
     | Local of Path.t
     | Named of string
@@ -20,8 +16,6 @@ module Switch : sig
   (** {4 Properties} *)
 
   val name : t -> string
-
-  val path : opam -> t -> Path.t
 
   (** {4 Utilities} *)
 
@@ -46,6 +40,8 @@ module Package : sig
 
   val dependencies : t -> (t list, string) result Promise.t
 end
+
+type t
 
 val make : ?root:Path.t -> unit -> t option Promise.t
 
@@ -105,6 +101,3 @@ val exec : t -> Switch.t -> args:string list -> Cmd.t
 
 (** Check that two instances of [Opam] are equal. *)
 val equal : t -> t -> bool
-
-(** Check that a package is installed in the given switch. *)
-val has_package : t -> Switch.t -> package_name:string -> bool Promise.t

--- a/src/opam.mli
+++ b/src/opam.mli
@@ -105,4 +105,4 @@ val exec : t -> Switch.t -> args:string list -> Cmd.t
 val equal : t -> t -> bool
 
 (** Check that a package is installed in the given switch. *)
-val has_package : t -> Switch.t -> string -> bool Promise.t
+val has_package : t -> Switch.t -> package_name:string -> bool Promise.t

--- a/src/opam.mli
+++ b/src/opam.mli
@@ -3,8 +3,12 @@
     The functions in this module either use the result of opam commands, or use
     the filesystem to get the state of opam configurations. *)
 
+type t
+
 (** An Opam switch *)
 module Switch : sig
+  type opam := t
+
   type t =
     | Local of Path.t
     | Named of string
@@ -16,6 +20,8 @@ module Switch : sig
   (** {4 Properties} *)
 
   val name : t -> string
+
+  val path : opam -> t -> Path.t
 
   (** {4 Utilities} *)
 
@@ -41,8 +47,6 @@ module Package : sig
   val dependencies : t -> (t list, string) result Promise.t
 end
 
-type t
-
 val make : ?root:Path.t -> unit -> t option Promise.t
 
 (** Install new packages in a switch *)
@@ -56,8 +60,6 @@ val upgrade : t -> Switch.t -> Cmd.t
 
 (* Remove a list of packages from a switch *)
 val remove : t -> Switch.t -> string list -> Cmd.t
-
-val path : t -> Switch.t -> Path.t
 
 (* Initialize a new Opam environment. *)
 val init : t -> Cmd.t

--- a/src/treeview_sandbox.ml
+++ b/src/treeview_sandbox.ml
@@ -114,18 +114,11 @@ module Command = struct
               package_name;
             Promise.resolve ()
           | Ok _ -> (
-            let start_server () =
-              let documentation_server =
-                Extension_instance.documentation_server instance
-              in
-              match documentation_server with
-              | Some server -> Promise.resolve (Ok server)
-              | None ->
-                let html_dir = Odig.html_dir odig in
-                Extension_instance.start_documentation_server instance
-                  ~path:html_dir
+            let+ server =
+              let html_dir = Odig.html_dir odig in
+              Extension_instance.start_documentation_server instance
+                ~path:html_dir
             in
-            let+ server = start_server () in
             match server with
             | Error () -> ()
             | Ok server ->

--- a/src/treeview_sandbox.ml
+++ b/src/treeview_sandbox.ml
@@ -89,7 +89,7 @@ module Command = struct
           | Sandbox.Global
           | Sandbox.Custom _ ->
             let message =
-              "\"OCaml: Generate Documentation\" command only works with OPAM \
+              "\"OCaml: Generate Documentation\" command only works with Opam \
                sandboxes."
             in
             let (_ : 'a option Promise.t) =

--- a/src/treeview_sandbox.ml
+++ b/src/treeview_sandbox.ml
@@ -89,9 +89,8 @@ module Command = struct
           | Sandbox.Global
           | Sandbox.Custom _ ->
             let message =
-              Printf.sprintf
-                "This functionality is not supported for %s sandbox"
-                (Sandbox.to_string sandbox)
+              "\"OCaml: Generate Documentation\" command only works with OPAM \
+               sandboxes."
             in
             let+ _ = Window.showErrorMessage ~message () in
             ()
@@ -102,7 +101,8 @@ module Command = struct
               let message =
                 match e with
                 | Odig.Odig_not_installed ->
-                  "Odig must be installed to generate the documentation."
+                  "\"OCaml: Generate Documentation\": the package \"odig\" \
+                   must be installed to generate documentation."
               in
               let+ _ = Window.showErrorMessage ~message () in
               ()

--- a/src/treeview_sandbox.ml
+++ b/src/treeview_sandbox.ml
@@ -125,20 +125,17 @@ module Command = struct
               | Some server ->
                 Promise.resolve (Ok (Documentation_server.port server))
               | None -> (
-                let* html_dir = Odig.html_dir odig in
-                match html_dir with
-                | Error e -> Promise.resolve (Error e)
-                | Ok html_dir -> (
-                  let+ result =
-                    Extension_instance.start_documentation_server instance
-                      ~path:html_dir
-                  in
-                  match result with
-                  | Error e ->
-                    log "Error while starting the documentation server: %s"
-                      (Node.JsError.message e);
-                    Error "OCaml: Error while starting the documentation server"
-                  | Ok server -> Ok (Documentation_server.port server)))
+                let html_dir = Odig.html_dir odig in
+                let+ result =
+                  Extension_instance.start_documentation_server instance
+                    ~path:html_dir
+                in
+                match result with
+                | Error e ->
+                  log "Error while starting the documentation server: %s"
+                    (Node.JsError.message e);
+                  Error "OCaml: Error while starting the documentation server"
+                | Ok server -> Ok (Documentation_server.port server))
             in
             let+ port = start_server () in
             match port with

--- a/src/treeview_sandbox.ml
+++ b/src/treeview_sandbox.ml
@@ -119,8 +119,7 @@ module Command = struct
                 Extension_instance.documentation_server instance
               in
               match documentation_server with
-              | Some server ->
-                Promise.resolve (Ok (Documentation_server.port server))
+              | Some server -> Promise.resolve (Ok server)
               | None -> (
                 let html_dir = Odig.html_dir odig in
                 let+ result =
@@ -132,19 +131,21 @@ module Command = struct
                   log "Error while starting the documentation server: %s"
                     (Node.JsError.message e);
                   Error "OCaml: Error while starting the documentation server"
-                | Ok server -> Ok (Documentation_server.port server))
+                | Ok server -> Ok server)
             in
-            let+ port = start_server () in
-            match port with
+            let+ server = start_server () in
+            match server with
             | Error e ->
               show_message `Error "%s" e;
               ()
-            | Ok port ->
+            | Ok server ->
               let (_ : Ojs.t option Promise.t) =
+                let port = Documentation_server.port server in
+                let host = Documentation_server.host server in
                 Vscode.Commands.executeCommand ~command:"simpleBrowser.show"
                   ~args:
                     [ Ojs.string_to_js
-                        (Printf.sprintf "http://localhost:%i/%s/index.html" port
+                        (Printf.sprintf "http://%s:%i/%s/index.html" host port
                            package_name)
                     ]
               in

--- a/src/treeview_sandbox.ml
+++ b/src/treeview_sandbox.ml
@@ -178,7 +178,7 @@ module Command = struct
                         let _ =
                           Vscode.Workspace.updateWorkspaceFolders ~start
                             ~deleteCount:(Some 0)
-                            ~workspaceFoldersToAdd:[ workspaceFoldersToAdd ] ()
+                            ~workspaceFoldersToAdd:[ workspaceFoldersToAdd ]
                         in
                         Promise.resolve ())
                     | Sandbox.Esy (_, _)

--- a/src/treeview_sandbox.ml
+++ b/src/treeview_sandbox.ml
@@ -113,14 +113,18 @@ module Command = struct
             | Ok odig -> (
               let arg = List.hd_exn args in
               let dep = Dependency.t_of_js arg in
-              let name = Sandbox.Package.name dep in
+              let package_name = Sandbox.Package.name dep in
               let options =
                 ProgressOptions.create
                   ~location:(`ProgressLocation Notification)
-                  ~title:(Printf.sprintf "Generating documentation for %s" name)
+                  ~title:
+                    (Printf.sprintf "Generating documentation for %s"
+                       package_name)
                   ~cancellable:false ()
               in
-              let task ~progress:_ ~token:_ = Odig.odoc_exec odig name in
+              let task ~progress:_ ~token:_ =
+                Odig.odoc_exec odig ~package_name
+              in
               let* result =
                 Vscode.Window.withProgress
                   (module Interop.Js.Result
@@ -134,7 +138,8 @@ module Command = struct
                   Window.showErrorMessage
                     ~message:
                       (Printf.sprintf
-                         "Error while generating documentation for %s" name)
+                         "Error while generating documentation for %s"
+                         package_name)
                     ()
                 in
                 Promise.resolve ()
@@ -165,7 +170,7 @@ module Command = struct
                     ~args:
                       [ Ojs.string_to_js
                           (Printf.sprintf "http://localhost:%i/%s/index.html"
-                             port name)
+                             port package_name)
                       ]
                 in
                 ()))

--- a/src/treeview_sandbox.ml
+++ b/src/treeview_sandbox.ml
@@ -106,7 +106,9 @@ module Command = struct
           in
           match result with
           | Error _ ->
-            show_message `Error "Error while generating documentation for %s"
+            show_message `Error
+              "Documentation could not be generated for %s. It might be \
+               because this package has no documentation."
               package_name;
             Promise.resolve ()
           | Ok _ -> (

--- a/src/treeview_sandbox.ml
+++ b/src/treeview_sandbox.ml
@@ -98,7 +98,9 @@ module Command = struct
                 (Printf.sprintf "Generating documentation for %s" package_name)
               ~cancellable:false ()
           in
-          let task ~progress:_ ~token:_ = Odig.odoc_exec odig ~package_name in
+          let task ~progress:_ ~token:_ =
+            Odig.odoc_exec odig ~sandbox ~package_name
+          in
           let* result =
             Vscode.Window.withProgress
               (module Interop.Js.Result (Interop.Js.Unit) (Interop.Js.String))

--- a/src/treeview_sandbox.ml
+++ b/src/treeview_sandbox.ml
@@ -99,15 +99,9 @@ module Command = struct
           | Sandbox.Opam (opam, switch) -> (
             let* odig = Odig.of_opam (opam, switch) in
             match odig with
-            | Error e ->
-              let message =
-                match e with
-                | Odig.Odig_not_installed ->
-                  "\"OCaml: Generate Documentation\": the package \"odig\" \
-                   must be installed to generate documentation."
-              in
+            | Error error ->
               let (_ : 'a option Promise.t) =
-                Window.showErrorMessage ~message ()
+                Window.showErrorMessage ~message:error ()
               in
               Promise.resolve ()
             | Ok odig -> (

--- a/src/treeview_sandbox.ml
+++ b/src/treeview_sandbox.ml
@@ -101,7 +101,7 @@ module Command = struct
           let task ~progress:_ ~token:_ = Odig.odoc_exec odig ~package_name in
           let* result =
             Vscode.Window.withProgress
-              (module Interop.Js.Result (Interop.Js.String) (Interop.Js.String))
+              (module Interop.Js.Result (Interop.Js.Unit) (Interop.Js.String))
               ~options ~task
           in
           match result with

--- a/src/treeview_sandbox.ml
+++ b/src/treeview_sandbox.ml
@@ -164,8 +164,9 @@ module Command = struct
                 | Ok _ ->
                   let+ html_dir = Odig.html_dir odig in
                   let () =
-                    match sandbox with
-                    | Sandbox.Opam (_, Opam.Switch.Named _) ->
+                    match switch with
+                    | Opam.Switch.Local _ -> ()
+                    | Opam.Switch.Named _ ->
                       let start =
                         Vscode.Workspace.workspaceFolders () |> List.length
                       in
@@ -180,11 +181,6 @@ module Command = struct
                           ~deleteCount:(Some 0)
                           ~workspaceFoldersToAdd:[ workspaceFoldersToAdd ]
                       in
-                      ()
-                    | Sandbox.Opam (_, Opam.Switch.Local _)
-                    | Sandbox.Esy (_, _)
-                    | Sandbox.Global
-                    | Sandbox.Custom _ ->
                       ()
                   in
                   let htmlDocumentationPath = Path.(html_dir / name) in

--- a/src/treeview_sandbox.ml
+++ b/src/treeview_sandbox.ml
@@ -147,7 +147,6 @@ module Command = struct
                               (Interop.Js.String))
                     ~options ~task
                 in
-
                 match result with
                 | Error _ ->
                   let+ _ =
@@ -162,25 +161,23 @@ module Command = struct
                   let* html_dir = Odig.html_dir odig in
                   let+ () =
                     match sandbox with
-                    | Sandbox.Opam (_, switch) -> (
-                      match switch with
-                      | Opam.Switch.Local _ -> Promise.resolve ()
-                      | Opam.Switch.Named _ ->
-                        let start =
-                          Vscode.Workspace.workspaceFolders () |> List.length
-                        in
-                        let workspaceFoldersToAdd :
-                            Vscode.Workspace.workspaceFolderToAdd =
-                          { name = "odig_doc"
-                          ; uri = Vscode.Uri.file (Path.to_string html_dir)
-                          }
-                        in
-                        let _ =
-                          Vscode.Workspace.updateWorkspaceFolders ~start
-                            ~deleteCount:(Some 0)
-                            ~workspaceFoldersToAdd:[ workspaceFoldersToAdd ]
-                        in
-                        Promise.resolve ())
+                    | Sandbox.Opam (_, Opam.Switch.Named _) ->
+                      let start =
+                        Vscode.Workspace.workspaceFolders () |> List.length
+                      in
+                      let workspaceFoldersToAdd :
+                          Vscode.Workspace.workspaceFolderToAdd =
+                        { name = "odig_doc"
+                        ; uri = Vscode.Uri.file (Path.to_string html_dir)
+                        }
+                      in
+                      let _ =
+                        Vscode.Workspace.updateWorkspaceFolders ~start
+                          ~deleteCount:(Some 0)
+                          ~workspaceFoldersToAdd:[ workspaceFoldersToAdd ]
+                      in
+                      Promise.resolve ()
+                    | Sandbox.Opam (_, Opam.Switch.Local _)
                     | Sandbox.Esy (_, _)
                     | Sandbox.Global
                     | Sandbox.Custom _ ->

--- a/src/treeview_sandbox.ml
+++ b/src/treeview_sandbox.ml
@@ -86,9 +86,7 @@ module Command = struct
         let* odig = Odig.of_sandbox sandbox in
         match odig with
         | Error error ->
-          let (_ : 'a option Promise.t) =
-            Window.showErrorMessage ~message:error ()
-          in
+          show_message `Error "%s" error;
           Promise.resolve ()
         | Ok odig -> (
           let arg = List.hd_exn args in
@@ -108,13 +106,8 @@ module Command = struct
           in
           match result with
           | Error _ ->
-            let (_ : 'a option Promise.t) =
-              Window.showErrorMessage
-                ~message:
-                  (Printf.sprintf "Error while generating documentation for %s"
-                     package_name)
-                ()
-            in
+            show_message `Error "Error while generating documentation for %s"
+              package_name;
             Promise.resolve ()
           | Ok _ -> (
             let start_server () =
@@ -140,9 +133,7 @@ module Command = struct
             let+ port = start_server () in
             match port with
             | Error e ->
-              let (_ : 'a option Promise.t) =
-                Window.showErrorMessage ~message:e ()
-              in
+              show_message `Error "%s" e;
               ()
             | Ok port ->
               let (_ : Ojs.t option Promise.t) =

--- a/src/treeview_sandbox.ml
+++ b/src/treeview_sandbox.ml
@@ -120,24 +120,14 @@ module Command = struct
               in
               match documentation_server with
               | Some server -> Promise.resolve (Ok server)
-              | None -> (
+              | None ->
                 let html_dir = Odig.html_dir odig in
-                let+ result =
-                  Extension_instance.start_documentation_server instance
-                    ~path:html_dir
-                in
-                match result with
-                | Error e ->
-                  log "Error while starting the documentation server: %s"
-                    (Node.JsError.message e);
-                  Error "OCaml: Error while starting the documentation server"
-                | Ok server -> Ok server)
+                Extension_instance.start_documentation_server instance
+                  ~path:html_dir
             in
             let+ server = start_server () in
             match server with
-            | Error e ->
-              show_message `Error "%s" e;
-              ()
+            | Error () -> ()
             | Ok server ->
               let (_ : Ojs.t option Promise.t) =
                 let port = Documentation_server.port server in

--- a/yarn.lock
+++ b/yarn.lock
@@ -2,6 +2,11 @@
 # yarn lockfile v1
 
 
+"@polka/url@^1.0.0-next.20", "@polka/url@^1.0.0-next.21":
+  version "1.0.0-next.21"
+  resolved "https://registry.yarnpkg.com/@polka/url/-/url-1.0.0-next.21.tgz#5de5a2385a35309427f6011992b544514d559aa1"
+  integrity sha512-a5Sab1C4/icpTZVzZc5Ghpz88yQtGOyNqYXcZgOssB2uuAr+wF/MvN6bgtW32q7HHrvBki+BsZ0OuNv6EV3K9g==
+
 "@tootallnate/once@1":
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/@tootallnate/once/-/once-1.1.2.tgz#ccb91445360179a04e7fe6aff78c00ffc1eeaf82"
@@ -1240,6 +1245,11 @@ mocha@9.2.0:
     yargs-parser "20.2.4"
     yargs-unparser "2.0.0"
 
+mrmime@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/mrmime/-/mrmime-1.0.0.tgz#14d387f0585a5233d291baba339b063752a2398b"
+  integrity sha512-a70zx7zFfVO7XpnQ2IX1Myh9yY4UYvfld/dikWRnsXxbyvMcfz+u6UfgNAtH+k2QqtJuzVpv6eLTx1G2+WKZbQ==
+
 ms@2.1.2:
   version "2.1.2"
   resolved "https://registry.yarnpkg.com/ms/-/ms-2.1.2.tgz#d09d1f357b443f493382a8eb3ccd183872ae6009"
@@ -1486,6 +1496,14 @@ pify@^3.0.0:
   resolved "https://registry.yarnpkg.com/pify/-/pify-3.0.0.tgz#e5a4acd2c101fdf3d9a4d07f0dbc4db49dd28176"
   integrity sha1-5aSs0sEB/fPZpNB/DbxNtJ3SgXY=
 
+polka@^1.0.0-next.22:
+  version "1.0.0-next.22"
+  resolved "https://registry.yarnpkg.com/polka/-/polka-1.0.0-next.22.tgz#3c25659a401608cf437732f292baf481dc6ec16e"
+  integrity sha512-a7tsZy5gFbJr0aUltZS97xCkbPglXuD67AMvTyZX7BTDBH384FWf0ZQF6rPvdutSxnO1vUlXM2zSLf5tCKk5RA==
+  dependencies:
+    "@polka/url" "^1.0.0-next.21"
+    trouter "^3.1.0"
+
 prebuild-install@^6.0.0:
   version "6.1.4"
   resolved "https://registry.yarnpkg.com/prebuild-install/-/prebuild-install-6.1.4.tgz#ae3c0142ad611d58570b89af4986088a4937e00f"
@@ -1591,6 +1609,11 @@ readdirp@~3.6.0:
   integrity sha512-hOS089on8RduqdbhvQ5Z37A0ESjsqz6qnRcffsMU3495FuTdqSm+7bhJ29JvIOsBDEEnan5DPu9t3To9VRlMzA==
   dependencies:
     picomatch "^2.2.1"
+
+regexparam@^1.3.0:
+  version "1.3.0"
+  resolved "https://registry.yarnpkg.com/regexparam/-/regexparam-1.3.0.tgz#2fe42c93e32a40eff6235d635e0ffa344b92965f"
+  integrity sha512-6IQpFBv6e5vz1QAqI+V4k8P2e/3gRrqfCJ9FI+O1FLQTO+Uz6RXZEZOPmTJ6hlGj7gkERzY5BRCv09whKP96/g==
 
 require-directory@^2.1.1:
   version "2.1.1"
@@ -1707,6 +1730,15 @@ simple-get@^3.0.3:
     decompress-response "^4.2.0"
     once "^1.3.1"
     simple-concat "^1.0.0"
+
+sirv@^1.0.19:
+  version "1.0.19"
+  resolved "https://registry.yarnpkg.com/sirv/-/sirv-1.0.19.tgz#1d73979b38c7fe91fcba49c85280daa9c2363b49"
+  integrity sha512-JuLThK3TnZG1TAKDwNIqNq6QA2afLOCcm+iE8D1Kj3GA40pSPsxQjjJl0J8X3tsR7T+CP1GavpzLwYkgVLWrZQ==
+  dependencies:
+    "@polka/url" "^1.0.0-next.20"
+    mrmime "^1.0.0"
+    totalist "^1.0.0"
 
 spdx-correct@^3.0.0:
   version "3.1.1"
@@ -1888,10 +1920,22 @@ to-regex-range@^5.0.1:
   dependencies:
     is-number "^7.0.0"
 
+totalist@^1.0.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/totalist/-/totalist-1.1.0.tgz#a4d65a3e546517701e3e5c37a47a70ac97fe56df"
+  integrity sha512-gduQwd1rOdDMGxFG1gEvhV88Oirdo2p+KjoYFU7k2g+i7n6AFFbDQ5kMPUsW0pNbfQsB/cwXvT1i4Bue0s9g5g==
+
 "traverse@>=0.3.0 <0.4":
   version "0.3.9"
   resolved "https://registry.yarnpkg.com/traverse/-/traverse-0.3.9.tgz#717b8f220cc0bb7b44e40514c22b2e8bbc70d8b9"
   integrity sha1-cXuPIgzAu3tE5AUUwisui7xw2Lk=
+
+trouter@^3.1.0:
+  version "3.2.0"
+  resolved "https://registry.yarnpkg.com/trouter/-/trouter-3.2.0.tgz#a9c510fce21b8e659a28732c9de9d82871efe8df"
+  integrity sha512-rLLXbhTObLy2MBVjLC+jTnoIKw99n0GuJs9ov10J870vDw5qhTurPzsDrudNtBf5w/CZ9ctZy2p2IMmhGcel2w==
+  dependencies:
+    regexparam "^1.3.0"
 
 tslib@^2.2.0:
   version "2.3.1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1731,14 +1731,14 @@ simple-get@^3.0.3:
     once "^1.3.1"
     simple-concat "^1.0.0"
 
-sirv@^2.0.0:
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/sirv/-/sirv-2.0.0.tgz#e6d41213d3b192f2207f551ba5c03e1cc7e11e31"
-  integrity sha512-TT+4+zSM9LR8soWT5/4gOYHfB5a5XEOSV2LtmBRN5MUxi8kh7BSRGuoRYjeBaqhR4w+yx+k6t0OibDNgoLfF7w==
+sirv@^2.0.2:
+  version "2.0.2"
+  resolved "https://registry.yarnpkg.com/sirv/-/sirv-2.0.2.tgz#128b9a628d77568139cff85703ad5497c46a4760"
+  integrity sha512-4Qog6aE29nIjAOKe/wowFTxOdmbEZKb+3tsLljaBRzJwtqto0BChD2zzH0LhgCSXiI+V7X+Y45v14wBZQ1TK3w==
   dependencies:
     "@polka/url" "^1.0.0-next.20"
     mrmime "^1.0.0"
-    totalist "^2.0.0"
+    totalist "^3.0.0"
 
 spdx-correct@^3.0.0:
   version "3.1.1"
@@ -1920,10 +1920,10 @@ to-regex-range@^5.0.1:
   dependencies:
     is-number "^7.0.0"
 
-totalist@^2.0.0:
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/totalist/-/totalist-2.0.0.tgz#db6f1e19c0fa63e71339bbb8fba89653c18c7eec"
-  integrity sha512-+Y17F0YzxfACxTyjfhnJQEe7afPA0GSpYlFkl2VFMxYP7jshQf9gXV7cH47EfToBumFThfKBvfAcoUn6fdNeRQ==
+totalist@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/totalist/-/totalist-3.0.0.tgz#4ef9c58c5f095255cdc3ff2a0a55091c57a3a1bd"
+  integrity sha512-eM+pCBxXO/njtF7vdFsHuqb+ElbxqtI4r5EAvk6grfAFyJ6IvWlSkfZ5T9ozC6xWw3Fj1fGoSmrl0gUs46JVIw==
 
 "traverse@>=0.3.0 <0.4":
   version "0.3.9"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1731,14 +1731,14 @@ simple-get@^3.0.3:
     once "^1.3.1"
     simple-concat "^1.0.0"
 
-sirv@^1.0.19:
-  version "1.0.19"
-  resolved "https://registry.yarnpkg.com/sirv/-/sirv-1.0.19.tgz#1d73979b38c7fe91fcba49c85280daa9c2363b49"
-  integrity sha512-JuLThK3TnZG1TAKDwNIqNq6QA2afLOCcm+iE8D1Kj3GA40pSPsxQjjJl0J8X3tsR7T+CP1GavpzLwYkgVLWrZQ==
+sirv@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/sirv/-/sirv-2.0.0.tgz#e6d41213d3b192f2207f551ba5c03e1cc7e11e31"
+  integrity sha512-TT+4+zSM9LR8soWT5/4gOYHfB5a5XEOSV2LtmBRN5MUxi8kh7BSRGuoRYjeBaqhR4w+yx+k6t0OibDNgoLfF7w==
   dependencies:
     "@polka/url" "^1.0.0-next.20"
     mrmime "^1.0.0"
-    totalist "^1.0.0"
+    totalist "^2.0.0"
 
 spdx-correct@^3.0.0:
   version "3.1.1"
@@ -1920,10 +1920,10 @@ to-regex-range@^5.0.1:
   dependencies:
     is-number "^7.0.0"
 
-totalist@^1.0.0:
-  version "1.1.0"
-  resolved "https://registry.yarnpkg.com/totalist/-/totalist-1.1.0.tgz#a4d65a3e546517701e3e5c37a47a70ac97fe56df"
-  integrity sha512-gduQwd1rOdDMGxFG1gEvhV88Oirdo2p+KjoYFU7k2g+i7n6AFFbDQ5kMPUsW0pNbfQsB/cwXvT1i4Bue0s9g5g==
+totalist@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/totalist/-/totalist-2.0.0.tgz#db6f1e19c0fa63e71339bbb8fba89653c18c7eec"
+  integrity sha512-+Y17F0YzxfACxTyjfhnJQEe7afPA0GSpYlFkl2VFMxYP7jshQf9gXV7cH47EfToBumFThfKBvfAcoUn6fdNeRQ==
 
 "traverse@>=0.3.0 <0.4":
   version "0.3.9"


### PR DESCRIPTION
**Opening that is one as draft to get some feedback and discuss the way to move forward (see some of my questions below). I also still need to write some tests.**

The purpose of this PR is to make it possible to generate and view the documentation for installed packages in the opam switch right from the VSCode editor. It uses [odig](https://github.com/b0-system/odig) to generate the HTML documentation for a given package and rely on the [vscode live preview](https://github.com/microsoft/vscode-livepreview) extension to display the generated documentation files. Both need to be installed to make it work.

A new icon (next to the existing one) added to the tree view allows to generate+show the documentation for a package:


https://user-images.githubusercontent.com/5595092/141298715-aaeb9234-29d2-47be-b8c5-6344a747d1dc.mov


Like I said above, `odig` and the `vscode live preview` extension have to be installed. We check that both are indeed available with an error message being displayed if that's not the case. Also, only **opam** sandboxes are supported for now.

I think it works quite well excepts for two things I would like to improve (and for which I would like to have your input):


1. The `vscode live preview` extension seems to freeze when the documentation for a package is generated while it's already showing documentation for another package (basically when we switch between package's doc). The extension probably has a file watcher to [reload the preview](https://github.com/microsoft/vscode-livepreview#live-refreshing) in live while you edit the code. Maybe that watcher is having some trouble when a couple of files are being added? 

https://user-images.githubusercontent.com/5595092/141302096-30603c8b-30d8-43b0-aa38-223798feea29.mp4

2. The `vscode live preview` internal server can't display files that are outside of the currently opened workspace.

<img src="https://user-images.githubusercontent.com/5595092/141304267-92630123-5950-425d-9074-c1a42dc458f3.png" width="400" />

It means that it won't work with the default opam switches since the documentation will live somewhere under `~/.opam/...`. As suggested by @ulugbekna, we could try to add the documentation folder in the workspace. There's actually a function `updateWorkspaceFolders` that allows adding folders to the current workspace. That's what I use but it doesn't work well because if we're not yet in a workspace, the extension is restarted. So the code that triggers the command to show the documentation via the live preview extension is not even executed (the extension is killed before).

From the doc:

> If the first workspace folder is added, removed or changed, the currently executing extensions (including the one that called this method) will be terminated and restarted so that the (deprecated) rootPath property is updated to point to the first workspace folder.

A possible solution could be to set some state before we're about the add a new folder to the workspace (and the extension being restarted) and then in the `onDidChangeWorkspaceFolders` we can check that state and eventually show the documentation.

Another solution I've experimented with is to not use the live preview extension. Instead, we could start our own server that serves the documentation files and display them via the built-in `Simple Browser` extension. I've used [polka](https://github.com/lukeed/polka) (lightweight server) together with [sirv](https://github.com/lukeed/sirv) (middleware to serve static files) for my experiment.

The cool thing is that it would not require any external extension to be installed and it would also solve both 1 and 2. See the video below (I'm on the default opam switch)

https://user-images.githubusercontent.com/5595092/141309271-28b8fbb8-4aae-4e49-956e-1fdd3826a933.mov


The `Simple Browser` has fewer features though. For instance, we can't search (CTRL+F) across the page, which might be handy when you're looking up something. 
