### PR TITLE
Indentation increase for more let expressions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 # Unreleased
 
 - Indentation level is increased more reliably for `let`, `and`, and their
-  binding operator equivalents.
+  binding operator equivalents (#1237)
 
 - Disable semantic highlight in reason files to fix highlighting when opening
   them over ssh (#1231)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,8 @@
 
 # Unreleased
 
-- Indentation level for let, let*, and let+ expressions increased for identifiers with single quotes.
+- Indentation level for let, let\*, and let+ expressions and their and
+  equivalents increased for identifiers with single quotes.
 
 - Disable semantic highlight in reason files to fix highlighting when opening
   them over ssh (#1231)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 # Unreleased
 
+- Indentation level for let, let*, and let+ expressions increased for identifiers with single quotes.
+
 - Disable semantic highlight in reason files to fix highlighting when opening
   them over ssh (#1231)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,8 +2,8 @@
 
 # Unreleased
 
-- Indentation level for let, let\*, and let+ expressions and their and
-  equivalents increased for identifiers with single quotes.
+- Indentation level is increased more reliably for `let`, `and`, and their
+  binding operator equivalents.
 
 - Disable semantic highlight in reason files to fix highlighting when opening
   them over ssh (#1231)

--- a/languages/ocaml.json
+++ b/languages/ocaml.json
@@ -25,7 +25,7 @@
   ],
   "indentationRules": {
     "decreaseIndentPattern": "^\\s*(end|done|with|in|else)\\b|^\\s*;;",
-    "increaseIndentPattern": "\\b(begin|object)\\s*$|\\blet[\\*\\+]? [a-zA-Z0-9'_-]+( [^ ]+)* =\\s*$|method!?[ \\t]+.*=[ \\t]*$|->[ \\t]*$|\\b(for|while)(_lwt)?[ \\t]+.*[ \\t]+do[ \\t]*$|(\\btry(_lwt)?$|\\bif\\s+.*\\sthen$|\\belse|[:=]\\s*sig|=\\s*struct)\\s*$",
+    "increaseIndentPattern": "\\b(begin|object)\\s*$|\\b(let|and)[\\*\\+]? [a-zA-Z0-9'_-]+( [^ ]+)* =\\s*$|method!?[ \\t]+.*=[ \\t]*$|->[ \\t]*$|\\b(for|while)(_lwt)?[ \\t]+.*[ \\t]+do[ \\t]*$|(\\btry(_lwt)?$|\\bif\\s+.*\\sthen$|\\belse|[:=]\\s*sig|=\\s*struct)\\s*$",
     "indentNextLinePattern": "(?!\\bif.*then.*(else.*|(;|[ \\t]in)[ \\t]*$))\\bif|\\bthen[ \\t]*$|\\belse[ \\t]*$$"
   },
   "onEnterRules": [

--- a/languages/ocaml.json
+++ b/languages/ocaml.json
@@ -25,7 +25,7 @@
   ],
   "indentationRules": {
     "decreaseIndentPattern": "^\\s*(end|done|with|in|else)\\b|^\\s*;;",
-    "increaseIndentPattern": "\\b(begin|object)\\s*$|\\blet [a-zA-Z0-9_-]+( [^ ]+)* =\\s*$|method!?[ \\t]+.*=[ \\t]*$|->[ \\t]*$|\\b(for|while)(_lwt)?[ \\t]+.*[ \\t]+do[ \\t]*$|(\\btry(_lwt)?$|\\bif\\s+.*\\sthen$|\\belse|[:=]\\s*sig|=\\s*struct)\\s*$",
+    "increaseIndentPattern": "\\b(begin|object)\\s*$|\\blet[\\*\\+]? [a-zA-Z0-9'_-]+( [^ ]+)* =\\s*$|method!?[ \\t]+.*=[ \\t]*$|->[ \\t]*$|\\b(for|while)(_lwt)?[ \\t]+.*[ \\t]+do[ \\t]*$|(\\btry(_lwt)?$|\\bif\\s+.*\\sthen$|\\belse|[:=]\\s*sig|=\\s*struct)\\s*$",
     "indentNextLinePattern": "(?!\\bif.*then.*(else.*|(;|[ \\t]in)[ \\t]*$))\\bif|\\bthen[ \\t]*$|\\belse[ \\t]*$$"
   },
   "onEnterRules": [

--- a/languages/ocaml.json
+++ b/languages/ocaml.json
@@ -25,7 +25,7 @@
   ],
   "indentationRules": {
     "decreaseIndentPattern": "^\\s*(end|done|with|in|else)\\b|^\\s*;;",
-    "increaseIndentPattern": "\\b(begin|object)\\s*$|\\b(let|and)[\\*\\+]? [a-zA-Z0-9'_-]+( [^ ]+)* =\\s*$|method!?[ \\t]+.*=[ \\t]*$|->[ \\t]*$|\\b(for|while)(_lwt)?[ \\t]+.*[ \\t]+do[ \\t]*$|(\\btry(_lwt)?$|\\bif\\s+.*\\sthen$|\\belse|[:=]\\s*sig|=\\s*struct)\\s*$",
+    "increaseIndentPattern": "\\b(begin|object)\\s*$|\\b(let|and)([$&*+\\-/=>@^|<][!?$&*+\\-/=>@^|%:]*)? [a-zA-Z0-9'_-]+( [^ ]+)* =\\s*$|method!?[ \\t]+.*=[ \\t]*$|->[ \\t]*$|\\b(for|while)(_lwt)?[ \\t]+.*[ \\t]+do[ \\t]*$|(\\btry(_lwt)?$|\\bif\\s+.*\\sthen$|\\belse|[:=]\\s*sig|=\\s*struct)\\s*$",
     "indentNextLinePattern": "(?!\\bif.*then.*(else.*|(;|[ \\t]in)[ \\t]*$))\\bif|\\bthen[ \\t]*$|\\belse[ \\t]*$$"
   },
   "onEnterRules": [


### PR DESCRIPTION
Right now if you write a let expression where the identifier has a single quote in it, the indentation level won't be increased. Then when you write an `in` keyword, the level will be decreased resulting in something like:

```ocaml
let test =
  let a' =
  2
in
a' + foo
```

The same thing applies for `let*` and `let+` expressions:
```ocaml
let test =
  let* a =
  bar
in
ret (a + foo)
```

This PR modifies the indentation regex so that all the binding operators for `let` and `and` are matched as well as single quotes in the identifier:

```ocaml
let test =
  let* a' =
    bar
  in
  ret (a' + foo)
```