### PR TITLE
fix #961: reveal ast node can now open ast explorer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- "Reveal AST Node" command now does not fail if the AST Explorer is not open 
+  but opens it and then reveals the node (#964)
 - Fix reading `ocaml.repl.useUtop` setting (#957)
 
 ## 1.10.4

--- a/src/import.ml
+++ b/src/import.ml
@@ -9,6 +9,17 @@ module Process = Node.Process
 module ChildProcess = Node.ChildProcess
 module Fs = Node.Fs
 
+module Node = struct
+  include Node
+
+  let setTimeout' ~wait_ms =
+    Promise.make (fun ~resolve ~reject:_ ->
+        let (_ : Node.Timeout.t) =
+          Node.setTimeout (fun () -> resolve ()) wait_ms
+        in
+        ())
+end
+
 let property_exists json property =
   Ojs.has_property (Jsonoo.t_to_js json) property
 


### PR DESCRIPTION
reveal ast node command can now open an ast explorer and reveal the node in the newly opened explorer

fixes #961 