### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,9 +45,7 @@ full without all of its dependencies.
      project root directory.
 
    - When you hover the cursor over OCaml code, the extension shows you the type
-     of the code. To get nicely formatted types, install
-     [ocamlformat-rpc](https://opam.ocaml.org/packages/ocamlformat-rpc/)
-     package.
+     of the code.
 
 2. Install this extension from the VSCode
    [Marketplace](https://marketplace.visualstudio.com/items?itemName=ocamllabs.ocaml-platform).


### PR DESCRIPTION
ocamlformat-rpc is no longer needed since ocamlformat 0.22.4 (See https://github.com/ocaml/opam-repository/pull/23824)