### PR TITLE
Add support for `${firstWorkspaceFolder}` as a placeholder variable in configuration files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@
 
 - Fix syntax highlighting for let bindings with type annotations (#991)
 
+- Add support for `${firstWorkspaceFolder}` as a placeholder variable in
+  configuration files (#1004)
+
 ## 1.10.8
 
 - Add more known versions of ocamllsp


### PR DESCRIPTION
`${firstWorkspaceFolder}` can now be used as a placeholder variable in configuration files to avoid specifying a folder name with `${workspaceFolder:name}`. When VSCode only has one folder open, `${firstWorkspaceFolder}` will correspond to that folder.