### PR TITLE
minify release bundle even more

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -37,8 +37,7 @@ build-release:
 		--outdir=dist \
 		--platform=node \
 		--target=es6 \
-		--minify-whitespace \
-		--minify-syntax \
+		--minify \
 		--sourcemap \
 		--sources-content=false
 


### PR DESCRIPTION
The `--minify` option does [3 things](https://esbuild.github.io/api/#minify): `--minify-whitespace`, `--minify-syntax` and `--minify-identifiers`. When `esbuild` was introduced in https://github.com/ocamllabs/vscode-ocaml-platform/pull/591, the `--minify-identifiers` was not used because [it broke the extension](https://github.com/ocamllabs/vscode-ocaml-platform/pull/591#discussion_r619703197).

I tried to re-introduce that flag it seems to work fine now.

Before: ` Packaged: ocaml-platform.vsix (76 files, 1.24MB)`
After: `Packaged: ocaml-platform.vsix (76 files, 1.06MB)`