### PR TITLE
Add arrays to auto closing pairs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Change Log
 
+## Unreleased
+
+- Add `[||]` to auto auto closing pairs (#946)
+
 ## 1.10.2
 
 - Add indentation rules for comments (#928)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## Unreleased
 
-- Add `[||]` to auto auto closing pairs (#946)
+- Add arrays to auto closing pairs (#946)
 
 ## 1.10.2
 

--- a/languages/ocaml.json
+++ b/languages/ocaml.json
@@ -4,7 +4,8 @@
     { "open": "[", "close": "]" },
     { "open": "(", "close": ")" },
     { "open": "\"", "close": "\"", "notIn": ["string"] },
-    { "open": "(*", "close": "*", "notIn": ["string"] }
+    { "open": "(*", "close": "*", "notIn": ["string"] },
+    { "open": "[|", "close": "|", "notIn": ["string"] }
   ],
   "brackets": [
     ["{", "}"],


### PR DESCRIPTION
Old behavior :
![image](https://user-images.githubusercontent.com/25438086/165507074-ef746f6e-9cb8-493b-8661-15e81b88f09f.png)
New behavior :
![image](https://user-images.githubusercontent.com/25438086/165507179-2af13b3f-7c95-4251-bec0-fc4815ac9188.png)


Can we add the feature for it ?