### PR TITLE
remove `lint-opam` CI check

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -113,44 +113,6 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ github.token }}
 
-  lint-opam:
-    strategy:
-      matrix:
-        ocaml-compiler:
-          - 4.14.x
-        node-version:
-          - 16.x
-
-    runs-on: ubuntu-latest
-
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@v3
-
-      - name: Use OCaml ${{ matrix.ocaml-compiler }}
-        uses: ocaml/setup-ocaml@v2
-        with:
-          ocaml-compiler: ${{ matrix.ocaml-compiler }}
-          dune-cache: true
-
-      - name: Use Node.js ${{ matrix.node-version }}
-        uses: actions/setup-node@v3
-        with:
-          node-version: ${{ matrix.node-version }}
-
-      - name: Install npm packages
-        run: |
-          yarn --frozen-lockfile --cwd astexplorer
-          yarn --frozen-lockfile
-
-      - run: opam depext opam-dune-lint --install
-
-      - run: opam install . --deps-only
-
-      - run: opam exec -- make build-release
-
-      - run: opam exec -- opam-dune-lint
-
   lint-fmt:
     strategy:
       matrix:


### PR DESCRIPTION
This check always fails because we can't install `opam-dune-lint` because it conflicts with our deps. 