### PR TITLE
[Reason] Disable semantic highlight

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,8 @@
 
 # Unreleased
 
-- Disable semantic highlight in reason files to fix highlighting when opening them over ssh (#1231)
+- Disable semantic highlight in reason files to fix highlighting when opening
+  them over ssh (#1231)
 
 # 1.13.1
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Change Log
 
+# Unreleased
+
+- Disable semantic highlight in reason files to fix highlighting when opening them over ssh (#1231)
+
 # 1.13.1
 
 - Fix highlighting of flags stanza in dune files (#1182)

--- a/package.json
+++ b/package.json
@@ -633,6 +633,9 @@
       "[cram]": {
         "editor.tabSize": 2,
         "editor.insertSpaces": true
+      },
+      "[reason]": {
+        "editor.semanticHighlighting.enabled": false
       }
     },
     "problemMatchers": [


### PR DESCRIPTION
Fixes #1087.

It seems the reason syntax in `reason.json` is not ready for [semantic highlight](https://code.visualstudio.com/api/language-extensions/semantic-highlight-guide). For some reason, this would break highlighting only when opening Reason files over ssh.

Disabling this option fixes the issue, until the necessary parts in the extension are adapted to support semantic highlight.