### PR TITLE
fix: improve outdated ocaml-lsp-server message

### DIFF
--- a/src/ocaml_lsp.ml
+++ b/src/ocaml_lsp.ml
@@ -120,12 +120,13 @@ let is_version_up_to_date t ocaml_v =
           let upgrade =
             match old with
             | None -> sprintf "to %s" new_
-            | Some old -> sprintf "%s to %s" old new_
+            | Some old -> sprintf "from %s to %s" old new_
           in
           sprintf
-            "The is a newer version of ocamllsp available. Consider upgrading \
-             %s"
-            upgrade
+            "There is a newer version of ocaml-lsp-server available. Consider \
+             upgrading %s. Hint: $ opam install ocaml-lsp-server=%s and \
+             restart the lsp server"
+            upgrade new_
       in
       `Msg msg)
 


### PR DESCRIPTION
https://github.com/ocamllabs/vscode-ocaml-platform/discussions/868#discussioncomment-2182588

Would that make sense to add a button to install the package? There's a [function for that in `Sandbox`](https://github.com/ocamllabs/vscode-ocaml-platform/blob/master/src/sandbox.ml#L573) so that shouldn't be much work I guess.