### PR TITLE
fix ast-explorer enable-scripts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@
 - Change the `ocaml.useOcamlEnv` setting to only enable `ocaml-env` usage for
   opam commands if it is available on the system (#978)
 
+- Fix AST Explorer not displaying anything with error "Blocked script execution" (#1050)
+
 ## 1.11.0
 
 - Fix syntax highlighting for let bindings with type annotations (#991)

--- a/src-bindings/vscode/vscode.ml
+++ b/src-bindings/vscode/vscode.ml
@@ -2724,21 +2724,20 @@ module WebviewOptions = struct
 
   include
     [%js:
-    val enableCommandUris : t -> bool [@@js.get]
+    val enableCommandUris : t -> bool option [@@js.get]
 
-    val enableScripts : t -> bool [@@js.get]
+    val enableScripts : t -> bool option [@@js.get]
 
-    val set_enableScripts : t -> bool -> unit [@@js.set]
+    val localResourceRoots : t -> Uri.t list option [@@js.get]
 
-    val localResourceRoots : t -> Uri.t list [@@js.get]
-
-    val portMapping : t -> WebviewPortMapping.t list [@@js.get]
+    val portMapping : t -> WebviewPortMapping.t list option [@@js.get]
 
     val create :
-         enableCommandUris:bool
-      -> enableScripts:bool
-      -> localResourceRoots:Uri.t list
-      -> portMapping:WebviewPortMapping.t list
+         ?enableCommandUris:bool
+      -> ?enableScripts:bool
+      -> ?localResourceRoots:Uri.t list
+      -> ?portMapping:WebviewPortMapping.t list
+      -> unit
       -> t
       [@@js.builder]]
 end

--- a/src-bindings/vscode/vscode.mli
+++ b/src-bindings/vscode/vscode.mli
@@ -2071,21 +2071,20 @@ end
 module WebviewOptions : sig
   include Js.T
 
-  val enableCommandUris : t -> bool
+  val enableCommandUris : t -> bool option
 
-  val enableScripts : t -> bool
+  val enableScripts : t -> bool option
 
-  val set_enableScripts : t -> bool -> unit
+  val localResourceRoots : t -> Uri.t list option
 
-  val localResourceRoots : t -> Uri.t list
-
-  val portMapping : t -> WebviewPortMapping.t list
+  val portMapping : t -> WebviewPortMapping.t list option
 
   val create :
-       enableCommandUris:bool
-    -> enableScripts:bool
-    -> localResourceRoots:Uri.t list
-    -> portMapping:WebviewPortMapping.t list
+       ?enableCommandUris:bool
+    -> ?enableScripts:bool
+    -> ?localResourceRoots:Uri.t list
+    -> ?portMapping:WebviewPortMapping.t list
+    -> unit
     -> t
 end
 

--- a/src/ast_editor.ml
+++ b/src/ast_editor.ml
@@ -238,6 +238,7 @@ let activate_hover_mode instance ~document =
 let resolveCustomTextEditor instance ~(document : TextDocument.t) ~webviewPanel
     ~token:_ : CustomTextEditorProvider.ResolvedEditor.t =
   let webview = WebviewPanel.webview webviewPanel in
+  WebView.set_options webview (WebviewOptions.create ~enableScripts:true ());
   let ast_editor_state = Extension_instance.ast_editor_state instance in
   Ast_editor_state.set_webview
     ast_editor_state
@@ -284,9 +285,6 @@ let resolveCustomTextEditor instance ~(document : TextDocument.t) ~webviewPanel
   (try transform_to_ast instance ~document ~webview
    with User_error err_msg ->
      send_msg "error" (Jsonoo.Encode.string err_msg |> Jsonoo.t_to_js) ~webview);
-  let options = WebView.options webview in
-  WebviewOptions.set_enableScripts options true;
-  WebView.set_options webview options;
   let p =
     let open Promise.Syntax in
     let+ r = read_html_file () in


### PR DESCRIPTION
* constructor fn for `WebviewOptions` incorrectly indicated that all fields were mandatory, while it's the opposite
* fields in `WebviewOptions` are also readonly in `vscode.d.ts`, which is not indicated in the vscode API webpage
* given the above, the previous code was incorrect to change fields of `WebviewOptions`
* the fix for ast-explorer comes from enabling the scripts earlier - so change of location of code is important for the fix

fixes #1046 