### PR TITLE
upgrade ppxlib to 0.26.0

### DIFF
--- a/dune-project
+++ b/dune-project
@@ -27,8 +27,12 @@
  (depends
   (vscode
    (= :version))
+  (dune
+   (< 3.0.0))
   (ocaml
-   (>= 4.11))
+   (and
+    (>= 4.11)
+    (< 4.14.0)))
   (js_of_ocaml
    (>= 3.9.0))
   (gen_js_api

--- a/dune-project
+++ b/dune-project
@@ -42,7 +42,7 @@
   (ocaml-version
    (>= 3.4.0))
   (ppxlib
-   (>= 0.23.0))
+   (>= 0.26.0))
   (opam-file-format
    (>= 2.1.2))))
 

--- a/vscode-ocaml-platform.opam
+++ b/vscode-ocaml-platform.opam
@@ -25,7 +25,7 @@ depends: [
   "promise_jsoo" {>= "0.3.1"}
   "jsonoo" {>= "0.2.1"}
   "ocaml-version" {>= "3.4.0"}
-  "ppxlib" {>= "0.23.0"}
+  "ppxlib" {>= "0.26.0"}
   "opam-file-format" {>= "2.1.2"}
   "odoc" {with-doc}
 ]

--- a/vscode-ocaml-platform.opam
+++ b/vscode-ocaml-platform.opam
@@ -16,9 +16,9 @@ license: "ISC"
 homepage: "https://github.com/ocamllabs/vscode-ocaml-platform"
 bug-reports: "https://github.com/ocamllabs/vscode-ocaml-platform/issues"
 depends: [
-  "dune" {>= "2.7"}
   "vscode" {= version}
-  "ocaml" {>= "4.11"}
+  "dune" {>= "2.7" & < "3.0.0"}
+  "ocaml" {>= "4.11" & < "4.14.0"}
   "js_of_ocaml" {>= "3.9.0"}
   "gen_js_api" {= "1.0.8"}
   "base" {>= "v0.14.1"}


### PR DESCRIPTION
- upgrade ppxlib to 0.26.0

0.26.0 has breaking API changes, so we set the required version of Ppxlib to >= 0.26.0

- fix CI failures: upper bound ocaml compiler and dune version

  - dune 3.0 complains about `--pretty` flag being passed to `js_of_ocaml link` because we have `(lang dune 2.7)` (dune doesn't complain on lang 3.0 about `--pretty`); see https://github.com/ocaml/dune/issues/5563

(this PR is a result of PR #919 being split in several)

