### PR TITLE
Unify and improve general dune syntax

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Change Log
 
+## Unreleased
+
+- Improve dune variable syntax highlighting. Add highlighting for `env` and
+  `bin-available` variables. (#872)
+
 ## 1.9.1
 
 - Make the check for out of date ocamllsp more conservative. It will no longer

--- a/syntaxes/dune-project.json
+++ b/syntaxes/dune-project.json
@@ -2,7 +2,7 @@
   "name": "dune-project",
   "scopeName": "source.dune-project",
   "fileTypes": ["dune-project"],
-  "patterns": [{ "include": "#stanzas" }, { "include": "#general" }],
+  "patterns": [{ "include": "#stanzas" }, { "include": "source.dune#general" }],
   "repository": {
     "stanzas": {
       "patterns": [
@@ -14,7 +14,7 @@
             "1": { "name": "keyword.language.dune-project" },
             "2": { "name": "keyword.language.dune-project" }
           },
-          "patterns": [{ "include": "#general" }]
+          "patterns": [{ "include": "source.dune#general" }]
         },
 
         {
@@ -25,7 +25,7 @@
             "1": { "name": "keyword.language.dune-project" }
           },
           "contentName": "variable.other.declaration.dune-project",
-          "patterns": [{ "include": "#general" }]
+          "patterns": [{ "include": "source.dune#general" }]
         },
 
         {
@@ -36,7 +36,7 @@
             "1": { "name": "keyword.language.dune-project" }
           },
           "contentName": "constant.language.dune-project",
-          "patterns": [{ "include": "#general" }]
+          "patterns": [{ "include": "source.dune#general" }]
         },
 
         {
@@ -46,7 +46,7 @@
           "beginCaptures": {
             "1": { "name": "keyword.language.dune-project" }
           },
-          "patterns": [{ "include": "#general" }]
+          "patterns": [{ "include": "source.dune#general" }]
         },
 
         {
@@ -56,7 +56,7 @@
           "beginCaptures": {
             "1": { "name": "keyword.language.dune-project" }
           },
-          "patterns": [{ "include": "#general" }]
+          "patterns": [{ "include": "source.dune#general" }]
         },
 
         {
@@ -83,7 +83,7 @@
                 "1": { "name": "keyword.language.dune-project" }
               },
               "contentName": "variable.other.declaration.dune-project",
-              "patterns": [{ "include": "#general" }]
+              "patterns": [{ "include": "source.dune#general" }]
             },
 
             {
@@ -101,12 +101,12 @@
                   "beginCaptures": {
                     "1": { "name": "keyword.language.dune-project" }
                   },
-                  "patterns": [{ "include": "#general" }]
+                  "patterns": [{ "include": "source.dune#general" }]
                 }
               ]
             },
 
-            { "include": "#general" }
+            { "include": "source.dune#general" }
           ]
         },
 
@@ -128,9 +128,9 @@
               "beginCaptures": {
                 "1": { "name": "keyword.language.dune-project" }
               },
-              "patterns": [{ "include": "#general" }]
+              "patterns": [{ "include": "source.dune#general" }]
             },
-            { "include": "#general" }
+            { "include": "source.dune#general" }
           ]
         },
 
@@ -141,7 +141,7 @@
           "beginCaptures": {
             "1": { "name": "keyword.language.dune-project" }
           },
-          "patterns": [{ "include": "#general" }]
+          "patterns": [{ "include": "source.dune#general" }]
         },
 
         {
@@ -160,7 +160,7 @@
                 "1": { "name": "keyword.language.dune-project" }
               },
               "contentName": "variable.other.declaration.dune-project",
-              "patterns": [{ "include": "#general" }]
+              "patterns": [{ "include": "source.dune#general" }]
             },
 
             {
@@ -170,7 +170,7 @@
               "beginCaptures": {
                 "1": { "name": "keyword.language.dune-project" }
               },
-              "patterns": [{ "include": "#general" }]
+              "patterns": [{ "include": "source.dune#general" }]
             },
 
             {
@@ -193,9 +193,9 @@
                   "beginCaptures": {
                     "1": { "name": "variable.other.declaration.dune-project" }
                   },
-                  "patterns": [{ "include": "#general" }]
+                  "patterns": [{ "include": "source.dune#general" }]
                 },
-                { "include": "#general" }
+                { "include": "source.dune#general" }
               ]
             },
 
@@ -207,7 +207,7 @@
                 "1": { "name": "keyword.language.dune-project" }
               },
               "contentName": "variable.other.declaration.dune-project",
-              "patterns": [{ "include": "#general" }]
+              "patterns": [{ "include": "source.dune#general" }]
             },
 
             {
@@ -217,11 +217,11 @@
               "beginCaptures": {
                 "1": { "name": "keyword.language.dune-project" }
               },
-              "patterns": [{ "include": "#general" }]
+              "patterns": [{ "include": "source.dune#general" }]
             },
 
             { "include": "#opam-metadata" },
-            { "include": "#general" }
+            { "include": "source.dune#general" }
           ]
         },
 
@@ -233,7 +233,7 @@
             "1": { "name": "keyword.language.dune-project" },
             "2": { "name": "variable.other.declaration.dune-project" }
           },
-          "patterns": [{ "include": "#general" }]
+          "patterns": [{ "include": "source.dune#general" }]
         },
 
         {
@@ -244,7 +244,7 @@
             "1": { "name": "keyword.language.dune-project" }
           },
           "contentName": "variable.other.declaration.dune-project",
-          "patterns": [{ "include": "#general" }]
+          "patterns": [{ "include": "source.dune#general" }]
         },
 
         { "include": "#opam-metadata" }
@@ -261,7 +261,7 @@
             "1": { "name": "keyword.language.dune-project" }
           },
           "contentName": "constant.language.dune-project",
-          "patterns": [{ "include": "#general" }]
+          "patterns": [{ "include": "source.dune#general" }]
         },
 
         {
@@ -271,7 +271,7 @@
           "beginCaptures": {
             "1": { "name": "keyword.language.dune-project" }
           },
-          "patterns": [{ "include": "#general" }]
+          "patterns": [{ "include": "source.dune#general" }]
         },
 
         {
@@ -294,7 +294,7 @@
                   "name": "keyword.language.dune-project",
                   "match": "/"
                 },
-                { "include": "#general" }
+                { "include": "source.dune#general" }
               ],
               "contentName": "string.other.line.dune-project"
             },
@@ -305,9 +305,9 @@
               "beginCaptures": {
                 "1": { "name": "keyword.language.dune-project" }
               },
-              "patterns": [{ "include": "#general" }]
+              "patterns": [{ "include": "source.dune#general" }]
             },
-            { "include": "#general" }
+            { "include": "source.dune#general" }
           ]
         },
 
@@ -318,166 +318,7 @@
           "beginCaptures": {
             "1": { "name": "keyword.language.dune-project" }
           },
-          "patterns": [{ "include": "#general" }]
-        }
-      ]
-    },
-
-    "general": {
-      "patterns": [
-        {
-          "name": "comment.line.dune",
-          "begin": ";",
-          "end": "$"
-        },
-        {
-          "name": "string.quoted.line.dune",
-          "begin": "\"\\\\\\|",
-          "end": "$",
-          "patterns": [{ "include": "#escape-characters" }]
-        },
-        {
-          "name": "string.quoted.line.dune",
-          "begin": "\"\\\\>",
-          "end": "$"
-        },
-        {
-          "name": "string.quoted.double.dune",
-          "begin": "\"",
-          "end": "\"",
-          "patterns": [{ "include": "#escape-characters" }]
-        },
-        {
-          "comment": "symbol",
-          "name": "constant.symbol.dune",
-          "match": "(:[[:alpha:]-]+)\\b"
-        },
-        {
-          "comment": "number or version",
-          "name": "constant.numeric.dune",
-          "match": "\\b([[:digit:]](\\.[[:digit:]]+)+)\\b"
-        },
-        {
-          "comment": "true or false",
-          "name": "constant.language.dune",
-          "match": "\\b(true|false)\\b"
-        },
-        {
-          "comment": "variable",
-          "begin": "%\\{",
-          "end": "\\}",
-          "beginCaptures": [{ "name": "keyword.operator.dune" }],
-          "endCaptures": [{ "name": "keyword.operator.dune" }],
-          "patterns": [{ "include": "#variables" }]
-        },
-        {
-          "comment": "boolean/predicate language",
-          "begin": "\\([[:space:]]*(=|<>|>=|<=|<|>)",
-          "end": "\\)",
-          "beginCaptures": { "1": { "name": "keyword.operator.dune" } },
-          "patterns": [{ "include": "#general" }]
-        },
-        {
-          "comment": "boolean/predicate language",
-          "begin": "\\([[:space:]]*(and|or|not)\\b",
-          "end": "\\)",
-          "beginCaptures": { "1": { "name": "keyword.operator.dune" } },
-          "patterns": [{ "include": "#general" }]
-        },
-        {
-          "comment": "ordered set language",
-          "begin": "\\(",
-          "end": "\\)",
-          "patterns": [
-            { "name": "keyword.operator.dune", "match": "/" },
-            { "include": "#general" }
-          ]
-        }
-      ]
-    },
-
-    "escape-characters": {
-      "patterns": [
-        {
-          "comment": "escaped newline",
-          "name": "constant.character.escape.dune",
-          "match": "\\\\$"
-        },
-        {
-          "comment": "escaped character",
-          "name": "constant.character.escape.dune",
-          "match": "\\\\(n|r|b|t|\\\\|\")"
-        },
-        {
-          "comment": "character from decimal ASCII code",
-          "name": "constant.character.escape.dune",
-          "match": "\\\\[[:digit:]]{3}"
-        },
-        {
-          "comment": "character from hexadecimal ASCII code",
-          "name": "constant.character.escape.dune",
-          "match": "\\\\x[[:xdigit:]]{2}"
-        },
-        {
-          "comment": "escaped variable",
-          "begin": "(\\%\\{)",
-          "end": "(\\})",
-          "beginCaptures": [{ "name": "constant.character.escape.dune" }],
-          "endCaptures": [{ "name": "constant.character.escape.dune" }],
-          "patterns": [{ "include": "#variables" }]
-        }
-      ]
-    },
-
-    "variables": {
-      "patterns": [
-        {
-          "name": "keyword.operator.variable.dune",
-          "match": ":"
-        },
-        {
-          "name": "constant.language.variable.dune",
-          "match": "\\b(project_root|workspace_root)\\b"
-        },
-        {
-          "name": "constant.language.variable.dune",
-          "match": "\\b(CC|CXX)\\b"
-        },
-        {
-          "name": "constant.language.variable.dune",
-          "match": "\\b(ocaml_bin|ocaml|ocamlc|ocamlopt|ocaml_version|ocaml_where|ocaml-config)\\b"
-        },
-        {
-          "name": "constant.language.variable.dune",
-          "match": "\\b(profile|null|context_name|ignoring_promoted_rule)\\b"
-        },
-        {
-          "name": "constant.language.variable.dune",
-          "match": "\\b(ext_obj|ext_asm|ext_lib|ext_dll|ext_exe|ext_plugin)\\b"
-        },
-        {
-          "name": "constant.language.variable.dune",
-          "match": "\\b(arch_sixtyfour|architecture|os_type|model|system)\\b"
-        },
-        {
-          "name": "constant.language.variable.dune",
-          "match": "\\b(cmo|cmi|cma|cmx|cmxa)\\b"
-        },
-        {
-          "name": "constant.language.variable.action.dune",
-          "match": "\\^"
-        },
-        {
-          "name": "constant.language.variable.action.dune",
-          "match": "\\b(targets|target|deps|dep|exe|bin|version)\\b"
-        },
-        {
-          "name": "constant.language.variable.action.dune",
-          "match": "\\b(lib-available|lib-private|libexec-private|libexec|lib)\\b"
-        },
-        {
-          "name": "constant.language.variable.action.dune",
-          "match": "\\b(read-lines|read-strings|read)\\b"
+          "patterns": [{ "include": "source.dune#general" }]
         }
       ]
     }

--- a/syntaxes/dune-workspace.json
+++ b/syntaxes/dune-workspace.json
@@ -2,7 +2,7 @@
   "name": "dune-workspace",
   "scopeName": "source.dune-workspace",
   "fileTypes": ["dune-workspace"],
-  "patterns": [{ "include": "#stanzas" }, { "include": "#general" }],
+  "patterns": [{ "include": "#stanzas" }, { "include": "source.dune#general" }],
   "repository": {
     "stanzas": {
       "patterns": [
@@ -14,7 +14,7 @@
             "1": { "name": "keyword.language.dune-workspace" },
             "2": { "name": "keyword.language.dune-workspace" }
           },
-          "patterns": [{ "include": "#general" }]
+          "patterns": [{ "include": "source.dune#general" }]
         },
 
         {
@@ -25,7 +25,7 @@
             "1": { "name": "keyword.language.dune-workspace" }
           },
           "contentName": "variable.other.declaration.dune-project",
-          "patterns": [{ "include": "#general" }]
+          "patterns": [{ "include": "source.dune#general" }]
         },
 
         {
@@ -35,7 +35,7 @@
           "beginCaptures": {
             "1": { "name": "keyword.language.dune-workspace" }
           },
-          "patterns": [{ "include": "#general" }]
+          "patterns": [{ "include": "source.dune#general" }]
         },
 
         {
@@ -66,7 +66,7 @@
                   "beginCaptures": {
                     "1": { "name": "keyword.language.dune-workspace" }
                   },
-                  "patterns": [{ "include": "#general" }]
+                  "patterns": [{ "include": "source.dune#general" }]
                 },
 
                 {
@@ -76,7 +76,7 @@
                   "beginCaptures": {
                     "1": { "name": "keyword.language.dune-workspace" }
                   },
-                  "patterns": [{ "include": "#general" }]
+                  "patterns": [{ "include": "source.dune#general" }]
                 },
 
                 {
@@ -86,7 +86,7 @@
                   "beginCaptures": {
                     "1": { "name": "keyword.language.dune-workspace" }
                   },
-                  "patterns": [{ "include": "#general" }]
+                  "patterns": [{ "include": "source.dune#general" }]
                 },
 
                 {
@@ -96,7 +96,7 @@
                   "beginCaptures": {
                     "1": { "name": "keyword.language.dune-workspace" }
                   },
-                  "patterns": [{ "include": "#general" }]
+                  "patterns": [{ "include": "source.dune#general" }]
                 },
 
                 {
@@ -106,7 +106,7 @@
                   "beginCaptures": {
                     "1": { "name": "keyword.language.dune-workspace" }
                   },
-                  "patterns": [{ "include": "#general" }]
+                  "patterns": [{ "include": "source.dune#general" }]
                 },
 
                 {
@@ -116,7 +116,7 @@
                   "beginCaptures": {
                     "1": { "name": "keyword.language.dune-workspace" }
                   },
-                  "patterns": [{ "include": "#general" }]
+                  "patterns": [{ "include": "source.dune#general" }]
                 },
 
                 {
@@ -126,7 +126,7 @@
                   "beginCaptures": {
                     "1": { "name": "keyword.language.dune-workspace" }
                   },
-                  "patterns": [{ "include": "#general" }]
+                  "patterns": [{ "include": "source.dune#general" }]
                 },
 
                 {
@@ -136,7 +136,7 @@
                   "beginCaptures": {
                     "1": { "name": "keyword.language.dune-workspace" }
                   },
-                  "patterns": [{ "include": "#general" }]
+                  "patterns": [{ "include": "source.dune#general" }]
                 },
 
                 {
@@ -146,7 +146,7 @@
                   "beginCaptures": {
                     "1": { "name": "keyword.language.dune-workspace" }
                   },
-                  "patterns": [{ "include": "#general" }]
+                  "patterns": [{ "include": "source.dune#general" }]
                 },
 
                 {
@@ -156,7 +156,7 @@
                   "beginCaptures": {
                     "1": { "name": "keyword.language.dune-workspace" }
                   },
-                  "patterns": [{ "include": "#general" }]
+                  "patterns": [{ "include": "source.dune#general" }]
                 },
 
                 {
@@ -166,7 +166,7 @@
                   "beginCaptures": {
                     "1": { "name": "keyword.language.dune-workspace" }
                   },
-                  "patterns": [{ "include": "#general" }]
+                  "patterns": [{ "include": "source.dune#general" }]
                 },
 
                 {
@@ -176,173 +176,14 @@
                   "beginCaptures": {
                     "1": { "name": "keyword.language.dune-workspace" }
                   },
-                  "patterns": [{ "include": "#general" }]
+                  "patterns": [{ "include": "source.dune#general" }]
                 },
 
-                { "include": "#general" }
+                { "include": "source.dune#general" }
               ]
             },
-            { "include": "#general" }
+            { "include": "source.dune#general" }
           ]
-        }
-      ]
-    },
-
-    "general": {
-      "patterns": [
-        {
-          "name": "comment.line.dune",
-          "begin": ";",
-          "end": "$"
-        },
-        {
-          "name": "string.quoted.line.dune",
-          "begin": "\"\\\\\\|",
-          "end": "$",
-          "patterns": [{ "include": "#escape-characters" }]
-        },
-        {
-          "name": "string.quoted.line.dune",
-          "begin": "\"\\\\>",
-          "end": "$"
-        },
-        {
-          "name": "string.quoted.double.dune",
-          "begin": "\"",
-          "end": "\"",
-          "patterns": [{ "include": "#escape-characters" }]
-        },
-        {
-          "comment": "symbol",
-          "name": "constant.symbol.dune",
-          "match": "(:[[:alpha:]-]+)\\b"
-        },
-        {
-          "comment": "number or version",
-          "name": "constant.numeric.dune",
-          "match": "\\b([[:digit:]](\\.[[:digit:]]+)+)\\b"
-        },
-        {
-          "comment": "true or false",
-          "name": "constant.language.dune",
-          "match": "\\b(true|false)\\b"
-        },
-        {
-          "comment": "variable",
-          "begin": "%\\{",
-          "end": "\\}",
-          "beginCaptures": [{ "name": "keyword.operator.dune" }],
-          "endCaptures": [{ "name": "keyword.operator.dune" }],
-          "patterns": [{ "include": "#variables" }]
-        },
-        {
-          "comment": "boolean/predicate language",
-          "begin": "\\([[:space:]]*(=|<>|>=|<=|<|>)",
-          "end": "\\)",
-          "beginCaptures": { "1": { "name": "keyword.operator.dune" } },
-          "patterns": [{ "include": "#general" }]
-        },
-        {
-          "comment": "boolean/predicate language",
-          "begin": "\\([[:space:]]*(and|or|not)\\b",
-          "end": "\\)",
-          "beginCaptures": { "1": { "name": "keyword.operator.dune" } },
-          "patterns": [{ "include": "#general" }]
-        },
-        {
-          "comment": "ordered set language",
-          "begin": "\\(",
-          "end": "\\)",
-          "patterns": [
-            { "name": "keyword.operator.dune", "match": "/" },
-            { "include": "#general" }
-          ]
-        }
-      ]
-    },
-
-    "escape-characters": {
-      "patterns": [
-        {
-          "comment": "escaped newline",
-          "name": "constant.character.escape.dune",
-          "match": "\\\\$"
-        },
-        {
-          "comment": "escaped character",
-          "name": "constant.character.escape.dune",
-          "match": "\\\\(n|r|b|t|\\\\|\")"
-        },
-        {
-          "comment": "character from decimal ASCII code",
-          "name": "constant.character.escape.dune",
-          "match": "\\\\[[:digit:]]{3}"
-        },
-        {
-          "comment": "character from hexadecimal ASCII code",
-          "name": "constant.character.escape.dune",
-          "match": "\\\\x[[:xdigit:]]{2}"
-        },
-        {
-          "comment": "escaped variable",
-          "begin": "(\\%\\{)",
-          "end": "(\\})",
-          "beginCaptures": [{ "name": "constant.character.escape.dune" }],
-          "endCaptures": [{ "name": "constant.character.escape.dune" }],
-          "patterns": [{ "include": "#variables" }]
-        }
-      ]
-    },
-
-    "variables": {
-      "patterns": [
-        {
-          "name": "keyword.operator.variable.dune",
-          "match": ":"
-        },
-        {
-          "name": "constant.language.variable.dune",
-          "match": "\\b(project_root|workspace_root)\\b"
-        },
-        {
-          "name": "constant.language.variable.dune",
-          "match": "\\b(CC|CXX)\\b"
-        },
-        {
-          "name": "constant.language.variable.dune",
-          "match": "\\b(ocaml_bin|ocaml|ocamlc|ocamlopt|ocaml_version|ocaml_where|ocaml-config)\\b"
-        },
-        {
-          "name": "constant.language.variable.dune",
-          "match": "\\b(profile|null|context_name|ignoring_promoted_rule)\\b"
-        },
-        {
-          "name": "constant.language.variable.dune",
-          "match": "\\b(ext_obj|ext_asm|ext_lib|ext_dll|ext_exe|ext_plugin)\\b"
-        },
-        {
-          "name": "constant.language.variable.dune",
-          "match": "\\b(arch_sixtyfour|architecture|os_type|model|system)\\b"
-        },
-        {
-          "name": "constant.language.variable.dune",
-          "match": "\\b(cmo|cmi|cma|cmx|cmxa)\\b"
-        },
-        {
-          "name": "constant.language.variable.action.dune",
-          "match": "\\^"
-        },
-        {
-          "name": "constant.language.variable.action.dune",
-          "match": "\\b(targets|target|deps|dep|exe|bin|version)\\b"
-        },
-        {
-          "name": "constant.language.variable.action.dune",
-          "match": "\\b(lib-available|lib-private|libexec-private|libexec|lib)\\b"
-        },
-        {
-          "name": "constant.language.variable.action.dune",
-          "match": "\\b(read-lines|read-strings|read)\\b"
         }
       ]
     }

--- a/syntaxes/dune.json
+++ b/syntaxes/dune.json
@@ -2891,6 +2891,10 @@
               "match": ":"
             },
             {
+              "name": "keyword.operator.variable.dune",
+              "match": "="
+            },
+            {
               "name": "constant.language.variable.action.dune",
               "match": "\\^"
             },
@@ -2934,6 +2938,10 @@
             },
             {
               "name": "constant.language.variable.dune",
+              "match": "(?<=\\{)(env)(?=:)"
+            },
+            {
+              "name": "constant.language.variable.dune",
               "match": "(?<=\\{)(version)(?=:)"
             },
             {
@@ -2942,7 +2950,7 @@
             },
             {
               "name": "constant.language.variable.action.dune",
-              "match": "(?<=\\{)(dep|exe|bin|lib|lib-private|libexec|libexec-private|lib-available)(?=:)"
+              "match": "(?<=\\{)(dep|exe|bin|bin-available|lib|lib-private|libexec|libexec-private|lib-available)(?=:)"
             },
             {
               "name": "constant.language.variable.action.dune",

--- a/syntaxes/dune.json
+++ b/syntaxes/dune.json
@@ -2891,48 +2891,62 @@
               "match": ":"
             },
             {
-              "name": "constant.language.variable.dune",
-              "match": "\\b(project_root|workspace_root)\\b"
-            },
-            {
-              "name": "constant.language.variable.dune",
-              "match": "\\b(CC|CXX)\\b"
-            },
-            {
-              "name": "constant.language.variable.dune",
-              "match": "\\b(ocaml_bin|ocaml|ocamlc|ocamlopt|ocaml_version|ocaml_where|ocaml-config)\\b"
-            },
-            {
-              "name": "constant.language.variable.dune",
-              "match": "\\b(profile|null|context_name|ignoring_promoted_rule)\\b"
-            },
-            {
-              "name": "constant.language.variable.dune",
-              "match": "\\b(ext_obj|ext_asm|ext_lib|ext_dll|ext_exe|ext_plugin)\\b"
-            },
-            {
-              "name": "constant.language.variable.dune",
-              "match": "\\b(arch_sixtyfour|architecture|os_type|model|system)\\b"
-            },
-            {
-              "name": "constant.language.variable.dune",
-              "match": "\\b(cmo|cmi|cma|cmx|cmxa)\\b"
-            },
-            {
               "name": "constant.language.variable.action.dune",
               "match": "\\^"
             },
+
             {
-              "name": "constant.language.variable.action.dune",
-              "match": "\\b(targets|target|deps|dep|exe|bin|version)\\b"
+              "name": "constant.language.variable.dune",
+              "match": "(?<=\\{)(project_root|workspace_root|profile|context_name)(?=\\})"
+            },
+            {
+              "name": "constant.language.variable.dune",
+              "match": "(?<=\\{)(CC|CXX)(?=\\})"
+            },
+            {
+              "name": "constant.language.variable.dune",
+              "match": "(?<=\\{)(ocaml_bin|ocaml|ocamlc|ocamlopt|ocaml_version|ocaml_where)(?=\\})"
+            },
+            {
+              "name": "constant.language.variable.dune",
+              "match": "(?<=\\{)(ext_obj|ext_asm|ext_lib|ext_dll|ext_exe|ext_plugin)(?=\\})"
+            },
+            {
+              "name": "constant.language.variable.dune",
+              "match": "(?<=\\{)(arch_sixtyfour|architecture|os_type|model|system)(?=\\})"
             },
             {
               "name": "constant.language.variable.action.dune",
-              "match": "\\b(lib-available|lib-private|libexec-private|libexec|lib)\\b"
+              "match": "(?<=\\{)(target|targets|deps)(?=\\})"
+            },
+            {
+              "name": "constant.language.variable.dune",
+              "match": "(?<=\\{)(null)(?=\\})"
+            },
+            {
+              "name": "constant.language.variable.dune",
+              "match": "(?<=\\{)(ignoring_promoted_rule)(?=\\})"
+            },
+
+            {
+              "name": "constant.language.variable.dune",
+              "match": "(?<=\\{)(ocaml-config)(?=:)"
+            },
+            {
+              "name": "constant.language.variable.dune",
+              "match": "(?<=\\{)(version)(?=:)"
+            },
+            {
+              "name": "constant.language.variable.dune",
+              "match": "(?<=\\{)(cmo|cmi|cma|cmx|cmxa)(?=:)"
             },
             {
               "name": "constant.language.variable.action.dune",
-              "match": "\\b(read-lines|read-strings|read)\\b"
+              "match": "(?<=\\{)(dep|exe|bin|lib|lib-private|libexec|libexec-private|lib-available)(?=:)"
+            },
+            {
+              "name": "constant.language.variable.action.dune",
+              "match": "(?<=\\{)(read|read-lines|read-strings)(?=:)"
             }
           ]
         }

--- a/syntaxes/dune.json
+++ b/syntaxes/dune.json
@@ -1600,215 +1600,6 @@
         }
       ]
     },
-    "general": {
-      "patterns": [
-        {
-          "name": "comment.line.dune",
-          "begin": ";",
-          "end": "$"
-        },
-        {
-          "name": "string.quoted.line.dune",
-          "begin": "\"\\\\\\|",
-          "end": "$",
-          "patterns": [
-            {
-              "include": "#escape-characters"
-            }
-          ]
-        },
-        {
-          "name": "string.quoted.line.dune",
-          "begin": "\"\\\\>",
-          "end": "$"
-        },
-        {
-          "name": "string.quoted.double.dune",
-          "begin": "\"",
-          "end": "\"",
-          "patterns": [
-            {
-              "include": "#escape-characters"
-            }
-          ]
-        },
-        {
-          "comment": "symbol",
-          "name": "entity.name.function.action.dune",
-          "match": "(:[[:alpha:]-]+)\\b"
-        },
-        {
-          "comment": "number or version",
-          "name": "constant.numeric.dune",
-          "match": "\\b([[:digit:]](\\.[[:digit:]]+)+)\\b"
-        },
-        {
-          "comment": "true or false",
-          "name": "constant.language.dune",
-          "match": "\\b(true|false)\\b"
-        },
-        {
-          "comment": "variable",
-          "begin": "%\\{",
-          "end": "\\}",
-          "beginCaptures": [
-            {
-              "name": "keyword.operator.dune"
-            }
-          ],
-          "endCaptures": [
-            {
-              "name": "keyword.operator.dune"
-            }
-          ],
-          "patterns": [
-            {
-              "include": "#variables"
-            }
-          ]
-        },
-        {
-          "comment": "boolean/predicate language",
-          "begin": "\\([[:space:]]*(=|<>|>=|<=|<|>)",
-          "end": "\\)",
-          "beginCaptures": {
-            "1": {
-              "name": "keyword.operator.dune"
-            }
-          },
-          "patterns": [
-            {
-              "include": "#general"
-            }
-          ]
-        },
-        {
-          "comment": "boolean/predicate language",
-          "begin": "\\([[:space:]]*(and|or|not)\\b",
-          "end": "\\)",
-          "beginCaptures": {
-            "1": {
-              "name": "entity.name.function.action.dune"
-            }
-          },
-          "patterns": [
-            {
-              "include": "#general"
-            }
-          ]
-        },
-        {
-          "comment": "ordered set language",
-          "begin": "\\(",
-          "end": "\\)",
-          "patterns": [
-            {
-              "name": "keyword.operator.dune",
-              "match": "/"
-            },
-            {
-              "include": "#general"
-            }
-          ]
-        }
-      ]
-    },
-    "escape-characters": {
-      "patterns": [
-        {
-          "comment": "escaped newline",
-          "name": "constant.character.escape.dune",
-          "match": "\\\\$"
-        },
-        {
-          "comment": "escaped character",
-          "name": "constant.character.escape.dune",
-          "match": "\\\\(n|r|b|t|\\\\|\")"
-        },
-        {
-          "comment": "character from decimal ASCII code",
-          "name": "constant.character.escape.dune",
-          "match": "\\\\[[:digit:]]{3}"
-        },
-        {
-          "comment": "character from hexadecimal ASCII code",
-          "name": "constant.character.escape.dune",
-          "match": "\\\\x[[:xdigit:]]{2}"
-        },
-        {
-          "comment": "escaped variable",
-          "begin": "(\\%\\{)",
-          "end": "(\\})",
-          "beginCaptures": [
-            {
-              "name": "constant.character.escape.dune"
-            }
-          ],
-          "endCaptures": [
-            {
-              "name": "constant.character.escape.dune"
-            }
-          ],
-          "patterns": [
-            {
-              "include": "#variables"
-            }
-          ]
-        }
-      ]
-    },
-    "variables": {
-      "patterns": [
-        {
-          "name": "keyword.operator.variable.dune",
-          "match": ":"
-        },
-        {
-          "name": "constant.language.variable.dune",
-          "match": "\\b(project_root|workspace_root)\\b"
-        },
-        {
-          "name": "constant.language.variable.dune",
-          "match": "\\b(CC|CXX)\\b"
-        },
-        {
-          "name": "constant.language.variable.dune",
-          "match": "\\b(ocaml_bin|ocaml|ocamlc|ocamlopt|ocaml_version|ocaml_where|ocaml-config)\\b"
-        },
-        {
-          "name": "constant.language.variable.dune",
-          "match": "\\b(profile|null|context_name|ignoring_promoted_rule)\\b"
-        },
-        {
-          "name": "constant.language.variable.dune",
-          "match": "\\b(ext_obj|ext_asm|ext_lib|ext_dll|ext_exe|ext_plugin)\\b"
-        },
-        {
-          "name": "constant.language.variable.dune",
-          "match": "\\b(arch_sixtyfour|architecture|os_type|model|system)\\b"
-        },
-        {
-          "name": "constant.language.variable.dune",
-          "match": "\\b(cmo|cmi|cma|cmx|cmxa)\\b"
-        },
-        {
-          "name": "constant.language.variable.action.dune",
-          "match": "\\^"
-        },
-        {
-          "name": "constant.language.variable.action.dune",
-          "match": "\\b(targets|target|deps|dep|exe|bin|version)\\b"
-        },
-        {
-          "name": "constant.language.variable.action.dune",
-          "match": "\\b(lib-available|lib-private|libexec-private|libexec|lib)\\b"
-        },
-        {
-          "name": "constant.language.variable.action.dune",
-          "match": "\\b(read-lines|read-strings|read)\\b"
-        }
-      ]
-    },
     "dependencies": {
       "patterns": [
         {
@@ -2935,6 +2726,217 @@
           ]
         }
       ]
+    },
+    "general": {
+      "patterns": [
+        {
+          "name": "comment.line.dune",
+          "begin": ";",
+          "end": "$"
+        },
+        {
+          "name": "string.quoted.line.dune",
+          "begin": "\"\\\\\\|",
+          "end": "$",
+          "patterns": [
+            {
+              "include": "#escape-characters"
+            }
+          ]
+        },
+        {
+          "name": "string.quoted.line.dune",
+          "begin": "\"\\\\>",
+          "end": "$"
+        },
+        {
+          "name": "string.quoted.double.dune",
+          "begin": "\"",
+          "end": "\"",
+          "patterns": [
+            {
+              "include": "#escape-characters"
+            }
+          ]
+        },
+        {
+          "comment": "symbol",
+          "name": "entity.name.function.action.dune",
+          "match": "(:[[:alpha:]-]+)\\b"
+        },
+        {
+          "comment": "number or version",
+          "name": "constant.numeric.dune",
+          "match": "\\b([[:digit:]](\\.[[:digit:]]+)+)\\b"
+        },
+        {
+          "comment": "true or false",
+          "name": "constant.language.dune",
+          "match": "\\b(true|false)\\b"
+        },
+        {
+          "comment": "variable",
+          "begin": "%\\{",
+          "end": "\\}",
+          "beginCaptures": [
+            {
+              "name": "keyword.operator.dune"
+            }
+          ],
+          "endCaptures": [
+            {
+              "name": "keyword.operator.dune"
+            }
+          ],
+          "patterns": [
+            {
+              "include": "#variables"
+            }
+          ]
+        },
+        {
+          "comment": "boolean/predicate language",
+          "begin": "\\([[:space:]]*(=|<>|>=|<=|<|>)",
+          "end": "\\)",
+          "beginCaptures": {
+            "1": {
+              "name": "keyword.operator.dune"
+            }
+          },
+          "patterns": [
+            {
+              "include": "#general"
+            }
+          ]
+        },
+        {
+          "comment": "boolean/predicate language",
+          "begin": "\\([[:space:]]*(and|or|not)\\b",
+          "end": "\\)",
+          "beginCaptures": {
+            "1": {
+              "name": "entity.name.function.action.dune"
+            }
+          },
+          "patterns": [
+            {
+              "include": "#general"
+            }
+          ]
+        },
+        {
+          "comment": "ordered set language",
+          "begin": "\\(",
+          "end": "\\)",
+          "patterns": [
+            {
+              "name": "keyword.operator.dune",
+              "match": "/"
+            },
+            {
+              "include": "#general"
+            }
+          ]
+        }
+      ],
+      "repository": {
+        "escape-characters": {
+          "patterns": [
+            {
+              "comment": "escaped newline",
+              "name": "constant.character.escape.dune",
+              "match": "\\\\$"
+            },
+            {
+              "comment": "escaped character",
+              "name": "constant.character.escape.dune",
+              "match": "\\\\(n|r|b|t|\\\\|\")"
+            },
+            {
+              "comment": "character from decimal ASCII code",
+              "name": "constant.character.escape.dune",
+              "match": "\\\\[[:digit:]]{3}"
+            },
+            {
+              "comment": "character from hexadecimal ASCII code",
+              "name": "constant.character.escape.dune",
+              "match": "\\\\x[[:xdigit:]]{2}"
+            },
+            {
+              "comment": "escaped variable",
+              "begin": "(\\%\\{)",
+              "end": "(\\})",
+              "beginCaptures": [
+                {
+                  "name": "constant.character.escape.dune"
+                }
+              ],
+              "endCaptures": [
+                {
+                  "name": "constant.character.escape.dune"
+                }
+              ],
+              "patterns": [
+                {
+                  "include": "#variables"
+                }
+              ]
+            }
+          ]
+        },
+        "variables": {
+          "patterns": [
+            {
+              "name": "keyword.operator.variable.dune",
+              "match": ":"
+            },
+            {
+              "name": "constant.language.variable.dune",
+              "match": "\\b(project_root|workspace_root)\\b"
+            },
+            {
+              "name": "constant.language.variable.dune",
+              "match": "\\b(CC|CXX)\\b"
+            },
+            {
+              "name": "constant.language.variable.dune",
+              "match": "\\b(ocaml_bin|ocaml|ocamlc|ocamlopt|ocaml_version|ocaml_where|ocaml-config)\\b"
+            },
+            {
+              "name": "constant.language.variable.dune",
+              "match": "\\b(profile|null|context_name|ignoring_promoted_rule)\\b"
+            },
+            {
+              "name": "constant.language.variable.dune",
+              "match": "\\b(ext_obj|ext_asm|ext_lib|ext_dll|ext_exe|ext_plugin)\\b"
+            },
+            {
+              "name": "constant.language.variable.dune",
+              "match": "\\b(arch_sixtyfour|architecture|os_type|model|system)\\b"
+            },
+            {
+              "name": "constant.language.variable.dune",
+              "match": "\\b(cmo|cmi|cma|cmx|cmxa)\\b"
+            },
+            {
+              "name": "constant.language.variable.action.dune",
+              "match": "\\^"
+            },
+            {
+              "name": "constant.language.variable.action.dune",
+              "match": "\\b(targets|target|deps|dep|exe|bin|version)\\b"
+            },
+            {
+              "name": "constant.language.variable.action.dune",
+              "match": "\\b(lib-available|lib-private|libexec-private|libexec|lib)\\b"
+            },
+            {
+              "name": "constant.language.variable.action.dune",
+              "match": "\\b(read-lines|read-strings|read)\\b"
+            }
+          ]
+        }
+      }
     }
   }
 }

--- a/syntaxes/dune.json
+++ b/syntaxes/dune.json
@@ -389,9 +389,6 @@
               "include": "#action"
             },
             {
-              "include": "#variables"
-            },
-            {
               "include": "#general"
             }
           ]
@@ -2108,9 +2105,6 @@
         },
         {
           "include": "#general"
-        },
-        {
-          "include": "#variables"
         }
       ]
     },
@@ -2408,9 +2402,6 @@
                     }
                   },
                   "patterns": [
-                    {
-                      "include": "#variables"
-                    },
                     {
                       "include": "#general"
                     }

--- a/test/fixtures/dune
+++ b/test/fixtures/dune
@@ -258,6 +258,7 @@
    %{dep:<path>}
    %{exe:<path>}
    %{bin:<program>}
+   %{bin-available:<program-name>}
    %{lib:<public-library-name>:<file>}
    %{lib-private:<library-name>:<file>}
    %{libexec:<public-library-name>:<file>}
@@ -267,6 +268,7 @@
    %{read:<path>}
    %{read-lines:<path>}
    %{read-strings:<path>}
+   %{env:BIN=/usr/bin}
    ; These don't exist
    %{test}
    %{error})))


### PR DESCRIPTION
The general dune syntax rules were duplicated between 3 files. This PR makes it so the `dune-project` and `dune-workspace` syntaxes reuse the general rules from the `dune` syntax.

Additionally, it fixes the incorrect highlighting in variables mentioned in https://github.com/ocamllabs/vscode-ocaml-platform/pull/742#issuecomment-1027296414 and adds a couple of missing variables.

