### PR TITLE
Bump github actions

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -58,8 +58,9 @@ jobs:
         run: npm install --global esy
 
       - name: Install and build esy packages
-        uses: esy/github-action@v1
+        uses: esy/github-action@v2
         with:
+          node-version: 16
           working-directory: test/fixtures/sample-esy
           cache-key: ${{ hashFiles('esy.lock/index.json') }}
 

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -80,13 +80,13 @@ jobs:
 
       - name: Upload artifact
         if: runner.os == 'Linux'
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         with:
           name: ocaml-platform-${{ github.sha }}
           path: ocaml-platform.vsix
 
       - name: Test extension
-        uses: GabrielBB/xvfb-action@v1
+        uses: coactions/xvfb-action@v1
         with:
           run: yarn test
         env:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -58,7 +58,7 @@ jobs:
         run: npm install --global esy
 
       - name: Install and build esy packages
-        uses: esy/github-action@v2
+        uses: esy/github-action@v1
         with:
           node-version: 16
           working-directory: test/fixtures/sample-esy
@@ -86,7 +86,7 @@ jobs:
           path: ocaml-platform.vsix
 
       - name: Test extension
-        uses: coactions/xvfb-action@v1
+        uses: coactions/setup-xvfb@v1
         with:
           run: yarn test
         env:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -60,7 +60,6 @@ jobs:
       - name: Install and build esy packages
         uses: esy/github-action@v1
         with:
-          node-version: 16
           working-directory: test/fixtures/sample-esy
           cache-key: ${{ hashFiles('esy.lock/index.json') }}
 


### PR DESCRIPTION
This PR addresses following CI warnings:
```
Node.js 12 actions are deprecated. Please update the following actions to use Node.js 16: esy/github-action@v1, actions/upload-artifact@v2, GabrielBB/xvfb-action@v1. For more information see: https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/.
```

Bumped upload-artifact and xvfb-action. Esy cannot be bumped, because it's hardocoded to 12. I will create a PR to esy to change it