### PR TITLE
Fix nix-shell for macOS

### DIFF
--- a/nix/default.nix
+++ b/nix/default.nix
@@ -4,6 +4,14 @@ let
   args = {
     inherit (pkgs.ocaml-ng.ocamlPackages_4_14) ocaml;
     selection = ./opam-selection.nix;
+    override = {pkg, selection}: {
+	    dune = super: super.overrideAttrs (attrs: {
+		    buildInputs =
+          (attrs.buildInputs or [])
+          ++ pkgs.lib.optionals stdenv.isDarwin
+            [ pkgs.darwin.apple_sdk.frameworks.CoreServices];
+      });
+    };
     src =
       let
         default = builtins.filterSource (path: type:


### PR DESCRIPTION
When trying to run `nix-shell` on macOS I get following error:
```
       > src/fsevents/fsevents_stubs.c:16:10: fatal error: 'CoreServices/CoreServices.h' file not found
       > #include <CoreServices/CoreServices.h>
       >          ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~
       > 1 error generated.
       > Command failed.
       For full logs, run 'nix log /nix/store/xp20z29pj9gv78jm3326sis3lyngwrdm-dune-3.7.1.drv'.
```

This PR fixes it