### PR TITLE
support cm* files

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -10,7 +10,7 @@
   Currently supported artifacts include `.cmi`, `.cmt(i)`, `.cmo`, `.cma`,
   `.cmx(a/s)`, and `.bc` files.
 
-  To learn more about these files: https://ocaml.org/manual/comp.html
+  To learn more about these files, see: https://ocaml.org/manual/comp.html
 
 - Warn if the extension sees not the latest OCaml-LSP version compatible with
   the OCaml distribution installed in the current sandbox.

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -4,8 +4,13 @@
 
 - Fix the detection of opam's root directory when no switch is detected (#831)
 
-- Support for opening `.cmi`, `.cmt`, `cmti`, `.cmo`, `.cma`, `.cmx`, `.cmxa`,
-  `.cmxs` and `.bc` files. (#798)
+- Add support for opening compilation artifacts in human-readable form in the
+  editor (#798)
+
+  Currently supported artifacts include `.cmi`, `.cmt(i)`, `.cmo`, `.cma`,
+  `.cmx(a/s)`, and `.bc` files.
+
+  To learn more about these files: https://ocaml.org/manual/comp.html
 
 - Warn if the extension sees not the latest OCaml-LSP version compatible with
   the OCaml distribution installed in the current sandbox.

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -4,6 +4,9 @@
 
 - Fix the detection of opam's root directory when no switch is detected (#831)
 
+- Support for opening `.cmi`, `.cmt`, `cmti`, `.cmo`, `.cma`, `.cmx`, `.cmxa`,
+  `.cmxs` and `.bc` files. (#798)
+
 - Warn if the extension sees not the latest OCaml-LSP version compatible with
   the OCaml distribution installed in the current sandbox.
 

--- a/package.json
+++ b/package.json
@@ -965,6 +965,18 @@
             "filenamePattern": "*.cmo"
           },
           {
+            "filenamePattern": "*.cma"
+          },
+          {
+            "filenamePattern": "*.cmx"
+          },
+          {
+            "filenamePattern": "*.cmxa"
+          },
+          {
+            "filenamePattern": "*.cmxs"
+          },
+          {
             "filenamePattern": "*.bc"
           }
         ]

--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
     "onCommand:ocaml.show-preprocessed-document",
     "onCommand:ocaml.open-pp-editor-and-ast-explorer",
     "onCustomEditor:ast-editor",
+    "onCustomEditor:cm-files-editor",
     "workspaceContains:**/dune-workspace",
     "workspaceContains:**/dune",
     "workspaceContains:**/dune-project",
@@ -944,6 +945,27 @@
           },
           {
             "filenamePattern": "*.mli"
+          }
+        ]
+      },
+      {
+        "viewType": "cm-files-editor",
+        "displayName": "Cm files preview",
+        "selector": [
+          {
+            "filenamePattern": "*.cmi"
+          },
+          {
+            "filenamePattern": "*.cmt"
+          },
+          {
+            "filenamePattern": "*.cmti"
+          },
+          {
+            "filenamePattern": "*.cmo"
+          },
+          {
+            "filenamePattern": "*.bc"
           }
         ]
       }

--- a/package.json
+++ b/package.json
@@ -950,7 +950,7 @@
       },
       {
         "viewType": "cm-files-editor",
-        "displayName": "Cm files preview",
+        "displayName": "OCaml Compilation Artifact Viewer",
         "selector": [
           {
             "filenamePattern": "*.cmi"

--- a/src-bindings/vscode/vscode.ml
+++ b/src-bindings/vscode/vscode.ml
@@ -2902,7 +2902,7 @@ end
 module CustomReadonlyEditorProvider = struct
   include Interface.Generic (Ojs) ()
 
-  module Make (T : module type of CustomDocument) = struct
+  module Make (T : CustomDocument.T) = struct
     type t = T.t generic [@@js]
 
     include

--- a/src-bindings/vscode/vscode.ml
+++ b/src-bindings/vscode/vscode.ml
@@ -2334,8 +2334,6 @@ module CustomDocument = struct
     val uri : t -> Uri.t
 
     val dispose : t -> unit
-
-    val create : uri:Uri.t -> dispose:(unit -> unit) -> t
   end
 
   include Interface.Make ()

--- a/src-bindings/vscode/vscode.ml
+++ b/src-bindings/vscode/vscode.ml
@@ -2328,6 +2328,20 @@ module TreeItemCollapsibleState = struct
 end
 
 module CustomDocument = struct
+  module type T = sig
+    type t
+
+    val t_of_js : Ojs.t -> t
+
+    val t_to_js : t -> Ojs.t
+
+    val uri : t -> Uri.t
+
+    val dispose : t -> unit
+
+    val create : uri:Uri.t -> dispose:(unit -> unit) -> t
+  end
+
   include Interface.Make ()
 
   include
@@ -2888,7 +2902,7 @@ end
 module CustomReadonlyEditorProvider = struct
   include Interface.Generic (Ojs) ()
 
-  module Make (T : Js.T) = struct
+  module Make (T : module type of CustomDocument) = struct
     type t = T.t generic [@@js]
 
     include
@@ -3152,7 +3166,7 @@ module Window = struct
     [%js.to: TreeView.t] (createTreeView ~viewId ~options)
 
   let registerCustomReadonlyEditorProvider (type a)
-      (module T : Js.T with type t = a) ~(viewType : string)
+      (module T : CustomDocument.T with type t = a) ~(viewType : string)
       ~(provider : a CustomReadonlyEditorProvider.t)
       ?(options : RegisterCustomEditorProviderOptions.t or_undefined) () :
       Disposable.t =

--- a/src-bindings/vscode/vscode.ml
+++ b/src-bindings/vscode/vscode.ml
@@ -2218,9 +2218,9 @@ end
 module FileSystemWatcher = struct
   include Interface.Make ()
 
-  include
-    [%js:
-    val onDidChange : t -> callback:(Uri.t -> unit) -> Disposable.t [@@js.call]]
+  module OnDidChange = Event.Make (Uri)
+
+  include [%js: val onDidChange : t -> OnDidChange.t [@@js.get]]
 end
 
 module Workspace = struct

--- a/src-bindings/vscode/vscode.ml
+++ b/src-bindings/vscode/vscode.ml
@@ -2336,7 +2336,7 @@ module CustomDocument = struct
 
     val dispose : t -> unit [@@js.call]
 
-    val create : uri:Uri.t -> dispose:(unit -> unit) -> unit -> t [@@js.builder]]
+    val create : uri:Uri.t -> dispose:(unit -> unit) -> t [@@js.builder]]
 end
 
 module TreeItemLabel = struct

--- a/src-bindings/vscode/vscode.ml
+++ b/src-bindings/vscode/vscode.ml
@@ -2330,27 +2330,13 @@ end
 module CustomDocument = struct
   include Interface.Make ()
 
-  module OnDidChange = Event.Make (Js.Unit)
-  module OnDidDispose = Event.Make (Js.Unit)
-
   include
     [%js:
     val uri : t -> Uri.t [@@js.get]
 
     val dispose : t -> unit [@@js.call]
 
-    val onDidChange : t -> OnDidChange.t [@@js.get]
-
-    val onDidDispose : t -> OnDidDispose.t [@@js.get]
-
-    val create :
-         uri:Uri.t
-      -> ?onDidChange:OnDidChange.t
-      -> ?onDidDispose:OnDidDispose.t
-      -> dispose:(unit -> unit)
-      -> unit
-      -> t
-      [@@js.builder]]
+    val create : uri:Uri.t -> dispose:(unit -> unit) -> unit -> t [@@js.builder]]
 end
 
 module TreeItemLabel = struct

--- a/src-bindings/vscode/vscode.ml
+++ b/src-bindings/vscode/vscode.ml
@@ -2329,11 +2329,7 @@ end
 
 module CustomDocument = struct
   module type T = sig
-    type t
-
-    val t_of_js : Ojs.t -> t
-
-    val t_to_js : t -> Ojs.t
+    include Js.T
 
     val uri : t -> Uri.t
 

--- a/src-bindings/vscode/vscode.ml
+++ b/src-bindings/vscode/vscode.ml
@@ -2215,6 +2215,14 @@ module TextDocumentContentProvider = struct
       [@@js.builder]]
 end
 
+module FileSystemWatcher = struct
+  include Interface.Make ()
+
+  include
+    [%js:
+    val onDidChange : t -> callback:(Uri.t -> unit) -> Disposable.t [@@js.call]]
+end
+
 module Workspace = struct
   module OnDidChangeWorkspaceFolders = Event.Make (WorkspaceFolder)
   module OnDidOpenTextDocument = Event.Make (TextDocument)
@@ -2234,6 +2242,15 @@ module Workspace = struct
       [@@js.get "vscode.workspace.workspaceFolders"]
 
     val name : unit -> string or_undefined [@@js.get "vscode.workspace.name"]
+
+    val createFileSystemWatcher :
+         GlobPattern.t
+      -> ?ignoreCreateEvents:(bool[@js.default false])
+      -> ?ignoreChangeEvents:(bool[@js.default false])
+      -> ?ignoreDeleteEvents:(bool[@js.default false])
+      -> unit
+      -> FileSystemWatcher.t
+      [@@js.global "vscode.workspace.createFileSystemWatcher"]
 
     val workspaceFile : unit -> Uri.t or_undefined
       [@@js.get "vscode.workspace.workspaceFile"]
@@ -2308,6 +2325,32 @@ module TreeItemCollapsibleState = struct
     | Collapsed [@js 1]
     | Expanded [@js 2]
   [@@js.enum] [@@js]
+end
+
+module CustomDocument = struct
+  include Interface.Make ()
+
+  module OnDidChange = Event.Make (Js.Unit)
+  module OnDidDispose = Event.Make (Js.Unit)
+
+  include
+    [%js:
+    val uri : t -> Uri.t [@@js.get]
+
+    val dispose : t -> unit [@@js.call]
+
+    val onDidChange : t -> OnDidChange.t [@@js.get]
+
+    val onDidDispose : t -> OnDidDispose.t [@@js.get]
+
+    val create :
+         uri:Uri.t
+      -> ?onDidChange:OnDidChange.t
+      -> ?onDidDispose:OnDidDispose.t
+      -> dispose:(unit -> unit)
+      -> unit
+      -> t
+      [@@js.builder]]
 end
 
 module TreeItemLabel = struct
@@ -2850,6 +2893,63 @@ module CustomTextEditorProvider = struct
       [@@js.builder]]
 end
 
+module CustomDocumentOpenContext = struct
+  include Interface.Make ()
+
+  include [%js: val backupId : t -> string or_undefined [@@js.get]]
+end
+
+module CustomReadonlyEditorProvider = struct
+  include Interface.Generic (Ojs) ()
+
+  module Make (T : Js.T) = struct
+    type t = T.t generic [@@js]
+
+    include
+      [%js:
+      val openCustomDocument :
+           t
+        -> uri:Uri.t
+        -> openContext:CustomDocumentOpenContext.t
+        -> token:CancellationToken.t
+        -> T.t Promise.t
+        [@@js.call]
+
+      val resolveCustomEditor :
+           t
+        -> document:T.t
+        -> webviewPanel:WebviewPanel.t
+        -> token:CancellationToken.t
+        -> unit Promise.t
+        [@@js.call]
+
+      val create :
+           resolveCustomEditor:
+             (   document:T.t
+              -> webviewPanel:WebviewPanel.t
+              -> token:CancellationToken.t
+              -> unit Promise.t)
+        -> openCustomDocument:
+             (   uri:Uri.t
+              -> openContext:CustomDocumentOpenContext.t
+              -> token:CancellationToken.t
+              -> T.t Promise.t)
+        -> t
+        [@@js.builder]]
+  end
+end
+
+module RegisterCustomEditorProviderOptions = struct
+  include Interface.Make ()
+
+  include
+    [%js:
+    val supportsMultipleEditorsPerDocument : t -> bool or_undefined [@@js.get]
+
+    val create : ?supportsMultipleEditorsPerDocument:bool -> unit -> t
+      [@@js.builder]]
+end
+
 module Window = struct
   module OnDidChangeActiveTextEditor = Event.Make (TextEditor)
   module OnDidChangeVisibleTextEditors = Event.Make (Js.List (TextEditor))
@@ -2992,16 +3092,19 @@ module Window = struct
       -> WebviewPanel.t
       [@@js.global "vscode.window.createWebviewPanel"]
 
-    val registerCustomEditorProvider :
+    val registerCustomTextEditorProvider :
          viewType:string
-      -> provider:
-           ([ `CustomTextEditorProvider of CustomTextEditorProvider.t
-            | `CustomReadonlyEditorProvider of
-              CustomTextEditorProvider.t
-              (*TODO*)
-            | `CustomEditorProvider of CustomTextEditorProvider.t (*TODO*)
-            ]
-           [@js.union])
+      -> provider:CustomTextEditorProvider.t
+      -> ?options:RegisterCustomEditorProviderOptions.t
+      -> unit
+      -> Disposable.t
+      [@@js.global "vscode.window.registerCustomEditorProvider"]
+
+    val registerCustomReadonlyEditorProvider :
+         viewType:string
+      -> provider:Ojs.t
+      -> ?options:RegisterCustomEditorProviderOptions.t
+      -> unit
       -> Disposable.t
       [@@js.global "vscode.window.registerCustomEditorProvider"]]
 
@@ -3061,6 +3164,16 @@ module Window = struct
     let module TreeView = TreeView.Make (T) in
     let options = [%js.of: TreeViewOptions.t] options in
     [%js.to: TreeView.t] (createTreeView ~viewId ~options)
+
+  let registerCustomReadonlyEditorProvider (type a)
+      (module T : Js.T with type t = a) ~(viewType : string)
+      ~(provider : a CustomReadonlyEditorProvider.t)
+      ?(options : RegisterCustomEditorProviderOptions.t or_undefined) () :
+      Disposable.t =
+    let module CustomReadonlyEditorProvider =
+      CustomReadonlyEditorProvider.Make (T) in
+    let provider = [%js.of: CustomReadonlyEditorProvider.t] provider in
+    registerCustomReadonlyEditorProvider ~viewType ~provider ?options ()
 end
 
 module Commands = struct

--- a/src-bindings/vscode/vscode.mli
+++ b/src-bindings/vscode/vscode.mli
@@ -789,8 +789,6 @@ module CustomDocument : sig
     val uri : t -> Uri.t
 
     val dispose : t -> unit
-
-    val create : uri:Uri.t -> dispose:(unit -> unit) -> t
   end
 
   include Js.T

--- a/src-bindings/vscode/vscode.mli
+++ b/src-bindings/vscode/vscode.mli
@@ -789,17 +789,7 @@ module CustomDocument : sig
 
   val dispose : t -> unit
 
-  val onDidChange : t -> Js.Unit.t Event.t
-
-  val onDidDispose : t -> Js.Unit.t Event.t
-
-  val create :
-       uri:Uri.t
-    -> ?onDidChange:Js.Unit.t Event.t
-    -> ?onDidDispose:Js.Unit.t Event.t
-    -> dispose:(unit -> unit)
-    -> unit
-    -> t
+  val create : uri:Uri.t -> dispose:(unit -> unit) -> unit -> t
 end
 
 module QuickPickItem : sig

--- a/src-bindings/vscode/vscode.mli
+++ b/src-bindings/vscode/vscode.mli
@@ -782,6 +782,26 @@ module CancellationToken : sig
     -> t
 end
 
+module CustomDocument : sig
+  include Js.T
+
+  val uri : t -> Uri.t
+
+  val dispose : t -> unit
+
+  val onDidChange : t -> Js.Unit.t Event.t
+
+  val onDidDispose : t -> Js.Unit.t Event.t
+
+  val create :
+       uri:Uri.t
+    -> ?onDidChange:Js.Unit.t Event.t
+    -> ?onDidDispose:Js.Unit.t Event.t
+    -> dispose:(unit -> unit)
+    -> unit
+    -> t
+end
+
 module QuickPickItem : sig
   include Js.T
 
@@ -1702,10 +1722,24 @@ module TextDocumentContentProvider : sig
     -> t
 end
 
+module FileSystemWatcher : sig
+  include Js.T
+
+  val onDidChange : t -> callback:(Uri.t -> unit) -> Disposable.t
+end
+
 module Workspace : sig
   val workspaceFolders : unit -> WorkspaceFolder.t list
 
   val name : unit -> string option
+
+  val createFileSystemWatcher :
+       GlobPattern.t
+    -> ?ignoreCreateEvents:bool
+    -> ?ignoreChangeEvents:bool
+    -> ?ignoreDeleteEvents:bool
+    -> unit
+    -> FileSystemWatcher.t
 
   val workspaceFile : unit -> Uri.t option
 
@@ -2168,6 +2202,55 @@ module CustomTextEditorProvider : sig
     -> t
 end
 
+module CustomDocumentOpenContext : sig
+  include Js.T
+
+  val backupId : t -> string or_undefined
+end
+
+module CustomReadonlyEditorProvider : sig
+  type 'a t
+
+  module Make (T : Js.T) : sig
+    type nonrec t = T.t t
+
+    val openCustomDocument :
+         t
+      -> uri:Uri.t
+      -> openContext:CustomDocumentOpenContext.t
+      -> token:CancellationToken.t
+      -> T.t Promise.t
+
+    val resolveCustomEditor :
+         t
+      -> document:T.t
+      -> webviewPanel:WebviewPanel.t
+      -> token:CancellationToken.t
+      -> unit Promise.t
+
+    val create :
+         resolveCustomEditor:
+           (   document:T.t
+            -> webviewPanel:WebviewPanel.t
+            -> token:CancellationToken.t
+            -> unit Promise.t)
+      -> openCustomDocument:
+           (   uri:Uri.t
+            -> openContext:CustomDocumentOpenContext.t
+            -> token:CancellationToken.t
+            -> T.t Promise.t)
+      -> t
+  end
+end
+
+module RegisterCustomEditorProviderOptions : sig
+  include Js.T
+
+  val supportsMultipleEditorsPerDocument : t -> bool or_undefined
+
+  val create : ?supportsMultipleEditorsPerDocument:bool -> unit -> t
+end
+
 module Window : sig
   val activeTextEditor : unit -> TextEditor.t option
 
@@ -2278,13 +2361,19 @@ module Window : sig
     -> showOptions:ViewColumn.t
     -> WebviewPanel.t
 
-  val registerCustomEditorProvider :
+  val registerCustomTextEditorProvider :
        viewType:string
-    -> provider:
-         [ `CustomTextEditorProvider of CustomTextEditorProvider.t
-         | `CustomReadonlyEditorProvider of CustomTextEditorProvider.t (*TODO*)
-         | `CustomEditorProvider of CustomTextEditorProvider.t (*TODO*)
-         ]
+    -> provider:CustomTextEditorProvider.t
+    -> ?options:RegisterCustomEditorProviderOptions.t
+    -> unit
+    -> Disposable.t
+
+  val registerCustomReadonlyEditorProvider :
+       'a Js.t
+    -> viewType:string
+    -> provider:'a CustomReadonlyEditorProvider.t
+    -> ?options:RegisterCustomEditorProviderOptions.t
+    -> unit
     -> Disposable.t
 end
 

--- a/src-bindings/vscode/vscode.mli
+++ b/src-bindings/vscode/vscode.mli
@@ -2215,7 +2215,7 @@ end
 module CustomReadonlyEditorProvider : sig
   type 'a t
 
-  module Make (T : module type of CustomDocument) : sig
+  module Make (T : CustomDocument.T) : sig
     type nonrec t = T.t t
 
     val openCustomDocument :
@@ -2373,7 +2373,7 @@ module Window : sig
     -> Disposable.t
 
   val registerCustomReadonlyEditorProvider :
-       'a Js.t
+       (module CustomDocument.T with type t = 'a)
     -> viewType:string
     -> provider:'a CustomReadonlyEditorProvider.t
     -> ?options:RegisterCustomEditorProviderOptions.t

--- a/src-bindings/vscode/vscode.mli
+++ b/src-bindings/vscode/vscode.mli
@@ -789,7 +789,7 @@ module CustomDocument : sig
 
   val dispose : t -> unit
 
-  val create : uri:Uri.t -> dispose:(unit -> unit) -> unit -> t
+  val create : uri:Uri.t -> dispose:(unit -> unit) -> t
 end
 
 module QuickPickItem : sig

--- a/src-bindings/vscode/vscode.mli
+++ b/src-bindings/vscode/vscode.mli
@@ -791,8 +791,6 @@ module CustomDocument : sig
     val dispose : t -> unit
   end
 
-  include Js.T
-
   include T
 
   val create : uri:Uri.t -> dispose:(unit -> unit) -> t

--- a/src-bindings/vscode/vscode.mli
+++ b/src-bindings/vscode/vscode.mli
@@ -1725,7 +1725,7 @@ end
 module FileSystemWatcher : sig
   include Js.T
 
-  val onDidChange : t -> callback:(Uri.t -> unit) -> Disposable.t
+  val onDidChange : t -> Uri.t Event.t
 end
 
 module Workspace : sig

--- a/src-bindings/vscode/vscode.mli
+++ b/src-bindings/vscode/vscode.mli
@@ -783,6 +783,20 @@ module CancellationToken : sig
 end
 
 module CustomDocument : sig
+  module type T = sig
+    type t
+
+    val t_of_js : Ojs.t -> t
+
+    val t_to_js : t -> Ojs.t
+
+    val uri : t -> Uri.t
+
+    val dispose : t -> unit
+
+    val create : uri:Uri.t -> dispose:(unit -> unit) -> t
+  end
+
   include Js.T
 
   val uri : t -> Uri.t
@@ -2201,7 +2215,7 @@ end
 module CustomReadonlyEditorProvider : sig
   type 'a t
 
-  module Make (T : Js.T) : sig
+  module Make (T : module type of CustomDocument) : sig
     type nonrec t = T.t t
 
     val openCustomDocument :

--- a/src-bindings/vscode/vscode.mli
+++ b/src-bindings/vscode/vscode.mli
@@ -784,11 +784,7 @@ end
 
 module CustomDocument : sig
   module type T = sig
-    type t
-
-    val t_of_js : Ojs.t -> t
-
-    val t_to_js : t -> Ojs.t
+    include Js.T
 
     val uri : t -> Uri.t
 

--- a/src-bindings/vscode/vscode.mli
+++ b/src-bindings/vscode/vscode.mli
@@ -793,9 +793,7 @@ module CustomDocument : sig
 
   include Js.T
 
-  val uri : t -> Uri.t
-
-  val dispose : t -> unit
+  include T
 
   val create : uri:Uri.t -> dispose:(unit -> unit) -> t
 end

--- a/src/ast_editor.ml
+++ b/src/ast_editor.ml
@@ -599,13 +599,12 @@ let register extension instance =
   Vscode.ExtensionContext.subscribe extension ~disposable;
   (*Register custom editor provider that is the AST explorer. *)
   let editorProvider =
-    `CustomEditorProvider
-      (CustomTextEditorProvider.create
-         ~resolveCustomTextEditor:(resolveCustomTextEditor instance))
+    CustomTextEditorProvider.create
+      ~resolveCustomTextEditor:(resolveCustomTextEditor instance)
   in
   let disposable =
-    Vscode.Window.registerCustomEditorProvider ~viewType:"ast-editor"
-      ~provider:editorProvider
+    Vscode.Window.registerCustomTextEditorProvider ~viewType:"ast-editor"
+      ~provider:editorProvider ()
   in
   Vscode.ExtensionContext.subscribe extension ~disposable;
   (*Register listener that monitors closing documents. *)

--- a/src/cm_editor.ml
+++ b/src/cm_editor.ml
@@ -6,8 +6,6 @@ module Cm_document : sig
 
   val content : t -> (string, string) result Promise.t
 
-  val create : uri:Uri.t -> dispose:(unit -> unit) -> t
-
   val onDidChange : t -> Js.Unit.t Event.t
 end = struct
   include CustomDocument

--- a/src/cm_editor.ml
+++ b/src/cm_editor.ml
@@ -1,0 +1,100 @@
+open Import
+open Interop
+
+module Cm_document : sig
+  include module type of CustomDocument
+
+  val content : t -> (string, string) result Promise.t
+
+  val create : uri:Uri.t -> t
+end = struct
+  include CustomDocument
+
+  let content t =
+    let uri = uri t in
+    let file_path = Uri.fsPath uri in
+    let bin = Path.of_string "ocamlobjinfo" in
+    Cmd.(output (Spawn { bin; args = [ file_path ] }))
+
+  let create ~(uri : Uri.t) =
+    let module EventEmitter = EventEmitter.Make (Js.Unit) in
+    let onDidChange_event_emitter = EventEmitter.make () in
+    let onDidChange_event = EventEmitter.event onDidChange_event_emitter in
+    let onDidDispose_event_emitter = EventEmitter.make () in
+    let onDidDispose_event = EventEmitter.event onDidDispose_event_emitter in
+    let watcher =
+      Workspace.createFileSystemWatcher
+        (`String (Uri.fsPath uri))
+        ~ignoreCreateEvents:true ~ignoreDeleteEvents:true ()
+    in
+    let disposable =
+      FileSystemWatcher.onDidChange watcher ~callback:(fun _ ->
+          EventEmitter.fire onDidChange_event_emitter ())
+    in
+    create ~uri ~onDidChange:onDidChange_event ~onDidDispose:onDidDispose_event
+      ~dispose:(fun () ->
+        EventEmitter.fire onDidDispose_event_emitter ();
+        Disposable.dispose disposable)
+      ()
+end
+
+let resolveCustomEditor _instance ~document ~webviewPanel ~token:_ :
+    unit Promise.t =
+  let open Promise.Syntax in
+  let update_content document =
+    let+ content = Cm_document.content document in
+    match content with
+    | Ok file_content ->
+      let webview = WebviewPanel.webview webviewPanel in
+      WebView.set_html webview (Printf.sprintf "<pre>%s</pre>" file_content)
+    | Error e ->
+      let uri = Cm_document.uri document in
+      let () = log "Error while trying to read content from file: %s" e in
+      let path = Uri.path uri in
+      let (_ : 'a option Promise.t) =
+        Window.showErrorMessage
+          ~message:
+            (Printf.sprintf "Error while trying to read content from %s."
+               (Node.Path.basename path))
+          ()
+      in
+      ()
+  in
+  let disposable =
+    Cm_document.onDidChange document
+      ~listener:(fun () ->
+        let (_ : unit Promise.t) = update_content document in
+        ())
+      ()
+  in
+  let (_ : Disposable.t) =
+    WebviewPanel.onDidDispose webviewPanel
+      ~listener:(fun () -> Disposable.dispose disposable)
+      ()
+  in
+  update_content document
+
+let openCustomDocument _instance ~(uri : Uri.t) ~openContext:_ ~token:_ :
+    Cm_document.t Promise.t =
+  let document = Cm_document.create ~uri in
+  Promise.resolve document
+
+let register (extension : ExtensionContext.t) (instance : Extension_instance.t)
+    =
+  let module CustomReadonlyEditorProvider =
+    CustomReadonlyEditorProvider.Make (Cm_document) in
+  let editorProvider =
+    CustomReadonlyEditorProvider.create
+      ~resolveCustomEditor:(resolveCustomEditor instance)
+      ~openCustomDocument:(openCustomDocument instance)
+  in
+  let disposable =
+    Vscode.Window.registerCustomReadonlyEditorProvider
+      (module Cm_document)
+      ~viewType:"cm-files-editor" ~provider:editorProvider
+      ~options:
+        (Vscode.RegisterCustomEditorProviderOptions.create
+           ~supportsMultipleEditorsPerDocument:true ())
+      ()
+  in
+  Vscode.ExtensionContext.subscribe extension ~disposable

--- a/src/cm_editor.ml
+++ b/src/cm_editor.ml
@@ -45,8 +45,7 @@ end = struct
         Disposable.dispose disposable)
 end
 
-let resolveCustomEditor _instance ~document ~webviewPanel ~token:_ :
-    unit Promise.t =
+let resolveCustomEditor ~document ~webviewPanel ~token:_ : unit Promise.t =
   let open Promise.Syntax in
   let update_content document =
     let+ content = Cm_document.content document in
@@ -81,19 +80,16 @@ let resolveCustomEditor _instance ~document ~webviewPanel ~token:_ :
   in
   update_content document
 
-let openCustomDocument _instance ~(uri : Uri.t) ~openContext:_ ~token:_ :
+let openCustomDocument ~(uri : Uri.t) ~openContext:_ ~token:_ :
     Cm_document.t Promise.t =
   let document = Cm_document.create ~uri in
   Promise.resolve document
 
-let register (extension : ExtensionContext.t) (instance : Extension_instance.t)
-    =
+let register (extension : ExtensionContext.t) =
   let module CustomReadonlyEditorProvider =
     CustomReadonlyEditorProvider.Make (Cm_document) in
   let editorProvider =
-    CustomReadonlyEditorProvider.create
-      ~resolveCustomEditor:(resolveCustomEditor instance)
-      ~openCustomDocument:(openCustomDocument instance)
+    CustomReadonlyEditorProvider.create ~resolveCustomEditor ~openCustomDocument
   in
   let disposable =
     Vscode.Window.registerCustomReadonlyEditorProvider

--- a/src/cm_editor.ml
+++ b/src/cm_editor.ml
@@ -2,7 +2,7 @@ open Import
 open Interop
 
 module Cm_document : sig
-  include module type of CustomDocument
+  include CustomDocument.T
 
   val content : t -> (string, string) result Promise.t
 

--- a/src/cm_editor.ml
+++ b/src/cm_editor.ml
@@ -60,13 +60,13 @@ let resolveCustomEditor instance ~document ~webviewPanel ~token:_ :
       WebView.set_html webview (Printf.sprintf "<pre>%s</pre>" file_content)
     | Error e ->
       let uri = Cm_document.uri document in
-      let () = log "Error while trying to read content from file: %s" e in
       let path = Uri.path uri in
+      let file_name = Node.Path.basename path in
       let (_ : 'a option Promise.t) =
         Window.showErrorMessage
           ~message:
-            (Printf.sprintf "Error while trying to read content from %s."
-               (Node.Path.basename path))
+            (Printf.sprintf
+               "Error while trying to read content from %s file. %s" file_name e)
           ()
       in
       ()
@@ -95,7 +95,9 @@ let register (extension : ExtensionContext.t) (instance : Extension_instance.t)
   let module CustomReadonlyEditorProvider =
     CustomReadonlyEditorProvider.Make (Cm_document) in
   let editorProvider =
-    CustomReadonlyEditorProvider.create ~resolveCustomEditor:(resolveCustomEditor instance) ~openCustomDocument
+    CustomReadonlyEditorProvider.create
+      ~resolveCustomEditor:(resolveCustomEditor instance)
+      ~openCustomDocument
   in
   let disposable =
     Vscode.Window.registerCustomReadonlyEditorProvider

--- a/src/cm_editor.ml
+++ b/src/cm_editor.ml
@@ -28,8 +28,9 @@ end = struct
         ~ignoreCreateEvents:true ~ignoreDeleteEvents:true ()
     in
     let disposable =
-      FileSystemWatcher.onDidChange watcher ~callback:(fun _ ->
-          EventEmitter.fire onDidChange_event_emitter ())
+      FileSystemWatcher.onDidChange watcher
+        ~listener:(fun _ -> EventEmitter.fire onDidChange_event_emitter ())
+        ()
     in
     create ~uri ~onDidChange:onDidChange_event ~onDidDispose:onDidDispose_event
       ~dispose:(fun () ->

--- a/src/cm_editor.ml
+++ b/src/cm_editor.ml
@@ -18,11 +18,7 @@ end = struct
     val onDidChange : t -> OnDidChange.t [@@js.get]
 
     val create :
-         uri:Uri.t
-      -> ?onDidChange:OnDidChange.t
-      -> dispose:(unit -> unit)
-      -> unit
-      -> t
+      uri:Uri.t -> onDidChange:OnDidChange.t -> dispose:(unit -> unit) -> t
       [@@js.builder]]
 
   let content t =
@@ -45,9 +41,8 @@ end = struct
         ~listener:(fun _ -> EventEmitter.fire onDidChange_event_emitter ())
         ()
     in
-    create ~uri ~onDidChange:onDidChange_event
-      ~dispose:(fun () -> Disposable.dispose disposable)
-      ()
+    create ~uri ~onDidChange:onDidChange_event ~dispose:(fun () ->
+        Disposable.dispose disposable)
 end
 
 let resolveCustomEditor _instance ~document ~webviewPanel ~token:_ :

--- a/src/cm_editor.ml
+++ b/src/cm_editor.ml
@@ -7,6 +7,8 @@ module Cm_document : sig
   val content : t -> (string, string) result Promise.t
 
   val onDidChange : t -> Js.Unit.t Event.t
+
+  val create : uri:Uri.t -> t
 end = struct
   include CustomDocument
   module OnDidChange = Event.Make (Js.Unit)
@@ -29,7 +31,7 @@ end = struct
     let bin = Path.of_string "ocamlobjinfo" in
     Cmd.(output (Spawn { bin; args = [ file_path ] }))
 
-  let create ~(uri : Uri.t) ~dispose =
+  let create ~(uri : Uri.t) =
     let module EventEmitter = EventEmitter.Make (Js.Unit) in
     let onDidChange_event_emitter = EventEmitter.make () in
     let onDidChange_event = EventEmitter.event onDidChange_event_emitter in
@@ -44,9 +46,7 @@ end = struct
         ()
     in
     create ~uri ~onDidChange:onDidChange_event
-      ~dispose:(fun () ->
-        Disposable.dispose disposable;
-        dispose ())
+      ~dispose:(fun () -> Disposable.dispose disposable)
       ()
 end
 
@@ -88,7 +88,7 @@ let resolveCustomEditor _instance ~document ~webviewPanel ~token:_ :
 
 let openCustomDocument _instance ~(uri : Uri.t) ~openContext:_ ~token:_ :
     Cm_document.t Promise.t =
-  let document = Cm_document.create ~uri ~dispose:(fun () -> ()) in
+  let document = Cm_document.create ~uri in
   Promise.resolve document
 
 let register (extension : ExtensionContext.t) (instance : Extension_instance.t)

--- a/src/cm_editor.mli
+++ b/src/cm_editor.mli
@@ -1,1 +1,1 @@
-val register : Vscode.ExtensionContext.t -> unit
+val register : Vscode.ExtensionContext.t -> Extension_instance.t -> unit

--- a/src/cm_editor.mli
+++ b/src/cm_editor.mli
@@ -1,0 +1,1 @@
+val register : Vscode.ExtensionContext.t -> Extension_instance.t -> unit

--- a/src/cm_editor.mli
+++ b/src/cm_editor.mli
@@ -1,1 +1,1 @@
-val register : Vscode.ExtensionContext.t -> Extension_instance.t -> unit
+val register : Vscode.ExtensionContext.t -> unit

--- a/src/dune
+++ b/src/dune
@@ -1,8 +1,20 @@
 (executable
  (name vscode_ocaml_platform)
- (libraries base gen_js_api js_of_ocaml jsonoo node ocaml-version
-   opam-file-format promise_jsoo vscode vscode_languageclient ppxlib
-   ppx_tools)
+ (preprocess
+  (pps gen_js_api.ppx))
+ (libraries
+  base
+  gen_js_api
+  js_of_ocaml
+  jsonoo
+  node
+  ocaml-version
+  opam-file-format
+  promise_jsoo
+  vscode
+  vscode_languageclient
+  ppxlib
+  ppx_tools)
  (modes js)
  (js_of_ocaml
   (flags --source-map --pretty)))

--- a/src/dune
+++ b/src/dune
@@ -2,19 +2,9 @@
  (name vscode_ocaml_platform)
  (preprocess
   (pps gen_js_api.ppx))
- (libraries
-  base
-  gen_js_api
-  js_of_ocaml
-  jsonoo
-  node
-  ocaml-version
-  opam-file-format
-  promise_jsoo
-  vscode
-  vscode_languageclient
-  ppxlib
-  ppx_tools)
+ (libraries base gen_js_api js_of_ocaml jsonoo node ocaml-version
+   opam-file-format promise_jsoo vscode vscode_languageclient ppxlib
+   ppx_tools)
  (modes js)
  (js_of_ocaml
   (flags --source-map --pretty)))

--- a/src/vscode_ocaml_platform.ml
+++ b/src/vscode_ocaml_platform.ml
@@ -35,7 +35,7 @@ let activate (extension : ExtensionContext.t) =
   Treeview_commands.register extension;
   Treeview_help.register extension;
   Ast_editor.register extension instance;
-  Cm_editor.register extension instance;
+  Cm_editor.register extension;
   Repl.register extension instance;
   let sandbox_opt = Sandbox.of_settings_or_detect () in
   let (_ : unit Promise.t) =

--- a/src/vscode_ocaml_platform.ml
+++ b/src/vscode_ocaml_platform.ml
@@ -35,7 +35,7 @@ let activate (extension : ExtensionContext.t) =
   Treeview_commands.register extension;
   Treeview_help.register extension;
   Ast_editor.register extension instance;
-  Cm_editor.register extension;
+  Cm_editor.register extension instance;
   Repl.register extension instance;
   let sandbox_opt = Sandbox.of_settings_or_detect () in
   let (_ : unit Promise.t) =

--- a/src/vscode_ocaml_platform.ml
+++ b/src/vscode_ocaml_platform.ml
@@ -35,6 +35,7 @@ let activate (extension : ExtensionContext.t) =
   Treeview_commands.register extension;
   Treeview_help.register extension;
   Ast_editor.register extension instance;
+  Cm_editor.register extension instance;
   Repl.register extension instance;
   let sandbox_opt = Sandbox.of_settings_or_detect () in
   let (_ : unit Promise.t) =


### PR DESCRIPTION


This PR adds a new custom editor that shows info about `.cm(t, i, ti, o)` and `.bc` files. It uses the `ocamlobjinfo` behind the scene.

I didn't test it with `.bc` files because I don't know how to generate these files 😅 

Question: it looks like `ocamlobjinfo` also supports `.cmx`, `.cmxa`, `.cma`, `.cmxs`. Should we also add support for them?


Partially implements #505 