### PR TITLE
Fix jump to hole on destruct/construct to jump only within new generated text

### DIFF
--- a/src-bindings/vscode_languageclient/vscode_languageclient.ml
+++ b/src-bindings/vscode_languageclient/vscode_languageclient.ml
@@ -143,6 +143,38 @@ end
 
 module ServerOptions = Executable
 
+module ClientCapabilities = struct
+  include Interface.Make ()
+
+  include
+    [%js:
+    val experimental : t -> Jsonoo.t or_undefined [@@js.get]
+
+    val set_experimental : t -> Jsonoo.t or_undefined -> unit [@@js.set]]
+end
+
+module InitializeParams = struct
+  include Interface.Make ()
+end
+
+module StaticFeature = struct
+  include Interface.Make ()
+
+  include
+    [%js:
+    val make :
+         ?fillInitializeParams:(params:InitializeParams.t -> unit)
+      -> fillClientCapabilities:(capabilities:ClientCapabilities.t -> unit)
+      -> initialize:
+           (   capabilities:ServerCapabilities.t
+            -> documentSelector:DocumentSelector.t or_undefined
+            -> unit)
+      -> dispose:(unit -> unit)
+      -> unit
+      -> t
+      [@@js.builder]]
+end
+
 module LanguageClient = struct
   include Class.Make ()
 
@@ -173,7 +205,9 @@ module LanguageClient = struct
       -> ?token:Vscode.CancellationToken.t
       -> unit
       -> Jsonoo.t Promise.t
-      [@@js.call]]
+      [@@js.call]
+
+    val registerFeature : t -> feature:StaticFeature.t -> unit [@@js.call]]
 
   let ready_initialize_result t =
     let open Promise.Syntax in

--- a/src-bindings/vscode_languageclient/vscode_languageclient.mli
+++ b/src-bindings/vscode_languageclient/vscode_languageclient.mli
@@ -119,6 +119,33 @@ end
 
 module ServerOptions = Executable
 
+module InitializeParams : sig
+  include Js.T
+end
+
+module ClientCapabilities : sig
+  include Js.T
+
+  val experimental : t -> Jsonoo.t or_undefined
+
+  val set_experimental : t -> Jsonoo.t or_undefined -> unit
+end
+
+module StaticFeature : sig
+  include Js.T
+
+  val make :
+       ?fillInitializeParams:(params:InitializeParams.t -> unit)
+    -> fillClientCapabilities:(capabilities:ClientCapabilities.t -> unit)
+    -> initialize:
+         (   capabilities:ServerCapabilities.t
+          -> documentSelector:DocumentSelector.t or_undefined
+          -> unit)
+    -> dispose:(unit -> unit)
+    -> unit
+    -> t
+end
+
 module LanguageClient : sig
   include Js.T
 
@@ -148,4 +175,6 @@ module LanguageClient : sig
     -> ?token:Vscode.CancellationToken.t
     -> unit
     -> Jsonoo.t Promise.t
+
+  val registerFeature : t -> feature:StaticFeature.t -> unit
 end

--- a/src/extension_commands.ml
+++ b/src/extension_commands.ml
@@ -212,7 +212,7 @@ end = struct
         let uri = TextDocument.uri doc in
         let (_ : unit Promise.t) =
           let+ holes =
-            Custom_requests.Typed_holes.send_request client ~for_doc:uri
+            Custom_requests.send_request client Custom_requests.typedHoles uri
           in
           jump ~cmd_args:args text_editor
             ~sorted_holes:(List.sort holes ~compare:Range.compare)

--- a/src/extension_instance.ml
+++ b/src/extension_instance.ml
@@ -79,6 +79,19 @@ end = struct
            "Sandbox initialization failed: `ocaml-lsp-server` is not installed \
             in the current sandbox.")
 
+  let client_capabilities =
+    let fillClientCapabilities ~capabilities =
+      let experimental =
+        Jsonoo.Encode.(object_ [ ("jumpToNextHole", bool true) ])
+      in
+      LanguageClient.ClientCapabilities.set_experimental capabilities
+        (Some experimental)
+    in
+    let initialize ~capabilities:_ ~documentSelector:_ = () in
+    let dispose () = () in
+    LanguageClient.StaticFeature.make ~fillClientCapabilities ~initialize
+      ~dispose ()
+
   let start_language_server t =
     stop_server t;
     let open Promise.Syntax in
@@ -91,6 +104,7 @@ end = struct
         LanguageClient.make ~id:"ocaml" ~name:"OCaml Platform VS Code extension"
           ~serverOptions ~clientOptions ()
       in
+      LanguageClient.registerFeature client ~feature:client_capabilities;
       LanguageClient.start client;
       let open Promise.Syntax in
       let+ initialize_result = LanguageClient.ready_initialize_result client in


### PR DESCRIPTION
comes in pair with https://github.com/ocaml/ocaml-lsp/pull/559

Some thoughts:

1. I think this was one of the last things I wanted to do before cutting a release for the extension. 
1.1. I think some testing would be nice, but few people use the master version, so we can release and then release again if there're problems reported
1.2. Could someone shed some light on how to cut a release? 

2. It would be nice to have a ppx to generate `of_/to_json` code. Doing that manually is wrong in many ways. It would be nice to reuse yojson ppxes but then we need to switch to using yojson ?