### PR TITLE
ci: fix lint-fmt job

### DIFF
--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -1,21 +1,20 @@
-name: Changelog check
+name: Check changelog
 
 on:
   pull_request:
-    branches: [master]
-    types: [opened, synchronize, reopened, labeled, unlabeled]
+    branches:
+      - master
+    types:
+      - labeled
+      - opened
+      - reopened
+      - synchronize
+      - unlabeled
 
 jobs:
-  build:
+  check-changelog:
+    name: Check changelog
     runs-on: ubuntu-latest
-
     steps:
-      - name: Checkout code
-        uses: actions/checkout@v2
-
-      - name: git diff
-        if: ${{ !contains(github.event.pull_request.labels.*.name, 'no changelog needed') }}
-        env:
-          BASE_REF: ${{ github.event.pull_request.base.ref }}
-        run: |
-          ! git diff --exit-code origin/$BASE_REF -- CHANGELOG.md
+      - name: Check changelog
+        uses: tarides/changelog-check-action@v1

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -161,6 +161,6 @@ jobs:
           ocaml-compiler: ${{ matrix.ocaml-compiler }}
           dune-cache: true
 
-      - run: opam depext ocamlformat=$(cat .ocamlformat | grep version | cut -d '=' -f 2 | cut -d ' ' -f 1) --install
+      - run: opam depext --install ocamlformat=$(awk -F = '/version=/{print $2}' .ocamlformat)
 
       - run: opam exec -- dune build @fmt

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -161,6 +161,6 @@ jobs:
           ocaml-compiler: ${{ matrix.ocaml-compiler }}
           dune-cache: true
 
-      - run: opam depext ocamlformat=$(cat .ocamlformat | grep version | cut -d '=' -f 2) --install
+      - run: opam depext ocamlformat=$(cat .ocamlformat | grep version | cut -d '=' -f 2 | cut -d ' ' -f 1) --install
 
       - run: opam exec -- dune build @fmt

--- a/.ocamlformat
+++ b/.ocamlformat
@@ -1,4 +1,5 @@
-version=0.19.0 # when updating ocamlformat version, update the version in Makefile `deps` target 
+# when updating ocamlformat version, update the version in Makefile `deps` target
+version=0.19.0
 profile=conventional
 break-separators=before
 dock-collection-brackets=false


### PR DESCRIPTION
It currently fails to parse the `ocamlformat` version due to the comment added in https://github.com/ocamllabs/vscode-ocaml-platform/pull/746