### PR TITLE
Fix external syntax highlighting for embedded ocaml source in comments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Change Log
 
+## Unreleased
+
+- Fix external syntax highlighting for embedded ocaml source in comments (#906)
+
 ## 1.10.0
 
 - Add the possibility to generate and show the documentation of an installed

--- a/syntaxes/ocaml.interface.json
+++ b/syntaxes/ocaml.interface.json
@@ -54,7 +54,7 @@
             "1": { "name": "keyword.ocaml" },
             "2": { "name": "entity.name.function.binding.ocaml" }
           },
-          "end": "(?<=]|\")[[:space:]]*$",
+          "end": "(?<=]|\")[[:space:]]*(?:$|(?=]))",
           "patterns": [
             {
               "comment": "string literal",


### PR DESCRIPTION
Closes #905 

The external syntax highlighting will now terminate if it finds a `]` after a string.