### PR TITLE
Fix astexplorer in `make build`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -21,7 +21,7 @@ switch: create_switch deps ## Create an opam switch and install development depe
 .PHONY: build
 build: ## Build the project
 	dune build src/vscode_ocaml_platform.bc.js
-	yarn --cwd astexplorer start
+	yarn --cwd astexplorer build
 	yarn esbuild _build/default/src/vscode_ocaml_platform.bc.js \
 		--bundle \
 		--external:vscode \


### PR DESCRIPTION
Previously `make build`, as suggested by CONTRIBUTING, fails with:
```
dune build src/vscode_ocaml_platform.bc.js
yarn --cwd astexplorer start           
yarn run v1.22.19
warning package.json: No license field
error Command "start" not found.
info Visit https://yarnpkg.com/en/docs/cli/run for documentation about this command.
make: *** [Makefile:24: build] Error 1
```