### PR TITLE
Add changelog check to CI

### DIFF
--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -1,0 +1,13 @@
+name: Changelog check
+
+on:
+  pull_request:
+    branches: [ master ]
+    types: [ opened, synchronize, reopened, labeled, unlabeled ]
+
+jobs:
+  Changelog-Entry-Check:
+    name: Check Changelog Action
+    runs-on: ubuntu-20.04
+    steps:
+      - uses: tarides/changelog-check-action@v1

--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -10,4 +10,4 @@ jobs:
     name: Check Changelog Action
     runs-on: ubuntu-20.04
     steps:
-      - uses: tarides/changelog-check-action@v1
+      - uses: tarides/changelog-check-action@v2

--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -2,8 +2,8 @@ name: Changelog check
 
 on:
   pull_request:
-    branches: [ master ]
-    types: [ opened, synchronize, reopened, labeled, unlabeled ]
+    branches: [master]
+    types: [opened, synchronize, reopened, labeled, unlabeled]
 
 jobs:
   Changelog-Entry-Check:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -75,11 +75,10 @@ very useful to:
 
 ### Changelog
 
-User-visible changes should come with an entry in the changelog under
-the appropriate part of the unreleased section. PR that doesn't
-provide an entry will fail CI check. This behavior can be overridden
-by using the "no changelog" label, which is used for changes that are
-not user-visible.
+User-visible changes should come with an entry in the changelog under the
+appropriate part of the unreleased section. PR that doesn't provide an entry
+will fail CI check. This behavior can be overridden by using the "no changelog"
+label, which is used for changes that are not user-visible.
 
 ## Repository Structure
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -73,6 +73,14 @@ very useful to:
 - Run the tests: this will check that all the data is correctly formatted and
   can be invoked with `make test`
 
+### Changelog
+
+User-visible changes should come with an entry in the changelog under
+the appropriate part of the unreleased section. PR that doesn't
+provide an entry will fail CI check. This behavior can be overridden
+by using the "no changelog" label, which is used for changes that are
+not user-visible.
+
 ## Repository Structure
 
 The following snippet describes VSCode OCaml's repository structure.


### PR DESCRIPTION
The same job is already used in ocaml-lsp. Let's add it to vscode plugin as well.