### PR TITLE
Require ocaml >= 413 to compile

### DIFF
--- a/dune-project
+++ b/dune-project
@@ -30,7 +30,7 @@
    (= :version))
   (ocaml
    (and
-    (>= 4.11)
+    (>= 4.13)
     (< 4.15.0)))
   (js_of_ocaml
    (>= 3.9.0))
@@ -54,7 +54,7 @@
  (synopsis "Visual Studio Code Bindings")
  (depends
   (ocaml
-   (>= 4.11))
+   (>= 4.13))
   (js_of_ocaml
    (>= 3.9.0))
   (gen_js_api

--- a/vscode-ocaml-platform.opam
+++ b/vscode-ocaml-platform.opam
@@ -18,7 +18,7 @@ bug-reports: "https://github.com/ocamllabs/vscode-ocaml-platform/issues"
 depends: [
   "dune" {>= "3.0"}
   "vscode" {= version}
-  "ocaml" {>= "4.11" & < "4.15.0"}
+  "ocaml" {>= "4.13" & < "4.15.0"}
   "js_of_ocaml" {>= "3.9.0"}
   "gen_js_api" {= "1.0.8"}
   "base" {>= "v0.14.1"}

--- a/vscode.opam
+++ b/vscode.opam
@@ -17,7 +17,7 @@ homepage: "https://github.com/ocamllabs/vscode-ocaml-platform"
 bug-reports: "https://github.com/ocamllabs/vscode-ocaml-platform/issues"
 depends: [
   "dune" {>= "3.0"}
-  "ocaml" {>= "4.11"}
+  "ocaml" {>= "4.13"}
   "js_of_ocaml" {>= "3.9.0"}
   "gen_js_api" {= "1.0.8"}
   "promise_jsoo" {>= "0.3.1"}


### PR DESCRIPTION
# Description

Since commit 93e88b7799830dc4711cf6b61957715460eac1fa support for let*/let+ punning introduced in ocaml 4.13 is required to compile the repository. 

Here I propose to bump ocaml version lower bound but an alternative fix could be to reformat for 4.11. 
Feel free to merge or close this PR. 