### PR TITLE
Reorder sandbox buttons

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Change Log
 
+## 1.12.3
+
+- Reorder sandbox buttons (#1083)
+
 ## 1.12.2
 
 - Add more known versions of ocamllsp

--- a/package.json
+++ b/package.json
@@ -429,11 +429,6 @@
           "group": "inline"
         },
         {
-          "command": "ocaml.uninstall-sandbox-package",
-          "when": "view == ocaml-sandbox",
-          "group": "inline"
-        },
-        {
           "command": "ocaml.open-switches-documentation",
           "when": "view == ocaml-switches && viewItem == package-with-doc",
           "group": "inline"
@@ -441,12 +436,17 @@
         {
           "command": "ocaml.open-sandbox-documentation",
           "when": "view == ocaml-sandbox && viewItem == package-with-doc",
-          "group": "inline"
+          "group": "inline@1"
         },
         {
           "command": "ocaml.generate-sandbox-documentation",
           "when": "view == ocaml-sandbox",
-          "group": "inline"
+          "group": "inline@2"
+        },
+        {
+          "command": "ocaml.uninstall-sandbox-package",
+          "when": "view == ocaml-sandbox",
+          "group": "inline@3"
         }
       ]
     },


### PR DESCRIPTION
Fixes #1054 
<img width="505" alt="Screenshot 2023-03-01 at 16 58 30" src="https://user-images.githubusercontent.com/22241847/222195299-08d456f1-a00c-4d21-8415-2d979e8fd273.png">

Ordering notation:
https://code.visualstudio.com/api/references/contribution-points#Sorting-inside-groups