### PR TITLE
VScode 1.82.0

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -14,3 +14,5 @@ updates:
     labels:
       - dependencies
       - no changelog
+    ignore:
+      - dependency-name: "@types/vscode"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 # Unreleased
 
+- Set the VSCode lower bound to 1.82.0 and set the build target to es2022 to get
+  better runtime performance (#1245)
+
 ## 1.13.2
 
 - Indentation level is increased more reliably for `let`, `and`, and their

--- a/Makefile
+++ b/Makefile
@@ -29,7 +29,7 @@ build: ## Build the project
 		--external:vscode \
 		--outdir=dist \
 		--platform=node \
-		--target=es6 \
+		--target=es2022 \
 		--sourcemap
 
 .PHONY: build-release
@@ -41,7 +41,7 @@ build-release:
 		--external:vscode \
 		--outdir=dist \
 		--platform=node \
-		--target=es6 \
+		--target=es2022 \
 		--minify-whitespace \
 		--minify-syntax \
 		--sourcemap \

--- a/package.json
+++ b/package.json
@@ -1209,7 +1209,7 @@
     "vscode-languageclient": "9.0.1"
   },
   "devDependencies": {
-    "@types/vscode": "1.64.0",
+    "@types/vscode": "1.82.0",
     "@vscode/test-electron": "2.3.5",
     "@vscode/vsce": "2.21.1",
     "esbuild": "0.19.5",
@@ -1222,7 +1222,7 @@
   },
   "packageManager": "yarn@4.0.0+sha256.6d855253732ba8d231b6cd917961654f6c8439164c962a4e355c9c58360ebe44",
   "engines": {
-    "vscode": "^1.64.0"
+    "vscode": "^1.82.0"
   },
   "icon": "assets/logo.png"
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -1419,10 +1419,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@types/vscode@npm:1.64.0":
-  version: 1.64.0
-  resolution: "@types/vscode@npm:1.64.0"
-  checksum: 5d14a8211887d2f368a57cdb1fe2b99e0fe175daa2dddb9d1413384f78191fe6e40a3c27c0216c05b957178c6facb6d7e841ce03c96e76d53fbd061cec71cbd4
+"@types/vscode@npm:1.82.0":
+  version: 1.82.0
+  resolution: "@types/vscode@npm:1.82.0"
+  checksum: 5ebc17c52edac6873cf37ce33e9fde160d6b4591c7b6928ed68ebed3e703228c8234fb05f49e25020ef775ecc9076b097452d7f6a6b2cdaceb334d6d4881fc4c
   languageName: node
   linkType: hard
 
@@ -4595,7 +4595,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "ocaml-platform@workspace:."
   dependencies:
-    "@types/vscode": "npm:1.64.0"
+    "@types/vscode": "npm:1.82.0"
     "@vscode/test-electron": "npm:2.3.5"
     "@vscode/vsce": "npm:2.21.1"
     esbuild: "npm:0.19.5"


### PR DESCRIPTION
VScode v1.82.0 and later uses Electron v25, which uses Node.js v18 internally[^1], so we should be able to safely raise the ECMAScript version[^2].

[^1]: https://github.com/ewanharris/vscode-versions
[^2]: https://node.green