### PR TITLE
Run CI once on PR opening

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,8 +1,10 @@
 name: Main workflow
 
 on:
-  - pull_request
-  - push
+  pull_request:
+  push:
+    branches:
+      - master
 
 jobs:
   build:

--- a/.github/workflows/nix.yml
+++ b/.github/workflows/nix.yml
@@ -2,6 +2,8 @@ name: "Nix"
 on:
   pull_request:
   push:
+    branches:
+      - master
 jobs:
   tests:
     runs-on: ubuntu-latest


### PR DESCRIPTION
This solves a problem of running the same job twice:
<img width="976" alt="image" src="https://github.com/ocamllabs/vscode-ocaml-platform/assets/22241847/ad1b9e60-5c5c-432b-9fdc-6525cec77b0f">

Source:
https://github.com/ocamllabs/vscode-ocaml-platform/pull/1135