### PR TITLE
Only use ocaml-env if it is available

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Change Log
 
+## Unreleased
+
+- Change the `ocaml.useOcamlEnv` setting to only enable `ocaml-env` usage for
+  opam commands if it is available on the system (#978)
+
 ## 1.11.0
 
 - Fix syntax highlighting for let bindings with type annotations (#991)

--- a/README.md
+++ b/README.md
@@ -214,7 +214,7 @@ the settings under `File > Preferences > Settings`.
 | `ocaml.sandbox`                    | Determines where to find the sandbox for a given project                                                | `null`  |
 | `ocaml.dune.autoDetect`            | Controls whether dune tasks should be automatically detected.                                           | `true`  |
 | `ocaml.trace.server`               | Controls the logging output of the language server. Valid settings are `off`, `messages`, or `verbose`. | `off`   |
-| `ocaml.useOcamlEnv`                | Controls whether to use ocaml-env for opam commands from OCaml for Windows.                             | `true`  |
+| `ocaml.useOcamlEnv`                | Controls whether to use ocaml-env (if available) for opam commands from OCaml for Windows.              | `true`  |
 | `ocaml.terminal.shell.linux`       | The path of the shell that the sandbox terminal uses on Linux                                           | `null`  |
 | `ocaml.terminal.shell.osx`         | The path of the shell that the sandbox terminal uses on macOS                                           | `null`  |
 | `ocaml.terminal.shell.windows`     | The path of the shell that the sandbox terminal uses on Windows                                         | `null`  |

--- a/package.json
+++ b/package.json
@@ -484,7 +484,7 @@
         "ocaml.useOcamlEnv": {
           "type": "boolean",
           "default": true,
-          "description": "Controls whether to use ocaml-env for opam commands from OCaml for Windows."
+          "description": "Controls whether to use ocaml-env (if available) for opam commands from OCaml for Windows."
         },
         "ocaml.terminal.shell.linux": {
           "description": "The path of the shell that the sandbox terminal uses on Linux",

--- a/src/ocaml_windows.ml
+++ b/src/ocaml_windows.ml
@@ -1,6 +1,6 @@
 open Import
 
-let ocaml_env_binary = Path.of_string "ocaml-env"
+let ocaml_env_command = { Cmd.bin = Path.of_string "ocaml-env"; args = [] }
 
 let ocaml_env_setting =
   Settings.create_setting
@@ -11,11 +11,14 @@ let ocaml_env_setting =
 
 let use_ocaml_env () =
   match (Platform.t, Settings.get ocaml_env_setting) with
-  | Win32, Some true -> true
-  | _ -> false
+  | Win32, Some true ->
+    let open Promise.Syntax in
+    let+ checked = Cmd.check_spawn ocaml_env_command in
+    Result.is_ok checked
+  | _ -> Promise.return false
 
 let spawn_ocaml_env args =
-  { Cmd.bin = ocaml_env_binary; args = "exec" :: "--" :: args }
+  { ocaml_env_command with args = "exec" :: "--" :: args }
 
 let cygwin_home () =
   let open Promise.Syntax in

--- a/src/ocaml_windows.mli
+++ b/src/ocaml_windows.mli
@@ -1,5 +1,5 @@
 (* Whether to use ocaml-env for opam on Windows *)
-val use_ocaml_env : unit -> bool
+val use_ocaml_env : unit -> bool Promise.t
 
 (* Spawn command from OCaml for Windows using ocaml-env *)
 val spawn_ocaml_env : string list -> Cmd.spawn

--- a/src/opam.ml
+++ b/src/opam.ml
@@ -8,12 +8,12 @@ type t =
 let opam_binary = Path.of_string "opam"
 
 let make ?root () =
+  let open Promise.Syntax in
+  let* use_ocaml_env = Ocaml_windows.use_ocaml_env () in
   let spawn =
-    if Ocaml_windows.use_ocaml_env () then
-      Ocaml_windows.spawn_ocaml_env [ "opam" ]
+    if use_ocaml_env then Ocaml_windows.spawn_ocaml_env [ "opam" ]
     else { Cmd.bin = opam_binary; args = [] }
   in
-  let open Promise.Syntax in
   let* spawn = Cmd.check_spawn spawn in
   match (spawn, root) with
   | Error _, _ -> Promise.return None


### PR DESCRIPTION
Resolves #977

This PR allows the extension to automatically use the Diskuv OCaml Windows executables from the PATH when `ocaml-env` does not exist.