### PR TITLE
Fix #183 idea

### DIFF
--- a/snippets/ocaml.json
+++ b/snippets/ocaml.json
@@ -50,5 +50,13 @@
   "type declaration": {
     "prefix": "type",
     "body": ["type ${1:name} = $0"]
+  },
+  "in": {
+    "prefix": "in",
+    "body": ["in"]
+  },
+  "do": {
+    "prefix": "do",
+    "body": ["do"]
   }
 }


### PR DESCRIPTION
Why don't we add `in` and `do` to snippets to facilitate their insertion ? With this, words like `do_at_exit` and `in_channel_length` would not be given priority. I think vscode's behaviour is better with these snippets.