### PR TITLE
ci: fix lint-fmt

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -169,6 +169,6 @@ jobs:
           ocaml-compiler: ${{ matrix.ocaml-compiler }}
           dune-cache: true
 
-      - run: opam depext --install ocamlformat=$(awk -F = '/version=/{print $2}' .ocamlformat)
+      - run: opam depext --install ocamlformat=$(awk -F = '/^version=/{print $2}' .ocamlformat)
 
       - run: opam exec -- dune build @fmt


### PR DESCRIPTION
Should fix

```bash
Run opam depext --install ocamlformat=$(awk -F = '/version=/{print $2}' .ocamlformat)
# Detecting depexts using vars: arch=x86_64, os=linux, os-distribution=ubuntu, os-family=debian
opam: option `--resolve': invalid element in list
      (`ocamlformat=0.[20](https://github.com/ocamllabs/vscode-ocaml-platform/runs/5211851399?check_suite_focus=true#step:4:20).1,4.13.1'): Invalid character in package name
      "4.13.1"
Usage: opam list [OPTION]... [PATTERNS]...
Try `opam list --help' or `opam --help' for more information.
Command failed: opam --cli=2.1 list --readonly --external '--resolve=ocamlformat=0.20.1,4.13.1' returned 2
Error: Process completed with exit code 2.
```
