### PR TITLE
Support lsp server settings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - Trim whitespace when running `Evaluate Selection` command (#1100)
 - Encode URI when sending the `switchImplIntf` request (#983)
+- Support LSP server settings (#1157)
 
 ## 1.12.3
 

--- a/package.json
+++ b/package.json
@@ -472,6 +472,16 @@
           "default": [],
           "markdownDescription": "Extra arguments to pass to ocamllsp."
         },
+        "ocaml.server.codelens": {
+          "type": "boolean",
+          "default": false,
+          "markdownDescription": "Enable/Disable codelens"
+        },
+        "ocaml.server.extendedHover": {
+          "type": "boolean",
+          "default": false,
+          "markdownDescription": "Enable/Disable extended hover"
+        },
         "ocaml.dune.autoDetect": {
           "type": "boolean",
           "default": true,

--- a/package.json
+++ b/package.json
@@ -474,7 +474,7 @@
         },
         "ocaml.server.codelens": {
           "type": "boolean",
-          "default": false,
+          "default": true,
           "markdownDescription": "Enable/Disable codelens"
         },
         "ocaml.server.extendedHover": {

--- a/src-bindings/vscode/vscode.ml
+++ b/src-bindings/vscode/vscode.ml
@@ -2221,12 +2221,17 @@ module FileSystemWatcher = struct
   include [%js: val onDidChange : t -> OnDidChange.t [@@js.get]]
 end
 
+module ConfigurationChangeEvent = struct
+  include Interface.Make ()
+end
+
 module Workspace = struct
   module OnDidChangeWorkspaceFolders = Event.Make (WorkspaceFolder)
   module OnDidOpenTextDocument = Event.Make (TextDocument)
   module OnDidCloseTextDocument = Event.Make (TextDocument)
   module OnDidSaveTextDocument = Event.Make (TextDocument)
   module OnDidChangeTextDocument = Event.Make (TextDocumentChangeEvent)
+  module OnDidChangeConfiguration = Event.Make (ConfigurationChangeEvent)
 
   type textDocumentOptions =
     { language : string
@@ -2264,6 +2269,9 @@ module Workspace = struct
 
     val textDocuments : unit -> TextDocument.t list
       [@@js.get "vscode.workspace.textDocuments"]
+
+    val onDidChangeConfiguration : OnDidChangeConfiguration.t
+      [@@js.global "vscode.workspace.onDidChangeConfiguration"]
 
     val onDidChangeWorkspaceFolders : OnDidChangeWorkspaceFolders.t
       [@@js.global "vscode.workspace.onDidChangeWorkspaceFolders"]

--- a/src-bindings/vscode/vscode.mli
+++ b/src-bindings/vscode/vscode.mli
@@ -1730,6 +1730,10 @@ module FileSystemWatcher : sig
   val onDidChange : t -> Uri.t Event.t
 end
 
+module ConfigurationChangeEvent : sig
+  include Js.T
+end
+
 module Workspace : sig
   val workspaceFolders : unit -> WorkspaceFolder.t list
 
@@ -1750,6 +1754,8 @@ module Workspace : sig
   val onDidChangeWorkspaceFolders : WorkspaceFolder.t Event.t
 
   val onDidChangeTextDocument : TextDocumentChangeEvent.t Event.t
+
+  val onDidChangeConfiguration : ConfigurationChangeEvent.t Event.t
 
   val asRelativePath :
        pathOrUri:([ `String of string | `Uri of Uri.t ][@js.union])

--- a/src-bindings/vscode_languageclient/vscode_languageclient.ml
+++ b/src-bindings/vscode_languageclient/vscode_languageclient.ml
@@ -78,7 +78,7 @@ module DocumentSelector = struct
     `Filter (DocumentFilter.createLanguage ~language:l ~scheme ?pattern ())
 end
 
-module OcamllspSetting = struct
+module OcamllspSettingEnable = struct
   include Interface.Make ()
 
   include
@@ -88,32 +88,18 @@ module OcamllspSetting = struct
     val create : enable:bool -> unit -> t [@@js.builder]]
 end
 
-module OcamllspConfig = struct
+module OcamllspSettings = struct
   include Interface.Make ()
 
   include
     [%js:
-    val codelens : t -> OcamllspSetting.t or_undefined [@@js.get]
+    val codelens : t -> OcamllspSettingEnable.t or_undefined [@@js.get]
 
-    val extendedHover : t -> OcamllspSetting.t or_undefined [@@js.get]
-
-    val createCodelens :
-         codelens:OcamllspSetting.t
-      -> ?extendedHover:OcamllspSetting.t
-      -> unit
-      -> t
-      [@@js.builder]
-
-    val createExtendedHover :
-         ?codelens:OcamllspSetting.t
-      -> extendedHover:OcamllspSetting.t
-      -> unit
-      -> t
-      [@@js.builder]
+    val extendedHover : t -> OcamllspSettingEnable.t or_undefined [@@js.get]
 
     val create :
-         ?codelens:OcamllspSetting.t
-      -> ?extendedHover:OcamllspSetting.t
+         ?codelens:OcamllspSettingEnable.t
+      -> ?extendedHover:OcamllspSettingEnable.t
       -> unit
       -> t
       [@@js.builder]]
@@ -130,13 +116,13 @@ module ClientOptions = struct
 
     val revealOutputChannelOn : t -> RevealOutputChannelOn.t [@@js.get]
 
-    val initializationOptions : t -> OcamllspConfig.t [@@js.get]
+    val initializationOptions : t -> Jsonoo.t [@@js.get]
 
     val create :
          ?documentSelector:DocumentSelector.t
       -> ?outputChannel:Vscode.OutputChannel.t
       -> ?revealOutputChannelOn:RevealOutputChannelOn.t
-      -> ?initializationOptions:OcamllspConfig.t
+      -> ?initializationOptions:Jsonoo.t
       -> unit
       -> t
       [@@js.builder]]
@@ -224,7 +210,7 @@ module DidChangeConfiguration = struct
 
   include
     [%js:
-    val create : settings:OcamllspConfig.t -> unit -> t [@@js.builder]]
+    val create : settings:OcamllspSettings.t -> unit -> t [@@js.builder]]
 end
 
 module LanguageClient = struct
@@ -261,6 +247,5 @@ module LanguageClient = struct
 
     val registerFeature : t -> feature:StaticFeature.t -> unit [@@js.call]
 
-    val sendNotification : t -> string -> DidChangeConfiguration.t -> unit
-      [@@js.call]]
+    val sendNotification : t -> string -> Ojs.t -> unit [@@js.call]]
 end

--- a/src-bindings/vscode_languageclient/vscode_languageclient.ml
+++ b/src-bindings/vscode_languageclient/vscode_languageclient.ml
@@ -78,6 +78,25 @@ module DocumentSelector = struct
     `Filter (DocumentFilter.createLanguage ~language:l ~scheme ?pattern ())
 end
 
+module InitializationOptions = struct
+  include Interface.Make ()
+
+  include
+    [%js:
+    val codelens : t -> bool or_undefined [@@js.get]
+
+    val extendedHover : t -> bool or_undefined [@@js.get]
+
+    val createCodelens : codelens:bool -> ?extendedHover:bool -> unit -> t
+      [@@js.builder]
+
+    val createExtendedHover : ?codelens:bool -> extendedHover:bool -> unit -> t
+      [@@js.builder]
+
+    val create : ?codelens:bool -> ?extendedHover:bool -> unit -> t
+      [@@js.builder]]
+end
+
 module ClientOptions = struct
   include Interface.Make ()
 
@@ -89,10 +108,13 @@ module ClientOptions = struct
 
     val revealOutputChannelOn : t -> RevealOutputChannelOn.t [@@js.get]
 
+    val initializationOptions : t -> InitializationOptions.t [@@js.get]
+
     val create :
          ?documentSelector:DocumentSelector.t
       -> ?outputChannel:Vscode.OutputChannel.t
       -> ?revealOutputChannelOn:RevealOutputChannelOn.t
+      -> ?initializationOptions:InitializationOptions.t
       -> unit
       -> t
       [@@js.builder]]

--- a/src-bindings/vscode_languageclient/vscode_languageclient.ml
+++ b/src-bindings/vscode_languageclient/vscode_languageclient.ml
@@ -78,22 +78,44 @@ module DocumentSelector = struct
     `Filter (DocumentFilter.createLanguage ~language:l ~scheme ?pattern ())
 end
 
-module InitializationOptions = struct
+module OcamllspSetting = struct
   include Interface.Make ()
 
   include
     [%js:
-    val codelens : t -> bool or_undefined [@@js.get]
+    val enable : t -> bool or_undefined [@@js.get]
 
-    val extendedHover : t -> bool or_undefined [@@js.get]
+    val create : enable:bool -> unit -> t [@@js.builder]]
+end
 
-    val createCodelens : codelens:bool -> ?extendedHover:bool -> unit -> t
+module OcamllspConfig = struct
+  include Interface.Make ()
+
+  include
+    [%js:
+    val codelens : t -> OcamllspSetting.t or_undefined [@@js.get]
+
+    val extendedHover : t -> OcamllspSetting.t or_undefined [@@js.get]
+
+    val createCodelens :
+         codelens:OcamllspSetting.t
+      -> ?extendedHover:OcamllspSetting.t
+      -> unit
+      -> t
       [@@js.builder]
 
-    val createExtendedHover : ?codelens:bool -> extendedHover:bool -> unit -> t
+    val createExtendedHover :
+         ?codelens:OcamllspSetting.t
+      -> extendedHover:OcamllspSetting.t
+      -> unit
+      -> t
       [@@js.builder]
 
-    val create : ?codelens:bool -> ?extendedHover:bool -> unit -> t
+    val create :
+         ?codelens:OcamllspSetting.t
+      -> ?extendedHover:OcamllspSetting.t
+      -> unit
+      -> t
       [@@js.builder]]
 end
 
@@ -108,13 +130,13 @@ module ClientOptions = struct
 
     val revealOutputChannelOn : t -> RevealOutputChannelOn.t [@@js.get]
 
-    val initializationOptions : t -> InitializationOptions.t [@@js.get]
+    val initializationOptions : t -> OcamllspConfig.t [@@js.get]
 
     val create :
          ?documentSelector:DocumentSelector.t
       -> ?outputChannel:Vscode.OutputChannel.t
       -> ?revealOutputChannelOn:RevealOutputChannelOn.t
-      -> ?initializationOptions:InitializationOptions.t
+      -> ?initializationOptions:OcamllspConfig.t
       -> unit
       -> t
       [@@js.builder]]
@@ -197,6 +219,14 @@ module StaticFeature = struct
       [@@js.builder]]
 end
 
+module DidChangeConfiguration = struct
+  include Interface.Make ()
+
+  include
+    [%js:
+    val create : settings:OcamllspConfig.t -> unit -> t [@@js.builder]]
+end
+
 module LanguageClient = struct
   include Class.Make ()
 
@@ -229,5 +259,8 @@ module LanguageClient = struct
       -> Jsonoo.t Promise.t
       [@@js.call]
 
-    val registerFeature : t -> feature:StaticFeature.t -> unit [@@js.call]]
+    val registerFeature : t -> feature:StaticFeature.t -> unit [@@js.call]
+
+    val sendNotification : t -> string -> DidChangeConfiguration.t -> unit
+      [@@js.call]]
 end

--- a/src-bindings/vscode_languageclient/vscode_languageclient.mli
+++ b/src-bindings/vscode_languageclient/vscode_languageclient.mli
@@ -63,7 +63,7 @@ module DocumentSelector : sig
   val language : ?scheme:string -> ?pattern:string -> string -> selector
 end
 
-module OcamllspSetting : sig
+module OcamllspSettingEnable : sig
   include Js.T
 
   val enable : t -> bool option
@@ -71,21 +71,18 @@ module OcamllspSetting : sig
   val create : enable:bool -> unit -> t
 end
 
-module OcamllspConfig : sig
+module OcamllspSettings : sig
   include Js.T
 
-  val codelens : t -> OcamllspSetting.t option
+  val codelens : t -> OcamllspSettingEnable.t option
 
-  val extendedHover : t -> OcamllspSetting.t option
-
-  val createCodelens :
-    codelens:OcamllspSetting.t -> ?extendedHover:OcamllspSetting.t -> unit -> t
-
-  val createExtendedHover :
-    ?codelens:OcamllspSetting.t -> extendedHover:OcamllspSetting.t -> unit -> t
+  val extendedHover : t -> OcamllspSettingEnable.t option
 
   val create :
-    ?codelens:OcamllspSetting.t -> ?extendedHover:OcamllspSetting.t -> unit -> t
+       ?codelens:OcamllspSettingEnable.t
+    -> ?extendedHover:OcamllspSettingEnable.t
+    -> unit
+    -> t
 end
 
 module ClientOptions : sig
@@ -97,13 +94,13 @@ module ClientOptions : sig
 
   val revealOutputChannelOn : t -> RevealOutputChannelOn.t
 
-  val initializationOptions : t -> OcamllspConfig.t
+  val initializationOptions : t -> Jsonoo.t
 
   val create :
        ?documentSelector:DocumentSelector.t
     -> ?outputChannel:Vscode.OutputChannel.t
     -> ?revealOutputChannelOn:RevealOutputChannelOn.t
-    -> ?initializationOptions:OcamllspConfig.t
+    -> ?initializationOptions:Jsonoo.t
     -> unit
     -> t
 end
@@ -177,7 +174,7 @@ end
 module DidChangeConfiguration : sig
   include Js.T
 
-  val create : settings:OcamllspConfig.t -> unit -> t
+  val create : settings:OcamllspSettings.t -> unit -> t
 end
 
 module LanguageClient : sig
@@ -211,5 +208,5 @@ module LanguageClient : sig
 
   val registerFeature : t -> feature:StaticFeature.t -> unit
 
-  val sendNotification : t -> string -> DidChangeConfiguration.t -> unit
+  val sendNotification : t -> string -> Ojs.t -> unit
 end

--- a/src-bindings/vscode_languageclient/vscode_languageclient.mli
+++ b/src-bindings/vscode_languageclient/vscode_languageclient.mli
@@ -63,18 +63,29 @@ module DocumentSelector : sig
   val language : ?scheme:string -> ?pattern:string -> string -> selector
 end
 
-module InitializationOptions : sig
+module OcamllspSetting : sig
   include Js.T
 
-  val codelens : t -> bool option
+  val enable : t -> bool option
 
-  val extendedHover : t -> bool option
+  val create : enable:bool -> unit -> t
+end
 
-  val createCodelens : codelens:bool -> ?extendedHover:bool -> unit -> t
+module OcamllspConfig : sig
+  include Js.T
 
-  val createExtendedHover : ?codelens:bool -> extendedHover:bool -> unit -> t
+  val codelens : t -> OcamllspSetting.t option
 
-  val create : ?codelens:bool -> ?extendedHover:bool -> unit -> t
+  val extendedHover : t -> OcamllspSetting.t option
+
+  val createCodelens :
+    codelens:OcamllspSetting.t -> ?extendedHover:OcamllspSetting.t -> unit -> t
+
+  val createExtendedHover :
+    ?codelens:OcamllspSetting.t -> extendedHover:OcamllspSetting.t -> unit -> t
+
+  val create :
+    ?codelens:OcamllspSetting.t -> ?extendedHover:OcamllspSetting.t -> unit -> t
 end
 
 module ClientOptions : sig
@@ -86,13 +97,13 @@ module ClientOptions : sig
 
   val revealOutputChannelOn : t -> RevealOutputChannelOn.t
 
-  val initializationOptions : t -> InitializationOptions.t
+  val initializationOptions : t -> OcamllspConfig.t
 
   val create :
        ?documentSelector:DocumentSelector.t
     -> ?outputChannel:Vscode.OutputChannel.t
     -> ?revealOutputChannelOn:RevealOutputChannelOn.t
-    -> ?initializationOptions:InitializationOptions.t
+    -> ?initializationOptions:OcamllspConfig.t
     -> unit
     -> t
 end
@@ -163,6 +174,12 @@ module StaticFeature : sig
     -> t
 end
 
+module DidChangeConfiguration : sig
+  include Js.T
+
+  val create : settings:OcamllspConfig.t -> unit -> t
+end
+
 module LanguageClient : sig
   include Js.T
 
@@ -193,4 +210,6 @@ module LanguageClient : sig
     -> Jsonoo.t Promise.t
 
   val registerFeature : t -> feature:StaticFeature.t -> unit
+
+  val sendNotification : t -> string -> DidChangeConfiguration.t -> unit
 end

--- a/src-bindings/vscode_languageclient/vscode_languageclient.mli
+++ b/src-bindings/vscode_languageclient/vscode_languageclient.mli
@@ -63,6 +63,20 @@ module DocumentSelector : sig
   val language : ?scheme:string -> ?pattern:string -> string -> selector
 end
 
+module InitializationOptions : sig
+  include Js.T
+
+  val codelens : t -> bool option
+
+  val extendedHover : t -> bool option
+
+  val createCodelens : codelens:bool -> ?extendedHover:bool -> unit -> t
+
+  val createExtendedHover : ?codelens:bool -> extendedHover:bool -> unit -> t
+
+  val create : ?codelens:bool -> ?extendedHover:bool -> unit -> t
+end
+
 module ClientOptions : sig
   include Js.T
 
@@ -72,10 +86,13 @@ module ClientOptions : sig
 
   val revealOutputChannelOn : t -> RevealOutputChannelOn.t
 
+  val initializationOptions : t -> InitializationOptions.t
+
   val create :
        ?documentSelector:DocumentSelector.t
     -> ?outputChannel:Vscode.OutputChannel.t
     -> ?revealOutputChannelOn:RevealOutputChannelOn.t
+    -> ?initializationOptions:InitializationOptions.t
     -> unit
     -> t
 end

--- a/src/extension_instance.ml
+++ b/src/extension_instance.ml
@@ -46,10 +46,17 @@ end = struct
     in
     let (lazy outputChannel) = Output.language_server_output_channel in
     let revealOutputChannelOn = LanguageClient.RevealOutputChannelOn.Never in
+    let initializationOptions =
+      LanguageClient.InitializationOptions.create
+        ?codelens:Settings.(get server_codelens_setting)
+        ?extendedHover:Settings.(get server_extendedHover_setting)
+        ()
+    in
     LanguageClient.ClientOptions.create
       ~outputChannel
       ~revealOutputChannelOn
       ~documentSelector
+      ~initializationOptions
       ()
 
   let server_options sandbox =

--- a/src/extension_instance.ml
+++ b/src/extension_instance.ml
@@ -47,10 +47,17 @@ end = struct
     let (lazy outputChannel) = Output.language_server_output_channel in
     let revealOutputChannelOn = LanguageClient.RevealOutputChannelOn.Never in
     let initializationOptions =
-      LanguageClient.InitializationOptions.create
-        ?codelens:Settings.(get server_codelens_setting)
-        ?extendedHover:Settings.(get server_extendedHover_setting)
-        ()
+      let codelens =
+        Option.map
+          Settings.(get server_codelens_setting)
+          ~f:(fun enable -> LanguageClient.OcamllspSetting.create ~enable ())
+      in
+      let extendedHover =
+        Option.map
+          Settings.(get server_extendedHover_setting)
+          ~f:(fun enable -> LanguageClient.OcamllspSetting.create ~enable ())
+      in
+      LanguageClient.OcamllspConfig.create ?codelens ?extendedHover ()
     in
     LanguageClient.ClientOptions.create
       ~outputChannel

--- a/src/extension_instance.ml
+++ b/src/extension_instance.ml
@@ -46,24 +46,10 @@ end = struct
     in
     let (lazy outputChannel) = Output.language_server_output_channel in
     let revealOutputChannelOn = LanguageClient.RevealOutputChannelOn.Never in
-    let initializationOptions =
-      let codelens =
-        Option.map
-          Settings.(get server_codelens_setting)
-          ~f:(fun enable -> LanguageClient.OcamllspSetting.create ~enable ())
-      in
-      let extendedHover =
-        Option.map
-          Settings.(get server_extendedHover_setting)
-          ~f:(fun enable -> LanguageClient.OcamllspSetting.create ~enable ())
-      in
-      LanguageClient.OcamllspConfig.create ?codelens ?extendedHover ()
-    in
     LanguageClient.ClientOptions.create
       ~outputChannel
       ~revealOutputChannelOn
       ~documentSelector
-      ~initializationOptions
       ()
 
   let server_options sandbox =

--- a/src/settings.ml
+++ b/src/settings.ml
@@ -118,12 +118,12 @@ let server_codelens_setting =
   create_setting
     ~scope:ConfigurationTarget.Workspace
     ~key:"ocaml.server.codelens"
-    ~of_json:Jsonoo.Decode.(bool)
-    ~to_json:Jsonoo.Encode.(bool)
+    ~of_json:Jsonoo.Decode.bool
+    ~to_json:Jsonoo.Encode.bool
 
 let server_extendedHover_setting =
   create_setting
     ~scope:ConfigurationTarget.Workspace
     ~key:"ocaml.server.extendedHover"
-    ~of_json:Jsonoo.Decode.(bool)
-    ~to_json:Jsonoo.Encode.(bool)
+    ~of_json:Jsonoo.Decode.bool
+    ~to_json:Jsonoo.Encode.bool

--- a/src/settings.ml
+++ b/src/settings.ml
@@ -113,3 +113,17 @@ let server_args_setting =
     ~key:"ocaml.server.args"
     ~of_json:Jsonoo.Decode.(list string)
     ~to_json:Jsonoo.Encode.(list string)
+
+let server_codelens_setting =
+  create_setting
+    ~scope:ConfigurationTarget.Workspace
+    ~key:"ocaml.server.codelens"
+    ~of_json:Jsonoo.Decode.(bool)
+    ~to_json:Jsonoo.Encode.(bool)
+
+let server_extendedHover_setting =
+  create_setting
+    ~scope:ConfigurationTarget.Workspace
+    ~key:"ocaml.server.extendedHover"
+    ~of_json:Jsonoo.Decode.(bool)
+    ~to_json:Jsonoo.Encode.(bool)

--- a/src/settings.mli
+++ b/src/settings.mli
@@ -37,3 +37,7 @@ val substitute_workspace_vars : string -> string
 val server_extraEnv : unit -> string Interop.Dict.t option
 
 val server_args_setting : string list setting
+
+val server_codelens_setting : bool setting
+
+val server_extendedHover_setting : bool setting

--- a/src/vscode_ocaml_platform.ml
+++ b/src/vscode_ocaml_platform.ml
@@ -20,12 +20,48 @@ let suggest_to_pick_sandbox () =
       in
       ())
 
+let notify_configuration_changes instance =
+  Workspace.onDidChangeConfiguration
+    ~listener:(fun _event ->
+      match Extension_instance.language_client instance with
+      | None -> ()
+      | Some client ->
+        let codelens =
+          Option.map
+            Settings.(get server_codelens_setting)
+            ~f:(fun enable ->
+              LanguageClient.OcamllspSettingEnable.create ~enable ())
+        in
+        let extendedHover =
+          Option.map
+            Settings.(get server_extendedHover_setting)
+            ~f:(fun enable ->
+              LanguageClient.OcamllspSettingEnable.create ~enable ())
+        in
+        let settings =
+          LanguageClient.OcamllspSettings.create ?codelens ?extendedHover ()
+        in
+        let payload =
+          let settings =
+            LanguageClient.DidChangeConfiguration.create ~settings ()
+          in
+          LanguageClient.DidChangeConfiguration.t_to_js settings
+        in
+        LanguageClient.sendNotification
+          client
+          "workspace/didChangeConfiguration"
+          payload)
+    ()
+
 let activate (extension : ExtensionContext.t) =
   let open Promise.Syntax in
   let instance = Extension_instance.make () in
   ExtensionContext.subscribe
     extension
     ~disposable:(Extension_instance.disposable instance);
+  ExtensionContext.subscribe
+    extension
+    ~disposable:(notify_configuration_changes instance);
   Dune_formatter.register extension instance;
   Dune_task_provider.register extension instance;
   Extension_commands.register_all_commands extension instance;
@@ -37,37 +73,6 @@ let activate (extension : ExtensionContext.t) =
   Cm_editor.register extension instance;
   Repl.register extension instance;
   let sandbox_opt = Sandbox.of_settings_or_detect () in
-  ExtensionContext.subscribe
-    extension
-    ~disposable:
-      (Workspace.onDidChangeConfiguration
-         ~listener:(fun _event ->
-           match Extension_instance.language_client instance with
-           | None -> ()
-           | Some client ->
-             let codelens =
-               Option.map
-                 Settings.(get server_codelens_setting)
-                 ~f:(fun enable ->
-                   LanguageClient.OcamllspSetting.create ~enable ())
-             in
-             let extendedHover =
-               Option.map
-                 Settings.(get server_extendedHover_setting)
-                 ~f:(fun enable ->
-                   LanguageClient.OcamllspSetting.create ~enable ())
-             in
-             let options =
-               LanguageClient.OcamllspConfig.create ?codelens ?extendedHover ()
-             in
-             let payload =
-               LanguageClient.DidChangeConfiguration.create ~settings:options ()
-             in
-             LanguageClient.sendNotification
-               client
-               "workspace/didChangeConfiguration"
-               payload)
-         ());
   let (_ : unit Promise.t) =
     let* sandbox_opt in
     let is_fallback = Option.is_none sandbox_opt in


### PR DESCRIPTION
ocamllsp has settings for codelens and extendedHover. They can be changed dynamically. And they are now critical since by default the codelens are disabled without an easy way to restore them. This is an effort to support those settings in vscode.

https://github.com/ocaml/ocaml-lsp/blob/ca325e770100adca845a563cad7eaffa75480fbc/ocaml-lsp-server/docs/ocamllsp/config.md?plain=1#L1-L25
https://github.com/ocaml/ocaml-lsp/pull/1134

This work is paid for by Ahrefs.