### PR TITLE
Preserve focus when sending to repl

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 - Support LSP server settings (#1157)
 
+- Maintain focus on editor when sending code to REPL (#1161)
+
 ## 1.12.2
 
 - Add more known versions of ocamllsp

--- a/src/extension_instance.ml
+++ b/src/extension_instance.ml
@@ -326,7 +326,7 @@ let update_ocaml_info t =
 
 let open_terminal sandbox =
   let terminal = Terminal_sandbox.create sandbox in
-  Terminal_sandbox.show terminal
+  Terminal_sandbox.show ~preserveFocus:false terminal
 
 let ast_editor_state t = t.ast_editor_state
 

--- a/src/repl.ml
+++ b/src/repl.ml
@@ -94,7 +94,7 @@ let default_repl sandbox =
 let create_terminal instance sandbox =
   match Extension_instance.repl instance with
   | Some term ->
-    Terminal_sandbox.show term;
+    Terminal_sandbox.show ~preserveFocus:true term;
     Promise.return (Ok term)
   | None -> (
     let open Promise.Syntax in
@@ -113,7 +113,7 @@ let create_terminal instance sandbox =
         (Error "Running a REPL from a Shell command is not supported")
     | Ok (Spawn cmd) -> (
       let term = Terminal_sandbox.create ~name ~command:cmd sandbox in
-      Terminal_sandbox.show term;
+      Terminal_sandbox.show ~preserveFocus:true term;
       (* Wait for UTop or OCaml REPL to be initialized before sending text to
          the terminal.
 

--- a/src/terminal_sandbox.ml
+++ b/src/terminal_sandbox.ml
@@ -91,7 +91,7 @@ let create ?name ?command sandbox =
 
 let dispose = Terminal.dispose
 
-let show t = Terminal.show t ()
+let show ?preserveFocus t = Terminal.show ?preserveFocus t ()
 
 let send t text =
   let addNewLine = not (String.is_suffix text ~suffix:"\n") in

--- a/src/terminal_sandbox.ml
+++ b/src/terminal_sandbox.ml
@@ -91,7 +91,7 @@ let create ?name ?command sandbox =
 
 let dispose = Terminal.dispose
 
-let show ?preserveFocus t = Terminal.show ?preserveFocus t ()
+let show preserveFocus t = Terminal.show ~preserveFocus t ()
 
 let send t text =
   let addNewLine = not (String.is_suffix text ~suffix:"\n") in

--- a/src/terminal_sandbox.ml
+++ b/src/terminal_sandbox.ml
@@ -91,7 +91,7 @@ let create ?name ?command sandbox =
 
 let dispose = Terminal.dispose
 
-let show preserveFocus t = Terminal.show ~preserveFocus t ()
+let show ~preserveFocus t = Terminal.show ~preserveFocus t ()
 
 let send t text =
   let addNewLine = not (String.is_suffix text ~suffix:"\n") in

--- a/src/terminal_sandbox.mli
+++ b/src/terminal_sandbox.mli
@@ -4,6 +4,6 @@ val create : ?name:string -> ?command:Cmd.spawn -> Sandbox.t -> t
 
 val dispose : t -> unit
 
-val show : ?preserveFocus:bool -> t -> unit
+val show : preserveFocus:bool -> t -> unit
 
 val send : t -> string -> unit

--- a/src/terminal_sandbox.mli
+++ b/src/terminal_sandbox.mli
@@ -4,6 +4,6 @@ val create : ?name:string -> ?command:Cmd.spawn -> Sandbox.t -> t
 
 val dispose : t -> unit
 
-val show : t -> unit
+val show : ?preserveFocus:bool -> t -> unit
 
 val send : t -> string -> unit


### PR DESCRIPTION
This just grabs the preserve focus part of this PR https://github.com/ocamllabs/vscode-ocaml-platform/pull/951 which seems stalled. I don't feel strongly about the rest of that PR, but loosing focus on the editor every time i use the repl Is a massive pain and basically just feels like a bug. So I'd love to get that little part merged :).