### PR TITLE
Update instructions surrounding ReasonML/OCaml + Rescript/Bucklescript Syntax Support.

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,8 +119,8 @@ use [rescript-vscode](https://github.com/rescript-lang/rescript-vscode) instead.
 If you're looking for a way to use OCaml or ReasonML syntax in a ReScript
 project, it is no longer supported by this extension.
 
-If you need to compile existing OCaml or ReasonML syntax to JS and use
-ocaml-lsp-server, you can use [Melange](https://github.com/melange-re/melange):
+If you need to compile existing OCaml or ReasonML syntax to JS and use this
+extension, you can use [Melange](https://github.com/melange-re/melange):
 
 1. Install esy
 
@@ -130,7 +130,7 @@ npm install esy --global
 
 2. You can use the
    [Melange basic template](https://github.com/melange-re/melange-basic-template)
-   to add OCaml LSP support. . Then modify esy.json to pin ocaml-lsp-server to
+   to add OCaml LSP support. Then modify esy.json to pin ocaml-lsp-server to
    version 1.8.3 due to lack of Merlin support in newer versions.
 
 ```json

--- a/README.md
+++ b/README.md
@@ -117,8 +117,10 @@ The new ReScript syntax (`res` and `resi` files) is not supported, you should
 use [rescript-vscode](https://github.com/rescript-lang/rescript-vscode) instead.
 
 If you're looking for a way to use OCaml or ReasonML syntax in a ReScript
-project, you'll need to install `ocaml-lsp` in your environment. We recommend
-using Esy for this:
+project, it is no longer supported by this extension.
+
+If you need to compile existing OCaml or ReasonML syntax to JS and use
+ocaml-lsp-server, you can use [Melange](https://github.com/melange-re/melange):
 
 1. Install esy
 
@@ -126,15 +128,15 @@ using Esy for this:
 npm install esy --global
 ```
 
-2. Add `esy.json` to the project root with following content:
+2. You can use the
+   [Melange basic template](https://github.com/melange-re/melange-basic-template)
+   to add OCaml LSP support. . Then modify esy.json to pin ocaml-lsp-server to
+   version 1.8.3 due to lack of Merlin support in newer versions.
 
 ```json
 {
   "dependencies": {
-    "@opam/ocaml-lsp-server": "*",
-    "@opam/ocamlfind-secondary": "*",
-    "@opam/reason": "*",
-    "ocaml": "4.6.x"
+    "@opam/ocaml-lsp-server": "1.8.3"
   }
 }
 ```


### PR DESCRIPTION
There is a section in the readme referencing using ReasonML/Ocaml syntax in ReScript. I was told that specific use case is no longer supported and it could be helpful for the (few) users still stuck doing that trying to migrate off reason-language-server. I also added a workaround using Melange which allows usage of ocaml-lsp-server while still compiling to JS. The wording around it was carefully chosen to try to avoid any confusion/conflict between Rescript and Melange.