### PR TITLE
Let prepare_code check trimmed code

### DIFF
--- a/src/repl.ml
+++ b/src/repl.ml
@@ -148,7 +148,7 @@ let get_code text_editor =
     Vscode.TextDocument.getText document ~range:(selection :> Vscode.Range.t) ()
 
 let prepare_code code =
-  if String.is_suffix code ~suffix:";;" then code else code ^ ";;"
+  if String.is_suffix (String.trim code) ~suffix:";;" then code else code ^ ";;"
 
 module Command = struct
   let _open_repl =


### PR DESCRIPTION
This patch resolves #1099 by using the trimmed code when checking whether the code has suffix `;;`.