### PR TITLE
Simplify gen_js_api bindings

### DIFF
--- a/src-bindings/interop/interop.ml
+++ b/src-bindings/interop/interop.ml
@@ -88,6 +88,14 @@ end
 module Js = struct
   type 'a t = (module Ojs.T with type t = 'a)
 
+  module type Generic = sig
+    type 'a t
+
+    val t_to_js : ('a -> Ojs.t) -> 'a t -> Ojs.t
+
+    val t_of_js : (Ojs.t -> 'a) -> Ojs.t -> 'a t
+  end
+
   module Unit = struct
     type t = unit
 

--- a/src-bindings/interop/interop.ml
+++ b/src-bindings/interop/interop.ml
@@ -140,13 +140,7 @@ module Interface = struct
   end
 
   module Generic (Super : Ojs.T) () = struct
-    type 'a t = Super.t
-
-    type 'a generic = 'a t
-
-    let generic_of_js _ = Super.t_of_js
-
-    let generic_to_js _ = Super.t_to_js
+    type 'a t = Super.t [@@js]
   end
 end
 

--- a/src-bindings/interop/interop.ml
+++ b/src-bindings/interop/interop.ml
@@ -86,19 +86,7 @@ module Dict = struct
 end
 
 module Js = struct
-  module type T = sig
-    type t
-
-    val t_of_js : Ojs.t -> t
-
-    val t_to_js : t -> Ojs.t
-  end
-
-  type 'a t = (module T with type t = 'a)
-
-  module Any = struct
-    type t = Ojs.t [@@js]
-  end
+  type 'a t = (module Ojs.T with type t = 'a)
 
   module Unit = struct
     type t = unit
@@ -108,23 +96,7 @@ module Js = struct
     let t_to_js _ = undefined
   end
 
-  module Bool = struct
-    type t = bool [@@js]
-  end
-
-  module Int = struct
-    type t = int [@@js]
-  end
-
-  module String = struct
-    type t = string [@@js]
-  end
-
-  module Option (T : T) = struct
-    type t = T.t option [@@js]
-  end
-
-  module Result (Ok : T) (Error : T) = struct
+  module Result (Ok : Ojs.T) (Error : Ojs.T) = struct
     type t = (Ok.t, Error.t) result
 
     type js_result =
@@ -149,15 +121,11 @@ module Js = struct
         js_result_to_js { case = "error"; error; ok = undefined }
   end
 
-  module Or_undefined (T : T) = struct
+  module Or_undefined (T : Ojs.T) = struct
     type t = T.t or_undefined [@@js]
   end
 
-  module List (T : T) = struct
-    type t = T.t list [@@js]
-  end
-
-  module Dict (T : T) = struct
+  module Dict (T : Ojs.T) = struct
     type t = T.t Dict.t [@@js]
   end
 end
@@ -167,11 +135,11 @@ module Interface = struct
     type t = Ojs.t [@@js]
   end
 
-  module Extend (Super : Js.T) () = struct
+  module Extend (Super : Ojs.T) () = struct
     type t = Super.t [@@js]
   end
 
-  module Generic (Super : Js.T) () = struct
+  module Generic (Super : Ojs.T) () = struct
     type 'a t = Super.t
 
     type 'a generic = 'a t

--- a/src-bindings/interop/interop.mli
+++ b/src-bindings/interop/interop.mli
@@ -60,11 +60,9 @@ module Interface : sig
   module Generic (Super : Ojs.T) () : sig
     type 'a t = private Super.t
 
-    type 'a generic = 'a t
+    val t_of_js : (Ojs.t -> 'a) -> Ojs.t -> 'a t
 
-    val generic_of_js : (Ojs.t -> 'a) -> Ojs.t -> 'a t
-
-    val generic_to_js : ('a -> Ojs.t) -> 'a t -> Ojs.t
+    val t_to_js : ('a -> Ojs.t) -> 'a t -> Ojs.t
   end
 end
 

--- a/src-bindings/interop/interop.mli
+++ b/src-bindings/interop/interop.mli
@@ -40,43 +40,24 @@ module Dict : sig
 end
 
 module Js : sig
-  module type T = sig
-    type t
+  type 'a t = (module Ojs.T with type t = 'a)
 
-    val t_of_js : Ojs.t -> t
+  module Unit : Ojs.T with type t = unit
 
-    val t_to_js : t -> Ojs.t
-  end
+  module Result (Ok : Ojs.T) (Error : Ojs.T) :
+    Ojs.T with type t = (Ok.t, Error.t) result
 
-  type 'a t = (module T with type t = 'a)
+  module Or_undefined (T : Ojs.T) : Ojs.T with type t = T.t or_undefined
 
-  module Any : T with type t = Ojs.t
-
-  module Unit : T with type t = unit
-
-  module Bool : T with type t = bool
-
-  module Int : T with type t = int
-
-  module String : T with type t = string
-
-  module Option (T : T) : T with type t = T.t option
-
-  module Result (Ok : T) (Error : T) : T with type t = (Ok.t, Error.t) result
-
-  module Or_undefined (T : T) : T with type t = T.t or_undefined
-
-  module List (T : T) : T with type t = T.t list
-
-  module Dict (T : T) : T with type t = T.t Dict.t
+  module Dict (T : Ojs.T) : Ojs.T with type t = T.t Dict.t
 end
 
 module Interface : sig
-  module Make () : Js.T with type t = private Ojs.t
+  module Make () : Ojs.T with type t = private Ojs.t
 
-  module Extend (Super : Js.T) () : Js.T with type t = private Super.t
+  module Extend (Super : Ojs.T) () : Ojs.T with type t = private Super.t
 
-  module Generic (Super : Js.T) () : sig
+  module Generic (Super : Ojs.T) () : sig
     type 'a t = private Super.t
 
     type 'a generic = 'a t

--- a/src-bindings/interop/interop.mli
+++ b/src-bindings/interop/interop.mli
@@ -42,6 +42,14 @@ end
 module Js : sig
   type 'a t = (module Ojs.T with type t = 'a)
 
+  module type Generic = sig
+    type 'a t
+
+    val t_to_js : ('a -> Ojs.t) -> 'a t -> Ojs.t
+
+    val t_of_js : (Ojs.t -> 'a) -> Ojs.t -> 'a t
+  end
+
   module Unit : Ojs.T with type t = unit
 
   module Result (Ok : Ojs.T) (Error : Ojs.T) :
@@ -57,13 +65,8 @@ module Interface : sig
 
   module Extend (Super : Ojs.T) () : Ojs.T with type t = private Super.t
 
-  module Generic (Super : Ojs.T) () : sig
-    type 'a t = private Super.t
-
-    val t_of_js : (Ojs.t -> 'a) -> Ojs.t -> 'a t
-
-    val t_to_js : ('a -> Ojs.t) -> 'a t -> Ojs.t
-  end
+  module Generic (Super : Ojs.T) () :
+    Js.Generic with type 'a t = private Super.t
 end
 
 module Class = Interface

--- a/src-bindings/node/node.mli
+++ b/src-bindings/node/node.mli
@@ -1,11 +1,9 @@
-open Interop
-
 val __filename : unit -> string
 
 val __dirname : unit -> string
 
 module Timeout : sig
-  include Js.T
+  include Ojs.T
 
   val hasRef : t -> bool
 
@@ -39,13 +37,13 @@ module Process : sig
 end
 
 module JsError : sig
-  include Js.T with type t = Promise.error
+  include Ojs.T with type t = Promise.error
 
   val message : t -> string
 end
 
 module Buffer : sig
-  include Js.T
+  include Ojs.T
 
   val toString : t -> string
 
@@ -67,7 +65,7 @@ end
 
 module Stream : sig
   module Readable : sig
-    include Js.T
+    include Ojs.T
 
     type chunk =
       [ `String of string
@@ -88,7 +86,7 @@ module Stream : sig
   end
 
   module Writable : sig
-    include Js.T
+    include Ojs.T
 
     val on :
          t

--- a/src-bindings/node/node.mli
+++ b/src-bindings/node/node.mli
@@ -135,7 +135,7 @@ end
 
 module Net : sig
   module Socket : sig
-    type t
+    include Ojs.T
 
     val make : unit -> t
 
@@ -159,7 +159,7 @@ end
 
 module ChildProcess : sig
   module Options : sig
-    type t
+    include Ojs.T
 
     val create : ?cwd:string -> ?env:string Interop.Dict.t -> unit -> t
   end

--- a/src-bindings/polka/polka.mli
+++ b/src-bindings/polka/polka.mli
@@ -9,7 +9,7 @@ module Server : sig
     val address : t -> string
   end
 
-  type t
+  include Ojs.T
 
   val close : t -> ?callback:(Node.JsError.t or_undefined -> unit) -> unit -> t
 
@@ -36,6 +36,8 @@ module Middleware : sig
 
   type t =
     request:Request.t -> response:Response.t -> next:(unit -> polka) -> polka
+
+  include Ojs.T with type t := t
 end
 
 val create : unit -> polka
@@ -51,7 +53,7 @@ val server : polka -> Server.t
 
 module Sirv : sig
   module Options : sig
-    type t
+    include Ojs.T
 
     val create : dev:bool -> t
   end

--- a/src-bindings/polka/polka.mli
+++ b/src-bindings/polka/polka.mli
@@ -2,7 +2,7 @@ open Interop
 
 module Server : sig
   module Address : sig
-    include Js.T
+    include Ojs.T
 
     val port : t -> int
 
@@ -27,11 +27,11 @@ type polka
 
 module Middleware : sig
   module Request : sig
-    include Js.T
+    include Ojs.T
   end
 
   module Response : sig
-    include Js.T
+    include Ojs.T
   end
 
   type t =

--- a/src-bindings/vscode/vscode.ml
+++ b/src-bindings/vscode/vscode.ml
@@ -982,13 +982,11 @@ module EventEmitter = struct
   module Make (T : Ojs.T) = struct
     type t = T.t G.t [@@js]
 
-    module Event = Event.Make (T)
-
     include
       [%js:
       val make : unit -> t [@@js.new "vscode.EventEmitter"]
 
-      val event : t -> Event.t [@@js.get]
+      val event : t -> T.t Event.t [@@js.get]
 
       val fire : t -> T.t -> unit [@@js.call]
 
@@ -998,18 +996,15 @@ end
 
 module CancellationToken = struct
   include Interface.Make ()
-  module OnCancellationRequested = Event.Make (Ojs)
 
   include
     [%js:
     val isCancellationRequested : t -> bool [@@js.get]
 
-    val onCancellationRequested : t -> OnCancellationRequested.t [@@js.get]
+    val onCancellationRequested : t -> Ojs.t Event.t [@@js.get]
 
     val create :
-         isCancellationRequested:bool
-      -> onCancellationRequested:OnCancellationRequested.t
-      -> t
+      isCancellationRequested:bool -> onCancellationRequested:Ojs.t Event.t -> t
     [@@js.builder]]
 end
 
@@ -1396,19 +1391,16 @@ end
 
 module Pseudoterminal = struct
   include Interface.Make ()
-  module OnDidWrite = Event.Make (Ojs.String)
-  module OnDidOverrideDimensions =
-    Event.Make (Js.Or_undefined (TerminalDimensions))
-  module OnDidClose = Event.Make (Js.Or_undefined (Ojs.Int))
 
   include
     [%js:
-    val onDidWrite : t -> OnDidWrite.t [@@js.get]
+    val onDidWrite : t -> string Event.t [@@js.get]
 
-    val onDidOverrideDimensions : t -> OnDidOverrideDimensions.t or_undefined
+    val onDidOverrideDimensions :
+      t -> TerminalDimensions.t or_undefined Event.t or_undefined
     [@@js.get]
 
-    val onDidClose : t -> OnDidClose.t or_undefined [@@js.get]
+    val onDidClose : t -> int or_undefined Event.t or_undefined [@@js.get]
 
     val open_ : t -> ?initialDimensions:TerminalDimensions.t -> unit -> unit
     [@@js.call]
@@ -1422,9 +1414,9 @@ module Pseudoterminal = struct
     [@@js.get]
 
     val create :
-         onDidWrite:OnDidWrite.t
-      -> ?onDidOverrideDimensions:OnDidOverrideDimensions.t
-      -> ?onDidClose:OnDidClose.t
+         onDidWrite:string Event.t
+      -> ?onDidOverrideDimensions:TerminalDimensions.t or_undefined Event.t
+      -> ?onDidClose:int or_undefined Event.t
       -> open_:(?initialDimensions:TerminalDimensions.t -> unit -> unit)
       -> close:(unit -> unit)
       -> ?handleInput:(data:string -> unit)
@@ -1609,7 +1601,6 @@ end
 
 module SecretStorage = struct
   include Interface.Make ()
-  module OnDidChange = Event.Make (SecretStorageChangeEvent)
 
   include
     [%js:
@@ -1619,7 +1610,7 @@ module SecretStorage = struct
 
     val delete : t -> key:string -> Promise.void [@@js.call]
 
-    val onDidChange : t -> OnDidChange.t [@@js.get]]
+    val onDidChange : t -> SecretStorageChangeEvent.t Event.t [@@js.get]]
 end
 
 module ExtensionContext = struct
@@ -2218,18 +2209,17 @@ end
 
 module TextDocumentContentProvider = struct
   include Interface.Make ()
-  module OnDidChange = Event.Make (Uri)
 
   include
     [%js:
-    val onDidChange : t -> OnDidChange.t or_undefined [@@js.get]
+    val onDidChange : t -> Uri.t Event.t or_undefined [@@js.get]
 
     val provideTextDocumentContent :
       t -> uri:Uri.t -> token:CancellationToken.t -> string ProviderResult.t
     [@@js.call]
 
     val create :
-         ?onDidChange:OnDidChange.t
+         ?onDidChange:Uri.t Event.t
       -> provideTextDocumentContent:
            (uri:Uri.t -> token:CancellationToken.t -> string ProviderResult.t)
       -> unit
@@ -2239,9 +2229,8 @@ end
 
 module FileSystemWatcher = struct
   include Interface.Make ()
-  module OnDidChange = Event.Make (Uri)
 
-  include [%js: val onDidChange : t -> OnDidChange.t [@@js.get]]
+  include [%js: val onDidChange : t -> Uri.t Event.t [@@js.get]]
 end
 
 module ConfigurationChangeEvent = struct
@@ -2249,13 +2238,6 @@ module ConfigurationChangeEvent = struct
 end
 
 module Workspace = struct
-  module OnDidChangeWorkspaceFolders = Event.Make (WorkspaceFolder)
-  module OnDidOpenTextDocument = Event.Make (TextDocument)
-  module OnDidCloseTextDocument = Event.Make (TextDocument)
-  module OnDidSaveTextDocument = Event.Make (TextDocument)
-  module OnDidChangeTextDocument = Event.Make (TextDocumentChangeEvent)
-  module OnDidChangeConfiguration = Event.Make (ConfigurationChangeEvent)
-
   type textDocumentOptions =
     { language : string
     ; content : string
@@ -2293,25 +2275,25 @@ module Workspace = struct
     val textDocuments : unit -> TextDocument.t list
     [@@js.get "vscode.workspace.textDocuments"]
 
-    val onDidChangeConfiguration : OnDidChangeConfiguration.t
+    val onDidChangeConfiguration : ConfigurationChangeEvent.t Event.t
     [@@js.global "vscode.workspace.onDidChangeConfiguration"]
 
-    val onDidChangeWorkspaceFolders : OnDidChangeWorkspaceFolders.t
+    val onDidChangeWorkspaceFolders : WorkspaceFolder.t Event.t
     [@@js.global "vscode.workspace.onDidChangeWorkspaceFolders"]
 
     val getWorkspaceFolder : uri:Uri.t -> WorkspaceFolder.t or_undefined
     [@@js.global "vscode.workspace.getWorkspaceFolder"]
 
-    val onDidOpenTextDocument : OnDidOpenTextDocument.t
+    val onDidOpenTextDocument : TextDocument.t Event.t
     [@@js.global "vscode.workspace.onDidOpenTextDocument"]
 
-    val onDidSaveTextDocument : OnDidSaveTextDocument.t
+    val onDidSaveTextDocument : TextDocument.t Event.t
     [@@js.global "vscode.workspace.onDidSaveTextDocument"]
 
-    val onDidCloseTextDocument : OnDidCloseTextDocument.t
+    val onDidCloseTextDocument : TextDocument.t Event.t
     [@@js.global "vscode.workspace.onDidCloseTextDocument"]
 
-    val onDidChangeTextDocument : OnDidChangeTextDocument.t
+    val onDidChangeTextDocument : TextDocumentChangeEvent.t Event.t
     [@@js.global "vscode.workspace.onDidChangeTextDocument"]
 
     val applyEdit : edit:WorkspaceEdit.t -> bool Promise.t
@@ -2568,10 +2550,6 @@ module TreeDataProvider = struct
   module Make (T : Ojs.T) = struct
     type t = T.t G.t [@@js]
 
-    module OnDidChangeTreeData = Event.Make (struct
-      type t = T.t or_undefined [@@js]
-    end)
-
     type getTreeItemResult =
       ([ `Value of TreeItem.t
        | `Promise of TreeItem.t Promise.t
@@ -2586,7 +2564,7 @@ module TreeDataProvider = struct
 
     include
       [%js:
-      val onDidChangeTreeData : t -> OnDidChangeTreeData.t or_undefined
+      val onDidChangeTreeData : t -> T.t or_undefined Event.t or_undefined
       [@@js.get]
 
       val getTreeItem : t -> element:T.t -> getTreeItemResult [@@js.call]
@@ -2607,7 +2585,7 @@ module TreeDataProvider = struct
       [@@js.call]
 
       val create :
-           ?onDidChangeTreeData:OnDidChangeTreeData.t
+           ?onDidChangeTreeData:T.t or_undefined Event.t
         -> getTreeItem:(element:T.t -> getTreeItemResult)
         -> getChildren:(?element:T.t -> unit -> T.t list ProviderResult.t)
         -> ?getParent:(element:T.t -> T.t ProviderResult.t)
@@ -2629,11 +2607,9 @@ module TreeViewOptions = struct
   module Make (T : Ojs.T) = struct
     type t = T.t G.t [@@js]
 
-    module TreeDataProvider = TreeDataProvider.Make (T)
-
     include
       [%js:
-      val treeDataProvider : t -> TreeDataProvider.t [@@js.get]
+      val treeDataProvider : t -> T.t TreeDataProvider.t [@@js.get]
 
       val showCollapseAll : t -> bool or_undefined [@@js.get]
 
@@ -2688,25 +2664,23 @@ module TreeView = struct
   module Make (T : Ojs.T) = struct
     type t = T.t G.t [@@js]
 
-    module OnDidExpandElement = Event.Make (TreeViewExpansionEvent.Make (T))
-    module OnDidCollapseElement = Event.Make (TreeViewExpansionEvent.Make (T))
-    module OnDidChangeSelection =
-      Event.Make (TreeViewSelectionChangeEvent.Make (T))
-    module OnDidChangeVisibility = Event.Make (TreeViewVisibilityChangeEvent)
-
     include
       [%js:
-      val onDidExpandElement : t -> OnDidExpandElement.t [@@js.get]
+      val onDidExpandElement : t -> T.t TreeViewExpansionEvent.t Event.t
+      [@@js.get]
 
-      val onDidCollapseElement : t -> OnDidCollapseElement.t [@@js.get]
+      val onDidCollapseElement : t -> T.t TreeViewExpansionEvent.t Event.t
+      [@@js.get]
 
       val selection : t -> T.t list [@@js.get]
 
-      val onDidChangeSelection : t -> OnDidChangeSelection.t [@@js.get]
+      val onDidChangeSelection : t -> T.t TreeViewSelectionChangeEvent.t Event.t
+      [@@js.get]
 
       val visible : t -> bool [@@js.get]
 
-      val onDidChangeVisibility : t -> OnDidChangeVisibility.t [@@js.get]
+      val onDidChangeVisibility : t -> TreeViewVisibilityChangeEvent.t Event.t
+      [@@js.get]
 
       val message : t -> string or_undefined [@@js.get]
 
@@ -2774,11 +2748,10 @@ end
 
 module WebView = struct
   include Interface.Make ()
-  module OnDidReceiveMessage = Event.Make (Ojs)
 
   include
     [%js:
-    val onDidReceiveMessage : t -> OnDidReceiveMessage.t [@@js.get]
+    val onDidReceiveMessage : t -> Ojs.t Event.t [@@js.get]
 
     val cspSource : t -> string [@@js.get]
 
@@ -2795,7 +2768,7 @@ module WebView = struct
     val postMessage : t -> Ojs.t -> bool Promise.t [@@js.call]
 
     val create :
-         onDidReceiveMessage:OnDidReceiveMessage.t
+         onDidReceiveMessage:Ojs.t Event.t
       -> cspSource:string
       -> html:string
       -> options:WebviewOptions.t
@@ -2832,15 +2805,13 @@ module WebviewPanel = struct
     [@js.union])
   [@@js]
 
-  module OnDidChangeViewState =
-    Event.Make (WebviewPanelOnDidChangeViewStateEvent)
-  module OnDidDispose = Event.Make (Js.Unit)
-
   include
     [%js:
-    val onDidChangeViewState : t -> OnDidChangeViewState.t [@@js.get]
+    val onDidChangeViewState :
+      t -> WebviewPanelOnDidChangeViewStateEvent.t Event.t
+    [@@js.get]
 
-    val onDidDispose : t -> OnDidDispose.t [@@js.get]
+    val onDidDispose : t -> unit Event.t [@@js.get]
 
     val active : t -> bool [@@js.get]
 
@@ -2865,8 +2836,8 @@ module WebviewPanel = struct
     [@@js.call]
 
     val create :
-         onDidChangeViewState:OnDidChangeViewState.t
-      -> onDidDispose:OnDidDispose.t
+         onDidChangeViewState:WebviewPanelOnDidChangeViewStateEvent.t Event.t
+      -> onDidDispose:unit Event.t
       -> active:bool
       -> options:WebviewPanelOptions.t
       -> title:string
@@ -2980,12 +2951,6 @@ module RegisterCustomEditorProviderOptions = struct
 end
 
 module Window = struct
-  module OnDidChangeActiveTextEditor = Event.Make (TextEditor)
-  module OnDidChangeVisibleTextEditors = Event.Make (Ojs.List (TextEditor))
-  module OnDidChangeActiveTerminal = Event.Make (Js.Or_undefined (Terminal))
-  module OnDidOpenTerminal = Event.Make (Terminal)
-  module OnDidCloseTerminal = Event.Make (Terminal)
-
   include
     [%js:
     val activeTextEditor : unit -> TextEditor.t or_undefined
@@ -2994,10 +2959,10 @@ module Window = struct
     val visibleTextEditors : unit -> TextEditor.t list
     [@@js.get "vscode.window.visibleTextEditors"]
 
-    val onDidChangeActiveTextEditor : unit -> OnDidChangeActiveTextEditor.t
+    val onDidChangeActiveTextEditor : unit -> TextEditor.t Event.t
     [@@js.get "vscode.window.onDidChangeActiveTextEditor"]
 
-    val onDidChangeVisibleTextEditors : unit -> OnDidChangeVisibleTextEditors.t
+    val onDidChangeVisibleTextEditors : unit -> TextEditor.t list Event.t
     [@@js.get "vscode.window.onDidChangeVisibleTextEditors"]
 
     val terminals : unit -> Terminal.t list [@@js.get "vscode.window.terminals"]
@@ -3005,13 +2970,13 @@ module Window = struct
     val activeTerminal : unit -> Terminal.t or_undefined
     [@@js.get "vscode.window.activeTerminal"]
 
-    val onDidChangeActiveTerminal : unit -> OnDidChangeActiveTerminal.t
+    val onDidChangeActiveTerminal : unit -> Terminal.t or_undefined Event.t
     [@@js.get "vscode.window.onDidChangeActiveTerminal"]
 
-    val onDidOpenTerminal : unit -> OnDidOpenTerminal.t
+    val onDidOpenTerminal : unit -> Terminal.t Event.t
     [@@js.get "vscode.window.onDidOpenTerminal"]
 
-    val onDidCloseTerminal : unit -> OnDidCloseTerminal.t
+    val onDidCloseTerminal : unit -> Terminal.t Event.t
     [@@js.get "vscode.window.onDidCloseTerminal"]
 
     val showTextDocument :

--- a/src-bindings/vscode/vscode.ml
+++ b/src-bindings/vscode/vscode.ml
@@ -975,10 +975,11 @@ module Event = struct
 end
 
 module EventEmitter = struct
-  include Class.Generic (Ojs) ()
+  module G = Class.Generic (Ojs) ()
+  include G
 
   module Make (T : Ojs.T) = struct
-    type t = T.t generic [@@js]
+    type t = T.t G.t [@@js]
 
     module Event = Event.Make (T)
 
@@ -2125,10 +2126,11 @@ module Task = struct
 end
 
 module TaskProvider = struct
-  include Interface.Generic (Ojs) ()
+  module G = Interface.Generic (Ojs) ()
+  include G
 
   module Make (T : Ojs.T) = struct
-    type t = T.t generic [@@js]
+    type t = T.t G.t [@@js]
 
     include
       [%js:
@@ -2559,10 +2561,11 @@ module TreeItem = struct
 end
 
 module TreeDataProvider = struct
-  include Interface.Generic (Ojs) ()
+  module G = Interface.Generic (Ojs) ()
+  include G
 
   module Make (T : Ojs.T) = struct
-    type t = T.t generic [@@js]
+    type t = T.t G.t [@@js]
 
     module OnDidChangeTreeData = Event.Make (struct
       type t = T.t or_undefined [@@js]
@@ -2619,10 +2622,11 @@ module TreeDataProvider = struct
 end
 
 module TreeViewOptions = struct
-  include Class.Generic (Ojs) ()
+  module G = Class.Generic (Ojs) ()
+  include G
 
   module Make (T : Ojs.T) = struct
-    type t = T.t generic [@@js]
+    type t = T.t G.t [@@js]
 
     module TreeDataProvider = TreeDataProvider.Make (T)
 
@@ -2637,10 +2641,11 @@ module TreeViewOptions = struct
 end
 
 module TreeViewExpansionEvent = struct
-  include Interface.Generic (Ojs) ()
+  module G = Interface.Generic (Ojs) ()
+  include G
 
   module Make (T : Ojs.T) = struct
-    type t = T.t generic [@@js]
+    type t = T.t G.t [@@js]
 
     include
       [%js:
@@ -2651,10 +2656,11 @@ module TreeViewExpansionEvent = struct
 end
 
 module TreeViewSelectionChangeEvent = struct
-  include Interface.Generic (Ojs) ()
+  module G = Interface.Generic (Ojs) ()
+  include G
 
   module Make (T : Ojs.T) = struct
-    type t = T.t generic [@@js]
+    type t = T.t G.t [@@js]
 
     include
       [%js:
@@ -2675,10 +2681,11 @@ module TreeViewVisibilityChangeEvent = struct
 end
 
 module TreeView = struct
-  include Class.Generic (Disposable) ()
+  module G = Class.Generic (Disposable) ()
+  include G
 
   module Make (T : Ojs.T) = struct
-    type t = T.t generic [@@js]
+    type t = T.t G.t [@@js]
 
     module OnDidExpandElement = Event.Make (TreeViewExpansionEvent.Make (T))
     module OnDidCollapseElement = Event.Make (TreeViewExpansionEvent.Make (T))
@@ -2920,10 +2927,11 @@ module CustomDocumentOpenContext = struct
 end
 
 module CustomReadonlyEditorProvider = struct
-  include Interface.Generic (Ojs) ()
+  module G = Interface.Generic (Ojs) ()
+  include G
 
   module Make (T : CustomDocument.T) = struct
-    type t = T.t generic [@@js]
+    type t = T.t G.t [@@js]
 
     include
       [%js:

--- a/src-bindings/vscode/vscode.ml
+++ b/src-bindings/vscode/vscode.ml
@@ -26,13 +26,13 @@ module Command = struct
 
     val tooltip : t -> string or_undefined [@@js.get]
 
-    val arguments : t -> Js.Any.t maybe_list [@@js.get]
+    val arguments : t -> Ojs.t maybe_list [@@js.get]
 
     val create :
          title:string
       -> command:string
       -> ?tooltip:string
-      -> ?arguments:Js.Any.t list
+      -> ?arguments:Ojs.t list
       -> unit
       -> t
     [@@js.builder]]
@@ -788,19 +788,29 @@ module WorkspaceConfiguration = struct
 
   include
     [%js:
-    val get : t -> section:string -> Js.Any.t or_undefined [@@js.call]
+    val get : t -> section:string -> Ojs.t or_undefined [@@js.call]
 
-    val get_default : t -> section:string -> defaultValue:Ojs.t -> Ojs.t
+    val get_default :
+         ((module Ojs.T with type t = 'a)[@js])
+      -> t
+      -> section:string
+      -> defaultValue:'a
+      -> 'a
     [@@js.call]
 
     val has : t -> section:string -> bool [@@js.call]
 
-    val inspect : t -> section:string -> Ojs.t [@@js.call]
+    val inspect :
+         ((module Ojs.T with type t = 'a)[@js])
+      -> t
+      -> section:string
+      -> 'a inspectResult or_undefined
+    [@@js.call]
 
     val update :
          t
       -> section:string
-      -> value:Js.Any.t
+      -> value:Ojs.t
       -> ?configurationTarget:
            ([ `ConfigurationTarget of ConfigurationTarget.t | `Bool of bool ]
            [@js.union])
@@ -808,15 +818,6 @@ module WorkspaceConfiguration = struct
       -> unit
       -> Promise.void
     [@@js.call]]
-
-  let inspect (type a) (module T : Js.T with type t = a) this ~section :
-      a inspectResult or_undefined =
-    [%js.to: T.t inspectResult or_undefined] (inspect this ~section)
-
-  let get_default (type a) (module T : Js.T with type t = a) this ~section
-      ~(defaultValue : a) : a =
-    let defaultValue = [%js.of: T.t] defaultValue in
-    [%js.to: T.t] (get_default this ~section ~defaultValue)
 end
 
 module WorkspaceEdit = struct
@@ -957,15 +958,15 @@ end
 module Event = struct
   type 'a t =
        listener:('a -> unit)
-    -> ?thisArgs:Js.Any.t
+    -> ?thisArgs:Ojs.t
     -> ?disposables:Disposable.t list
     -> unit
     -> Disposable.t
 
-  module Make (T : Js.T) = struct
+  module Make (T : Ojs.T) = struct
     type t =
          listener:(T.t -> unit)
-      -> ?thisArgs:Js.Any.t
+      -> ?thisArgs:Ojs.t
       -> ?disposables:Disposable.t list
       -> unit
       -> Disposable.t
@@ -976,7 +977,7 @@ end
 module EventEmitter = struct
   include Class.Generic (Ojs) ()
 
-  module Make (T : Js.T) = struct
+  module Make (T : Ojs.T) = struct
     type t = T.t generic [@@js]
 
     module Event = Event.Make (T)
@@ -995,7 +996,7 @@ end
 
 module CancellationToken = struct
   include Interface.Make ()
-  module OnCancellationRequested = Event.Make (Js.Any)
+  module OnCancellationRequested = Event.Make (Ojs)
 
   include
     [%js:
@@ -1393,10 +1394,10 @@ end
 
 module Pseudoterminal = struct
   include Interface.Make ()
-  module OnDidWrite = Event.Make (Js.String)
+  module OnDidWrite = Event.Make (Ojs.String)
   module OnDidOverrideDimensions =
     Event.Make (Js.Or_undefined (TerminalDimensions))
-  module OnDidClose = Event.Make (Js.Or_undefined (Js.Int))
+  module OnDidClose = Event.Make (Js.Or_undefined (Ojs.Int))
 
   include
     [%js:
@@ -1528,16 +1529,17 @@ module Memento = struct
 
   include
     [%js:
-    val get : t -> key:string -> Js.Any.t or_undefined [@@js.call]
+    val get : t -> key:string -> Ojs.t or_undefined [@@js.call]
 
-    val get_default : t -> key:string -> defaultValue:Ojs.t -> Ojs.t [@@js.call]
+    val get_default :
+         ((module Ojs.T with type t = 'a)[@js])
+      -> t
+      -> key:string
+      -> defaultValue:'a
+      -> 'a
+    [@@js.call]
 
-    val update : t -> key:string -> value:Js.Any.t -> Promise.void [@@js.call]]
-
-  let get_default (type a) (module T : Js.T with type t = a) this ~key
-      ~(defaultValue : a) : a =
-    let defaultValue = [%js.of: T.t] defaultValue in
-    [%js.to: T.t] (get_default this ~key ~defaultValue)
+    val update : t -> key:string -> value:Ojs.t -> Promise.void [@@js.call]]
 end
 
 module EnvironmentVariableMutatorType = struct
@@ -2125,7 +2127,7 @@ end
 module TaskProvider = struct
   include Interface.Generic (Ojs) ()
 
-  module Make (T : Js.T) = struct
+  module Make (T : Ojs.T) = struct
     type t = T.t generic [@@js]
 
     include
@@ -2366,7 +2368,7 @@ end
 
 module CustomDocument = struct
   module type T = sig
-    include Js.T
+    include Ojs.T
 
     val uri : t -> Uri.t
 
@@ -2559,7 +2561,7 @@ end
 module TreeDataProvider = struct
   include Interface.Generic (Ojs) ()
 
-  module Make (T : Js.T) = struct
+  module Make (T : Ojs.T) = struct
     type t = T.t generic [@@js]
 
     module OnDidChangeTreeData = Event.Make (struct
@@ -2619,7 +2621,7 @@ end
 module TreeViewOptions = struct
   include Class.Generic (Ojs) ()
 
-  module Make (T : Js.T) = struct
+  module Make (T : Ojs.T) = struct
     type t = T.t generic [@@js]
 
     module TreeDataProvider = TreeDataProvider.Make (T)
@@ -2637,7 +2639,7 @@ end
 module TreeViewExpansionEvent = struct
   include Interface.Generic (Ojs) ()
 
-  module Make (T : Js.T) = struct
+  module Make (T : Ojs.T) = struct
     type t = T.t generic [@@js]
 
     include
@@ -2651,7 +2653,7 @@ end
 module TreeViewSelectionChangeEvent = struct
   include Interface.Generic (Ojs) ()
 
-  module Make (T : Js.T) = struct
+  module Make (T : Ojs.T) = struct
     type t = T.t generic [@@js]
 
     include
@@ -2675,7 +2677,7 @@ end
 module TreeView = struct
   include Class.Generic (Disposable) ()
 
-  module Make (T : Js.T) = struct
+  module Make (T : Ojs.T) = struct
     type t = T.t generic [@@js]
 
     module OnDidExpandElement = Event.Make (TreeViewExpansionEvent.Make (T))
@@ -2764,7 +2766,7 @@ end
 
 module WebView = struct
   include Interface.Make ()
-  module OnDidReceiveMessage = Event.Make (Js.Any)
+  module OnDidReceiveMessage = Event.Make (Ojs)
 
   include
     [%js:
@@ -2782,7 +2784,7 @@ module WebView = struct
 
     val asWebviewUri : t -> localResource:Uri.t -> Uri.t [@@js.call]
 
-    val postMessage : t -> Js.Any.t -> bool Promise.t [@@js.call]
+    val postMessage : t -> Ojs.t -> bool Promise.t [@@js.call]
 
     val create :
          onDidReceiveMessage:OnDidReceiveMessage.t
@@ -2791,7 +2793,7 @@ module WebView = struct
       -> options:WebviewOptions.t
       -> close:(unit -> unit)
       -> asWebviewUri:(Uri.t -> Uri.t)
-      -> postMessage:(Js.Any.t -> bool Promise.t)
+      -> postMessage:(Ojs.t -> bool Promise.t)
       -> t
     [@@js.builder]]
 end
@@ -2848,7 +2850,7 @@ module WebviewPanel = struct
 
     val set_webview : t -> WebView.t -> unit [@@js.set]
 
-    val dispose : t -> Js.Any.t [@@js.call]
+    val dispose : t -> Ojs.t [@@js.call]
 
     val reveal :
       t -> ?preserveFocus:bool -> ?viewColumn:ViewColumn.t -> unit -> unit
@@ -2864,7 +2866,7 @@ module WebviewPanel = struct
       -> viewType:string
       -> visible:bool
       -> webview:WebView.t
-      -> dispose:Js.Any.t
+      -> dispose:Ojs.t
       -> reveal:
            (?preserveFocus:bool -> ?viewColumn:ViewColumn.t -> unit -> unit)
       -> t
@@ -2970,7 +2972,7 @@ end
 
 module Window = struct
   module OnDidChangeActiveTextEditor = Event.Make (TextEditor)
-  module OnDidChangeVisibleTextEditors = Event.Make (Js.List (TextEditor))
+  module OnDidChangeVisibleTextEditors = Event.Make (Ojs.List (TextEditor))
   module OnDidChangeActiveTerminal = Event.Make (Js.Or_undefined (Terminal))
   module OnDidOpenTerminal = Event.Make (Terminal)
   module OnDidCloseTerminal = Event.Make (Terminal)
@@ -3080,7 +3082,11 @@ module Window = struct
       -> Disposable.t
     [@@js.global "vscode.window.setStatusBarMessage"]
 
-    val withProgress : options:ProgressOptions.t -> task:Ojs.t -> Ojs.t
+    val withProgress :
+         ((module Ojs.T with type t = 'a)[@js])
+      -> options:ProgressOptions.t
+      -> task:(progress:Progress.t -> token:CancellationToken.t -> 'a Promise.t)
+      -> 'a Promise.t
     [@@js.global "vscode.window.withProgress"]
 
     val createStatusBarItem :
@@ -3172,23 +3178,14 @@ module Window = struct
     in
     List.assoc item choices
 
-  let withProgress (type a) (module T : Js.T with type t = a) ~options ~task :
-      a Promise.t =
-    let task =
-      [%js.of:
-        progress:Progress.t -> token:CancellationToken.t -> T.t Promise.t]
-        task
-    in
-    [%js.to: T.t Promise.t] (withProgress ~options ~task)
-
-  let registerTreeDataProvider (type a) (module T : Js.T with type t = a)
+  let registerTreeDataProvider (type a) (module T : Ojs.T with type t = a)
       ~(viewId : string) ~(treeDataProvider : a TreeDataProvider.t) :
       Disposable.t =
     let module TreeDataProvider = TreeDataProvider.Make (T) in
     let treeDataProvider = [%js.of: TreeDataProvider.t] treeDataProvider in
     registerTreeDataProvider ~viewId ~treeDataProvider
 
-  let createTreeView (type a) (module T : Js.T with type t = a)
+  let createTreeView (type a) (module T : Ojs.T with type t = a)
       ~(viewId : string) ~(options : a TreeViewOptions.t) : a TreeView.t =
     let module TreeViewOptions = TreeViewOptions.Make (T) in
     let module TreeView = TreeView.Make (T) in
@@ -3211,13 +3208,13 @@ module Commands = struct
     [%js:
     val registerCommand :
          command:string
-      -> callback:(args:(Js.Any.t list[@js.variadic]) -> unit)
+      -> callback:(args:(Ojs.t list[@js.variadic]) -> unit)
       -> Disposable.t
     [@@js.global "vscode.commands.registerCommand"]
 
     val registerCommandReturn :
          command:string
-      -> callback:(args:(Js.Any.t list[@js.variadic]) -> Js.Any.t)
+      -> callback:(args:(Ojs.t list[@js.variadic]) -> Ojs.t)
       -> Disposable.t
     [@@js.global "vscode.commands.registerCommand"]
 
@@ -3226,15 +3223,15 @@ module Commands = struct
       -> callback:
            (   textEditor:TextEditor.t
             -> edit:TextEditorEdit.t
-            -> args:(Js.Any.t list[@js.variadic])
+            -> args:(Ojs.t list[@js.variadic])
             -> unit)
       -> Disposable.t
     [@@js.global "vscode.commands.registerTextEditorCommand"]
 
     val executeCommand :
          command:string
-      -> args:(Js.Any.t list[@js.variadic])
-      -> Js.Any.t or_undefined Promise.t
+      -> args:(Ojs.t list[@js.variadic])
+      -> Ojs.t or_undefined Promise.t
     [@@js.global "vscode.commands.executeCommand"]
 
     val getCommands : ?filterInternal:bool -> unit -> string list Promise.t
@@ -3344,7 +3341,7 @@ module DebugSession = struct
   include
     [%js:
     val customRequest :
-      t -> command:string -> ?args:Js.Any.t -> unit -> Js.Any.t Promise.t
+      t -> command:string -> ?args:Ojs.t -> unit -> Ojs.t Promise.t
     [@@js.call]]
 end
 

--- a/src-bindings/vscode/vscode.ml
+++ b/src-bindings/vscode/vscode.ml
@@ -3122,10 +3122,17 @@ module Window = struct
     [@@js.global "vscode.window.createTerminal"]
 
     val registerTreeDataProvider :
-      viewId:string -> treeDataProvider:Ojs.t -> Disposable.t
+         ((module Ojs.T with type t = 'a)[@js])
+      -> viewId:string
+      -> treeDataProvider:'a TreeDataProvider.t
+      -> Disposable.t
     [@@js.global "vscode.window.registerTreeDataProvider"]
 
-    val createTreeView : viewId:string -> options:Ojs.t -> Ojs.t
+    val createTreeView :
+         ((module Ojs.T with type t = 'a)[@js])
+      -> viewId:string
+      -> options:'a TreeViewOptions.t
+      -> 'a TreeView.t
     [@@js.global "vscode.window.createTreeView"]
 
     val createWebviewPanel :
@@ -3144,8 +3151,9 @@ module Window = struct
     [@@js.global "vscode.window.registerCustomEditorProvider"]
 
     val registerCustomReadonlyEditorProvider :
-         viewType:string
-      -> provider:Ojs.t
+         ((module Ojs.T with type t = 'a)[@js])
+      -> viewType:string
+      -> provider:'a CustomReadonlyEditorProvider.t
       -> ?options:RegisterCustomEditorProviderOptions.t
       -> unit
       -> Disposable.t
@@ -3186,29 +3194,15 @@ module Window = struct
     in
     List.assoc item choices
 
-  let registerTreeDataProvider (type a) (module T : Ojs.T with type t = a)
-      ~(viewId : string) ~(treeDataProvider : a TreeDataProvider.t) :
-      Disposable.t =
-    let module TreeDataProvider = TreeDataProvider.Make (T) in
-    let treeDataProvider = [%js.of: TreeDataProvider.t] treeDataProvider in
-    registerTreeDataProvider ~viewId ~treeDataProvider
-
-  let createTreeView (type a) (module T : Ojs.T with type t = a)
-      ~(viewId : string) ~(options : a TreeViewOptions.t) : a TreeView.t =
-    let module TreeViewOptions = TreeViewOptions.Make (T) in
-    let module TreeView = TreeView.Make (T) in
-    let options = [%js.of: TreeViewOptions.t] options in
-    [%js.to: TreeView.t] (createTreeView ~viewId ~options)
-
   let registerCustomReadonlyEditorProvider (type a)
-      (module T : CustomDocument.T with type t = a) ~(viewType : string)
-      ~(provider : a CustomReadonlyEditorProvider.t)
-      ?(options : RegisterCustomEditorProviderOptions.t or_undefined) () :
-      Disposable.t =
-    let module CustomReadonlyEditorProvider =
-      CustomReadonlyEditorProvider.Make (T) in
-    let provider = [%js.of: CustomReadonlyEditorProvider.t] provider in
-    registerCustomReadonlyEditorProvider ~viewType ~provider ?options ()
+      (module T : CustomDocument.T with type t = a) ~viewType
+      ~(provider : a CustomReadonlyEditorProvider.t) ?options () =
+    registerCustomReadonlyEditorProvider
+      (module T)
+      ~viewType
+      ~provider
+      ?options
+      ()
 end
 
 module Commands = struct

--- a/src-bindings/vscode/vscode.ml
+++ b/src-bindings/vscode/vscode.ml
@@ -962,6 +962,7 @@ module Event = struct
     -> ?disposables:Disposable.t list
     -> unit
     -> Disposable.t
+  [@@js]
 
   module Make (T : Ojs.T) = struct
     type t =

--- a/src-bindings/vscode/vscode.mli
+++ b/src-bindings/vscode/vscode.mli
@@ -3,7 +3,7 @@ open Interop
 val version : string
 
 module Disposable : sig
-  include Js.T
+  include Ojs.T
 
   val from : t list -> t
 
@@ -13,7 +13,7 @@ module Disposable : sig
 end
 
 module Command : sig
-  include Js.T
+  include Ojs.T
 
   val title : t -> string
 
@@ -21,19 +21,19 @@ module Command : sig
 
   val tooltip : t -> string option
 
-  val arguments : t -> Js.Any.t list
+  val arguments : t -> Ojs.t list
 
   val create :
        title:string
     -> command:string
     -> ?tooltip:string
-    -> ?arguments:Js.Any.t list
+    -> ?arguments:Ojs.t list
     -> unit
     -> t
 end
 
 module Position : sig
-  include Js.T
+  include Ojs.T
 
   val make : line:int -> character:int -> t
 
@@ -59,7 +59,7 @@ module Position : sig
 end
 
 module Range : sig
-  include Js.T
+  include Ojs.T
 
   val start : t -> Position.t
 
@@ -87,7 +87,7 @@ module Range : sig
 end
 
 module TextLine : sig
-  include Js.T
+  include Ojs.T
 
   val lineNumber : t -> int
 
@@ -116,11 +116,11 @@ module EndOfLine : sig
     | CRLF
     | LF
 
-  include Js.T with type t := t
+  include Ojs.T with type t := t
 end
 
 module TextEdit : sig
-  include Js.T
+  include Ojs.T
 
   val replace : range:Range.t -> newText:string -> t
 
@@ -140,7 +140,7 @@ module TextEdit : sig
 end
 
 module Uri : sig
-  include Js.T
+  include Ojs.T
 
   module Scheme : sig
     type t =
@@ -188,7 +188,7 @@ module Uri : sig
 end
 
 module TextDocument : sig
-  include Js.T
+  include Ojs.T
 
   val uri : t -> Uri.t
 
@@ -233,7 +233,7 @@ module TextDocument : sig
 end
 
 module WorkspaceFolder : sig
-  include Js.T
+  include Ojs.T
 
   val uri : t -> Uri.t
 
@@ -258,7 +258,7 @@ module ViewColumn : sig
     | Eight
     | Nine
 
-  include Js.T with type t := t
+  include Ojs.T with type t := t
 end
 
 module Selection : sig
@@ -281,7 +281,7 @@ module Selection : sig
 end
 
 module TextEditorEdit : sig
-  include Js.T
+  include Ojs.T
 
   type replaceLocation =
     [ `Position of Position.t
@@ -319,7 +319,7 @@ module TextEditorCursorStyle : sig
     | BlockOutline
     | UnderlineThin
 
-  include Js.T with type t := t
+  include Ojs.T with type t := t
 end
 
 module TextEditorLineNumbersStyle : sig
@@ -328,7 +328,7 @@ module TextEditorLineNumbersStyle : sig
     | On
     | Relative
 
-  include Js.T with type t := t
+  include Ojs.T with type t := t
 end
 
 module TextEditorRevealType : sig
@@ -338,11 +338,11 @@ module TextEditorRevealType : sig
     | InCenterIfOutsideViewport
     | AtTop
 
-  include Js.T with type t := t
+  include Ojs.T with type t := t
 end
 
 module TextEditorOptions : sig
-  include Js.T
+  include Ojs.T
 
   type tabSize =
     [ `Int of int
@@ -372,7 +372,7 @@ module TextEditorOptions : sig
 end
 
 module TextEditorDecorationType : sig
-  include Js.T
+  include Ojs.T
 
   val key : t -> string
 
@@ -384,7 +384,7 @@ module TextEditorDecorationType : sig
 end
 
 module MarkdownString : sig
-  include Js.T
+  include Ojs.T
 
   val value : t -> string
 
@@ -402,13 +402,13 @@ module MarkdownString : sig
 end
 
 module ThemeColor : sig
-  include Js.T
+  include Ojs.T
 
   val make : id:string -> t
 end
 
 module ThemableDecorationAttachmentRenderOptions : sig
-  include Js.T
+  include Ojs.T
 
   type contentIconPath =
     [ `String of string
@@ -462,7 +462,7 @@ module ThemableDecorationAttachmentRenderOptions : sig
 end
 
 module ThemableDecorationInstanceRenderOptions : sig
-  include Js.T
+  include Ojs.T
 
   val before : t -> ThemableDecorationAttachmentRenderOptions.t option
 
@@ -476,7 +476,7 @@ module ThemableDecorationInstanceRenderOptions : sig
 end
 
 module DecorationInstanceRenderOptions : sig
-  include Js.T
+  include Ojs.T
 
   val light : t -> ThemableDecorationInstanceRenderOptions.t option
 
@@ -490,7 +490,7 @@ module DecorationInstanceRenderOptions : sig
 end
 
 module DecorationOptions : sig
-  include Js.T
+  include Ojs.T
 
   type hoverMessage =
     [ `MarkdownString of MarkdownString.t
@@ -512,7 +512,7 @@ module DecorationOptions : sig
 end
 
 module SnippetString : sig
-  include Js.T
+  include Ojs.T
 
   val value : t -> string
 
@@ -539,7 +539,7 @@ module SnippetString : sig
 end
 
 module TextEditor : sig
-  include Js.T
+  include Ojs.T
 
   type insertSnippetLocation =
     [ `Position of Position.t
@@ -596,11 +596,11 @@ module ConfigurationTarget : sig
     | Workspace
     | WorkspaceFolder
 
-  include Js.T with type t := t
+  include Ojs.T with type t := t
 end
 
 module WorkspaceConfiguration : sig
-  include Js.T
+  include Ojs.T
 
   type 'a inspectResult =
     { key : string
@@ -615,7 +615,7 @@ module WorkspaceConfiguration : sig
     ; languageIds : string list option
     }
 
-  val get : t -> section:string -> Js.Any.t option
+  val get : t -> section:string -> Ojs.t option
 
   val get_default : 'a Js.t -> t -> section:string -> defaultValue:'a -> 'a
 
@@ -626,7 +626,7 @@ module WorkspaceConfiguration : sig
   val update :
        t
     -> section:string
-    -> value:Js.Any.t
+    -> value:Ojs.t
     -> ?configurationTarget:
          [ `ConfigurationTarget of ConfigurationTarget.t | `Bool of bool ]
     -> ?overrideInLanguage:bool
@@ -635,7 +635,7 @@ module WorkspaceConfiguration : sig
 end
 
 module WorkspaceEdit : sig
-  include Js.T
+  include Ojs.T
 
   val size : t -> int
 
@@ -654,11 +654,11 @@ module StatusBarAlignment : sig
     | Left
     | Right
 
-  include Js.T with type t := t
+  include Ojs.T with type t := t
 end
 
 module AccessibilityInformation : sig
-  include Js.T
+  include Ojs.T
 
   val label : t -> string
 
@@ -668,7 +668,7 @@ module AccessibilityInformation : sig
 end
 
 module StatusBarItem : sig
-  include Js.T
+  include Ojs.T
 
   type color =
     [ `String of string
@@ -722,7 +722,7 @@ module StatusBarItem : sig
 end
 
 module WorkspaceFoldersChangeEvent : sig
-  include Js.T
+  include Ojs.T
 
   val added : t -> WorkspaceFolder.t list
 
@@ -733,7 +733,7 @@ module WorkspaceFoldersChangeEvent : sig
 end
 
 module FormattingOptions : sig
-  include Js.T
+  include Ojs.T
 
   val tabSize : t -> int
 
@@ -745,19 +745,19 @@ end
 module Event : sig
   type 'a t =
        listener:('a -> unit)
-    -> ?thisArgs:Js.Any.t
+    -> ?thisArgs:Ojs.t
     -> ?disposables:Disposable.t list
     -> unit
     -> Disposable.t
 
-  module Make (T : Js.T) : Js.T with type t = T.t t
+  module Make (T : Ojs.T) : Ojs.T with type t = T.t t
 end
 
 module EventEmitter : sig
   type 'a t
 
-  module Make (T : Js.T) : sig
-    include Js.T with type t = T.t t
+  module Make (T : Ojs.T) : sig
+    include Ojs.T with type t = T.t t
 
     val make : unit -> t
 
@@ -770,21 +770,19 @@ module EventEmitter : sig
 end
 
 module CancellationToken : sig
-  include Js.T
+  include Ojs.T
 
   val isCancellationRequested : t -> bool
 
-  val onCancellationRequested : t -> Js.Any.t Event.t
+  val onCancellationRequested : t -> Ojs.t Event.t
 
   val create :
-       isCancellationRequested:bool
-    -> onCancellationRequested:Js.Any.t Event.t
-    -> t
+    isCancellationRequested:bool -> onCancellationRequested:Ojs.t Event.t -> t
 end
 
 module CustomDocument : sig
   module type T = sig
-    include Js.T
+    include Ojs.T
 
     val uri : t -> Uri.t
 
@@ -797,7 +795,7 @@ module CustomDocument : sig
 end
 
 module QuickPickItem : sig
-  include Js.T
+  include Ojs.T
 
   val label : t -> string
 
@@ -820,7 +818,7 @@ module QuickPickItem : sig
 end
 
 module QuickPickOptions : sig
-  include Js.T
+  include Ojs.T
 
   type onDidSelectItemArgs =
     [ `QuickPickItem of QuickPickItem.t
@@ -865,7 +863,7 @@ module ProviderResult : sig
 end
 
 module InputBoxOptions : sig
-  include Js.T
+  include Ojs.T
 
   val title : t -> string option
 
@@ -897,7 +895,7 @@ module InputBoxOptions : sig
 end
 
 module OpenDialogOptions : sig
-  include Js.T
+  include Ojs.T
 
   val create :
        ?canSelectFiles:bool
@@ -912,7 +910,7 @@ module OpenDialogOptions : sig
 end
 
 module MessageItem : sig
-  include Js.T
+  include Ojs.T
 
   val title : t -> string
 
@@ -922,7 +920,7 @@ module MessageItem : sig
 end
 
 module Location : sig
-  include Js.T
+  include Ojs.T
 
   val uri : t -> Uri.t
 
@@ -940,11 +938,11 @@ module ProgressLocation : sig
     | Window
     | Notification
 
-  include Js.T with type t := t
+  include Ojs.T with type t := t
 end
 
 module ProgressOptions : sig
-  include Js.T
+  include Ojs.T
 
   type location =
     [ `ProgressLocation of ProgressLocation.t
@@ -972,7 +970,7 @@ module DiagnosticSeverity : sig
 end
 
 module DiagnosticRelatedInformation : sig
-  include Js.T
+  include Ojs.T
 
   val location : t -> Location.t
 
@@ -988,7 +986,7 @@ module DiagnosticTag : sig
 end
 
 module Diagnostic : sig
-  include Js.T
+  include Ojs.T
 
   type code_target =
     { value : [ `String of string | `Int of int ]
@@ -1019,7 +1017,7 @@ module Diagnostic : sig
 end
 
 module TextDocumentShowOptions : sig
-  include Js.T
+  include Ojs.T
 
   val viewColumn : t -> ViewColumn.t option
 
@@ -1039,7 +1037,7 @@ module TextDocumentShowOptions : sig
 end
 
 module TerminalOptions : sig
-  include Js.T
+  include Ojs.T
 
   type shellArgs =
     [ `Arg of string
@@ -1067,7 +1065,7 @@ module TerminalOptions : sig
 end
 
 module TerminalDimensions : sig
-  include Js.T
+  include Ojs.T
 
   val columns : t -> int
 
@@ -1077,7 +1075,7 @@ module TerminalDimensions : sig
 end
 
 module Pseudoterminal : sig
-  include Js.T
+  include Ojs.T
 
   val onDidWrite : t -> string Event.t
 
@@ -1106,7 +1104,7 @@ module Pseudoterminal : sig
 end
 
 module ExtensionTerminalOptions : sig
-  include Js.T
+  include Ojs.T
 
   val name : t -> string
 
@@ -1116,7 +1114,7 @@ module ExtensionTerminalOptions : sig
 end
 
 module Extension : sig
-  include Js.T
+  include Ojs.T
 end
 
 module Extensions : sig
@@ -1124,7 +1122,7 @@ module Extensions : sig
 end
 
 module TerminalExitStatus : sig
-  include Js.T
+  include Ojs.T
 
   val code : t -> int
 
@@ -1132,7 +1130,7 @@ module TerminalExitStatus : sig
 end
 
 module Terminal : sig
-  include Js.T
+  include Ojs.T
 
   type creationOptions =
     [ `TerminalOptions of TerminalOptions.t
@@ -1159,7 +1157,7 @@ module Terminal : sig
 end
 
 module OutputChannel : sig
-  include Js.T
+  include Ojs.T
 
   val name : t -> string
 
@@ -1179,13 +1177,13 @@ module OutputChannel : sig
 end
 
 module Memento : sig
-  include Js.T
+  include Ojs.T
 
-  val get : t -> key:string -> Js.Any.t option
+  val get : t -> key:string -> Ojs.t option
 
   val get_default : 'a Js.t -> t -> key:string -> defaultValue:'a -> 'a
 
-  val update : t -> key:string -> value:Js.Any.t -> Promise.void
+  val update : t -> key:string -> value:Ojs.t -> Promise.void
 end
 
 module EnvironmentVariableMutatorType : sig
@@ -1194,11 +1192,11 @@ module EnvironmentVariableMutatorType : sig
     | Append
     | Prepend
 
-  include Js.T with type t := t
+  include Ojs.T with type t := t
 end
 
 module EnvironmentVariableMutator : sig
-  include Js.T
+  include Ojs.T
 
   val type_ : t -> EnvironmentVariableMutatorType.t
 
@@ -1206,7 +1204,7 @@ module EnvironmentVariableMutator : sig
 end
 
 module EnvironmentVariableCollection : sig
-  include Js.T
+  include Ojs.T
 
   val persistent : t -> bool
 
@@ -1238,17 +1236,17 @@ module ExtensionMode : sig
     | Development
     | Test
 
-  include Js.T with type t := t
+  include Ojs.T with type t := t
 end
 
 module SecretStorageChangeEvent : sig
-  include Js.T
+  include Ojs.T
 
   val key : t -> string
 end
 
 module SecretStorage : sig
-  include Js.T
+  include Ojs.T
 
   val get : t -> key:string -> string option Promise.t
 
@@ -1260,7 +1258,7 @@ module SecretStorage : sig
 end
 
 module ExtensionContext : sig
-  include Js.T
+  include Ojs.T
 
   val subscriptions : t -> Disposable.t list
 
@@ -1290,7 +1288,7 @@ module ExtensionContext : sig
 end
 
 module ShellQuotingOptions : sig
-  include Js.T
+  include Ojs.T
 
   type escapeLiteral =
     { escapeChar : string
@@ -1312,7 +1310,7 @@ module ShellQuotingOptions : sig
 end
 
 module ShellExecutionOptions : sig
-  include Js.T
+  include Ojs.T
 
   val executable : t -> string option
 
@@ -1340,11 +1338,11 @@ module ShellQuoting : sig
     | Strong
     | Weak
 
-  include Js.T with type t := t
+  include Ojs.T with type t := t
 end
 
 module ShellQuotedString : sig
-  include Js.T
+  include Ojs.T
 
   val value : t -> string
 
@@ -1354,7 +1352,7 @@ module ShellQuotedString : sig
 end
 
 module ShellExecution : sig
-  include Js.T
+  include Ojs.T
 
   type shellString =
     [ `String of string
@@ -1381,7 +1379,7 @@ module ShellExecution : sig
 end
 
 module ProcessExecutionOptions : sig
-  include Js.T
+  include Ojs.T
 
   val cwd : t -> string option
 
@@ -1391,7 +1389,7 @@ module ProcessExecutionOptions : sig
 end
 
 module ProcessExecution : sig
-  include Js.T
+  include Ojs.T
 
   val makeProcess :
     process:string -> ?options:ProcessExecutionOptions.t -> unit -> t
@@ -1411,19 +1409,19 @@ module ProcessExecution : sig
 end
 
 module TaskDefinition : sig
-  include Js.T
+  include Ojs.T
 
   val type_ : t -> string
 
-  val get_attribute : t -> string -> Js.Any.t
+  val get_attribute : t -> string -> Ojs.t
 
-  val set_attribute : t -> string -> Js.Any.t -> unit
+  val set_attribute : t -> string -> Ojs.t -> unit
 
-  val create : type_:string -> ?attributes:(string * Js.Any.t) list -> unit -> t
+  val create : type_:string -> ?attributes:(string * Ojs.t) list -> unit -> t
 end
 
 module CustomExecution : sig
-  include Js.T
+  include Ojs.T
 
   val make :
        callback:
@@ -1432,7 +1430,7 @@ module CustomExecution : sig
 end
 
 module RelativePattern : sig
-  include Js.T
+  include Ojs.T
 
   val base : t -> string
 
@@ -1454,11 +1452,11 @@ module GlobPattern : sig
     | `RelativePattern of RelativePattern.t
     ]
 
-  include Js.T with type t := t
+  include Ojs.T with type t := t
 end
 
 module DocumentFilter : sig
-  include Js.T
+  include Ojs.T
 
   val language : t -> string option
 
@@ -1481,11 +1479,11 @@ module DocumentSelector : sig
     | `List of selector list
     ]
 
-  include Js.T with type t := t
+  include Ojs.T with type t := t
 end
 
 module DocumentFormattingEditProvider : sig
-  include Js.T
+  include Ojs.T
 
   val provideDocumentFormattingEdits :
        t
@@ -1504,7 +1502,7 @@ module DocumentFormattingEditProvider : sig
 end
 
 module Hover : sig
-  include Js.T
+  include Ojs.T
 
   val contents : t -> MarkdownString.t
 
@@ -1519,7 +1517,7 @@ module Hover : sig
 end
 
 module HoverProvider : sig
-  include Js.T
+  include Ojs.T
 
   val provideHover :
        t
@@ -1538,7 +1536,7 @@ module HoverProvider : sig
 end
 
 module TaskGroup : sig
-  include Js.T
+  include Ojs.T
 
   val clean : t
 
@@ -1555,11 +1553,11 @@ module TaskScope : sig
     | Global
     | Workspace
 
-  include Js.T with type t := t
+  include Ojs.T with type t := t
 end
 
 module RunOptions : sig
-  include Js.T
+  include Ojs.T
 
   val reevaluateOnRerun : t -> bool option
 
@@ -1572,7 +1570,7 @@ module TaskRevealKind : sig
     | Silent
     | Never
 
-  include Js.T with type t := t
+  include Ojs.T with type t := t
 end
 
 module TaskPanelKind : sig
@@ -1581,11 +1579,11 @@ module TaskPanelKind : sig
     | Dedicated
     | New
 
-  include Js.T with type t := t
+  include Ojs.T with type t := t
 end
 
 module TaskPresentationOptions : sig
-  include Js.T
+  include Ojs.T
 
   val reveal : t -> TaskRevealKind.t option
 
@@ -1611,7 +1609,7 @@ module TaskPresentationOptions : sig
 end
 
 module Task : sig
-  include Js.T
+  include Ojs.T
 
   type execution =
     [ `ProcessExecution of ProcessExecution.t
@@ -1655,7 +1653,7 @@ end
 module TaskProvider : sig
   type 'a t
 
-  module Make (T : Js.T) : sig
+  module Make (T : Ojs.T) : sig
     type nonrec t = T.t t
 
     val provideTasks :
@@ -1681,11 +1679,11 @@ module ConfigurationScope : sig
     | `WorkspaceFolder of WorkspaceFolder.t
     ]
 
-  include Js.T with type t := t
+  include Ojs.T with type t := t
 end
 
 module MessageOptions : sig
-  include Js.T
+  include Ojs.T
 
   val modal : t -> bool option
 
@@ -1693,7 +1691,7 @@ module MessageOptions : sig
 end
 
 module Progress : sig
-  include Js.T
+  include Ojs.T
 
   type value =
     { message : string option
@@ -1704,7 +1702,7 @@ module Progress : sig
 end
 
 module TextDocumentContentChangeEvent : sig
-  include Js.T
+  include Ojs.T
 
   val range : t -> Range.t
 
@@ -1716,7 +1714,7 @@ module TextDocumentContentChangeEvent : sig
 end
 
 module TextDocumentChangeEvent : sig
-  include Js.T
+  include Ojs.T
 
   val contentChanges : t -> TextDocumentContentChangeEvent.t list
 
@@ -1724,7 +1722,7 @@ module TextDocumentChangeEvent : sig
 end
 
 module TextDocumentContentProvider : sig
-  include Js.T
+  include Ojs.T
 
   val onDidChange : t -> Uri.t Event.t option
 
@@ -1740,13 +1738,13 @@ module TextDocumentContentProvider : sig
 end
 
 module FileSystemWatcher : sig
-  include Js.T
+  include Ojs.T
 
   val onDidChange : t -> Uri.t Event.t
 end
 
 module ConfigurationChangeEvent : sig
-  include Js.T
+  include Ojs.T
 end
 
 module Workspace : sig
@@ -1837,11 +1835,11 @@ module TreeItemCollapsibleState : sig
     | Collapsed
     | Expanded
 
-  include Js.T with type t := t
+  include Ojs.T with type t := t
 end
 
 module TreeItemLabel : sig
-  include Js.T
+  include Ojs.T
 
   val create : label:string -> ?highlights:(int * int) list -> unit -> t
 
@@ -1851,7 +1849,7 @@ module TreeItemLabel : sig
 end
 
 module ThemeIcon : sig
-  include Js.T
+  include Ojs.T
 
   val make : id:string -> ?color:ThemeColor.t -> unit -> t
 
@@ -1865,7 +1863,7 @@ module ThemeIcon : sig
 end
 
 module TreeItem : sig
-  include Js.T
+  include Ojs.T
 
   type label =
     [ `String of string
@@ -1878,7 +1876,7 @@ module TreeItem : sig
       ; dark : [ `String of string | `Uri of Uri.t ]
       }
 
-    include Js.T with type t := t
+    include Ojs.T with type t := t
   end
 
   type iconPath =
@@ -1952,7 +1950,7 @@ end
 module TreeDataProvider : sig
   type 'a t
 
-  module Make (T : Js.T) : sig
+  module Make (T : Ojs.T) : sig
     type nonrec t = T.t t
 
     val onDidChangeTreeData : t -> T.t option Event.t option
@@ -1994,7 +1992,7 @@ end
 module TreeViewOptions : sig
   type 'a t
 
-  module Make (T : Js.T) : sig
+  module Make (T : Ojs.T) : sig
     type nonrec t = T.t t
 
     val treeDataProvider : t -> T.t TreeDataProvider.t
@@ -2008,7 +2006,7 @@ end
 module TreeViewExpansionEvent : sig
   type 'a t
 
-  module Make (T : Js.T) : sig
+  module Make (T : Ojs.T) : sig
     type nonrec t = T.t t
 
     val element : t -> T.t
@@ -2020,7 +2018,7 @@ end
 module TreeViewSelectionChangeEvent : sig
   type 'a t
 
-  module Make (T : Js.T) : sig
+  module Make (T : Ojs.T) : sig
     type nonrec t = T.t t
 
     val selection : t -> T.t list
@@ -2030,7 +2028,7 @@ module TreeViewSelectionChangeEvent : sig
 end
 
 module TreeViewVisibilityChangeEvent : sig
-  include Js.T
+  include Ojs.T
 
   val visible : t -> bool
 
@@ -2040,7 +2038,7 @@ end
 module TreeView : sig
   type 'a t = private Disposable.t
 
-  module Make (T : Js.T) : sig
+  module Make (T : Ojs.T) : sig
     type nonrec t = T.t t
 
     val onDidExpandElement : t -> T.t TreeViewExpansionEvent.t Event.t
@@ -2074,7 +2072,7 @@ module TreeView : sig
 end
 
 module WebviewPanelOptions : sig
-  include Js.T
+  include Ojs.T
 
   val enableFindWidget : t -> bool option
 
@@ -2082,7 +2080,7 @@ module WebviewPanelOptions : sig
 end
 
 module WebviewPortMapping : sig
-  include Js.T
+  include Ojs.T
 
   val extensionHostPort : t -> int
 
@@ -2090,7 +2088,7 @@ module WebviewPortMapping : sig
 end
 
 module WebviewOptions : sig
-  include Js.T
+  include Ojs.T
 
   val enableCommandUris : t -> bool option
 
@@ -2110,9 +2108,9 @@ module WebviewOptions : sig
 end
 
 module WebView : sig
-  include Js.T
+  include Ojs.T
 
-  val onDidReceiveMessage : t -> Js.Any.t Event.t
+  val onDidReceiveMessage : t -> Ojs.t Event.t
 
   val cspSource : t -> string
 
@@ -2126,26 +2124,26 @@ module WebView : sig
 
   val asWebviewUri : t -> localResource:Uri.t -> Uri.t
 
-  val postMessage : t -> Js.Any.t -> bool Promise.t
+  val postMessage : t -> Ojs.t -> bool Promise.t
 
   val create :
-       onDidReceiveMessage:Js.Any.t Event.t
+       onDidReceiveMessage:Ojs.t Event.t
     -> cspSource:string
     -> html:string
     -> options:WebviewOptions.t
     -> close:(unit -> unit)
     -> asWebviewUri:(Uri.t -> Uri.t)
-    -> postMessage:(Js.Any.t -> bool Promise.t)
+    -> postMessage:(Ojs.t -> bool Promise.t)
     -> t
 end
 
 module WebviewPanel : sig
-  include Js.T
+  include Ojs.T
 
   module WebviewPanelOnDidChangeViewStateEvent : sig
     type webviewPanel := t
 
-    include Js.T
+    include Ojs.T
 
     val webviewPanel : t -> webviewPanel
   end
@@ -2156,7 +2154,7 @@ module WebviewPanel : sig
       ; dark : Uri.t
       }
 
-    include Js.T with type t := t
+    include Ojs.T with type t := t
   end
 
   val onDidChangeViewState :
@@ -2185,7 +2183,7 @@ module WebviewPanel : sig
 
   val set_webview : t -> WebView.t -> unit
 
-  val dispose : t -> Js.Any.t
+  val dispose : t -> Ojs.t
 
   val reveal :
     t -> ?preserveFocus:bool -> ?viewColumn:ViewColumn.t -> unit -> unit
@@ -2200,13 +2198,13 @@ module WebviewPanel : sig
     -> viewType:string
     -> visible:bool
     -> webview:WebView.t
-    -> dispose:Js.Any.t
+    -> dispose:Ojs.t
     -> reveal:(?preserveFocus:bool -> ?viewColumn:ViewColumn.t -> unit -> unit)
     -> t
 end
 
 module CustomTextEditorProvider : sig
-  include Js.T
+  include Ojs.T
 
   module ResolvedEditor : sig
     type t =
@@ -2236,7 +2234,7 @@ module CustomTextEditorProvider : sig
 end
 
 module CustomDocumentOpenContext : sig
-  include Js.T
+  include Ojs.T
 
   val backupId : t -> string or_undefined
 end
@@ -2277,7 +2275,7 @@ module CustomReadonlyEditorProvider : sig
 end
 
 module RegisterCustomEditorProviderOptions : sig
-  include Js.T
+  include Ojs.T
 
   val supportsMultipleEditorsPerDocument : t -> bool or_undefined
 
@@ -2421,22 +2419,22 @@ end
 
 module Commands : sig
   val registerCommand :
-    command:string -> callback:(args:Js.Any.t list -> unit) -> Disposable.t
+    command:string -> callback:(args:Ojs.t list -> unit) -> Disposable.t
 
   val registerCommandReturn :
-    command:string -> callback:(args:Js.Any.t list -> Js.Any.t) -> Disposable.t
+    command:string -> callback:(args:Ojs.t list -> Ojs.t) -> Disposable.t
 
   val registerTextEditorCommand :
        command:string
     -> callback:
          (   textEditor:TextEditor.t
           -> edit:TextEditorEdit.t
-          -> args:Js.Any.t list
+          -> args:Ojs.t list
           -> unit)
     -> Disposable.t
 
   val executeCommand :
-    command:string -> args:Js.Any.t list -> Js.Any.t option Promise.t
+    command:string -> args:Ojs.t list -> Ojs.t option Promise.t
 
   val getCommands : ?filterInternal:bool -> unit -> string list Promise.t
 end
@@ -2465,7 +2463,7 @@ module Env : sig
 end
 
 module DebugAdapterExecutableOptions : sig
-  include Js.T
+  include Ojs.T
 
   val cwd : t -> string option
 
@@ -2475,7 +2473,7 @@ module DebugAdapterExecutableOptions : sig
 end
 
 module DebugAdapterExecutable : sig
-  include Js.T
+  include Ojs.T
 
   val make :
        command:string
@@ -2486,15 +2484,15 @@ module DebugAdapterExecutable : sig
 end
 
 module DebugAdapterServer : sig
-  include Js.T
+  include Ojs.T
 end
 
 module DebugAdapterNamedPipeServer : sig
-  include Js.T
+  include Ojs.T
 end
 
 module DebugAdapterInlineImplementation : sig
-  include Js.T
+  include Ojs.T
 end
 
 module DebugAdapterDescriptor : sig
@@ -2505,18 +2503,18 @@ module DebugAdapterDescriptor : sig
     | `InlineImplementation of DebugAdapterInlineImplementation.t
     ]
 
-  include Js.T with type t := t
+  include Ojs.T with type t := t
 end
 
 module DebugSession : sig
-  include Js.T
+  include Ojs.T
 
   val customRequest :
-    t -> command:string -> ?args:Js.Any.t -> unit -> Js.Any.t Promise.t
+    t -> command:string -> ?args:Ojs.t -> unit -> Ojs.t Promise.t
 end
 
 module DebugAdapterDescriptorFactory : sig
-  include Js.T
+  include Ojs.T
 
   (* TODO: unused? remove? *)
   val createDebugAdapterDescriptor :
@@ -2534,7 +2532,7 @@ module DebugAdapterDescriptorFactory : sig
 end
 
 module DebugConfiguration : sig
-  include Js.T
+  include Ojs.T
 
   val create : name:string -> request:string -> type_:string -> t
 
@@ -2542,7 +2540,7 @@ module DebugConfiguration : sig
 end
 
 module DebugConfigurationProvider : sig
-  include Js.T
+  include Ojs.T
 
   val create :
        ?provideDebugConfigurations:
@@ -2571,7 +2569,7 @@ module DebugConfigurationProviderTriggerKind : sig
     | Initial
     | Dynamic
 
-  include Js.T with type t := t
+  include Ojs.T with type t := t
 end
 
 module Debug : sig

--- a/src-bindings/vscode/vscode.mli
+++ b/src-bindings/vscode/vscode.mli
@@ -750,11 +750,13 @@ module Event : sig
     -> unit
     -> Disposable.t
 
+  include Js.Generic with type 'a t := 'a t
+
   module Make (T : Ojs.T) : Ojs.T with type t = T.t t
 end
 
 module EventEmitter : sig
-  type 'a t
+  include Js.Generic
 
   module Make (T : Ojs.T) : sig
     include Ojs.T with type t = T.t t
@@ -857,9 +859,7 @@ module ProviderResult : sig
     | `Promise of 'a option Promise.t
     ]
 
-  val t_to_js : ('a -> Ojs.t) -> 'a t -> Ojs.t
-
-  val t_of_js : (Ojs.t -> 'a) -> Ojs.t -> 'a t
+  include Js.Generic with type 'a t := 'a t
 end
 
 module InputBoxOptions : sig
@@ -1651,7 +1651,7 @@ module Task : sig
 end
 
 module TaskProvider : sig
-  type 'a t
+  include Js.Generic
 
   module Make (T : Ojs.T) : sig
     type nonrec t = T.t t
@@ -1948,7 +1948,7 @@ module TreeItem : sig
 end
 
 module TreeDataProvider : sig
-  type 'a t
+  include Js.Generic
 
   module Make (T : Ojs.T) : sig
     type nonrec t = T.t t
@@ -1990,7 +1990,7 @@ module TreeDataProvider : sig
 end
 
 module TreeViewOptions : sig
-  type 'a t
+  include Js.Generic
 
   module Make (T : Ojs.T) : sig
     type nonrec t = T.t t
@@ -2004,7 +2004,7 @@ module TreeViewOptions : sig
 end
 
 module TreeViewExpansionEvent : sig
-  type 'a t
+  include Js.Generic
 
   module Make (T : Ojs.T) : sig
     type nonrec t = T.t t
@@ -2016,7 +2016,7 @@ module TreeViewExpansionEvent : sig
 end
 
 module TreeViewSelectionChangeEvent : sig
-  type 'a t
+  include Js.Generic
 
   module Make (T : Ojs.T) : sig
     type nonrec t = T.t t
@@ -2036,7 +2036,7 @@ module TreeViewVisibilityChangeEvent : sig
 end
 
 module TreeView : sig
-  type 'a t = private Disposable.t
+  include Js.Generic with type 'a t = private Disposable.t
 
   module Make (T : Ojs.T) : sig
     type nonrec t = T.t t
@@ -2067,7 +2067,6 @@ module TreeView : sig
       -> ?expand:[ `Bool of bool | `Int of int ]
       -> unit
       -> Promise.void
-    [@@js.call]
   end
 end
 
@@ -2240,7 +2239,7 @@ module CustomDocumentOpenContext : sig
 end
 
 module CustomReadonlyEditorProvider : sig
-  type 'a t
+  include Js.Generic
 
   module Make (T : CustomDocument.T) : sig
     type nonrec t = T.t t

--- a/src-bindings/vscode_languageclient/vscode_languageclient.mli
+++ b/src-bindings/vscode_languageclient/vscode_languageclient.mli
@@ -7,11 +7,11 @@ module RevealOutputChannelOn : sig
     | Error
     | Never
 
-  include Js.T with type t := t
+  include Ojs.T with type t := t
 end
 
 module ServerCapabilities : sig
-  include Js.T
+  include Ojs.T
 
   val experimental : t -> Jsonoo.t option
 
@@ -19,7 +19,7 @@ module ServerCapabilities : sig
 end
 
 module InitializeResult : sig
-  include Js.T
+  include Ojs.T
 
   val capabilities : t -> ServerCapabilities.t
 
@@ -32,7 +32,7 @@ module InitializeResult : sig
 end
 
 module DocumentFilter : sig
-  include Js.T
+  include Ojs.T
 
   val language : t -> string option
 
@@ -58,13 +58,13 @@ module DocumentSelector : sig
 
   type t = selector array
 
-  include Js.T with type t := t
+  include Ojs.T with type t := t
 
   val language : ?scheme:string -> ?pattern:string -> string -> selector
 end
 
 module OcamllspSettingEnable : sig
-  include Js.T
+  include Ojs.T
 
   val enable : t -> bool option
 
@@ -72,7 +72,7 @@ module OcamllspSettingEnable : sig
 end
 
 module OcamllspSettings : sig
-  include Js.T
+  include Ojs.T
 
   val codelens : t -> OcamllspSettingEnable.t option
 
@@ -86,7 +86,7 @@ module OcamllspSettings : sig
 end
 
 module ClientOptions : sig
-  include Js.T
+  include Ojs.T
 
   val documentSelector : t -> DocumentSelector.t option
 
@@ -106,7 +106,7 @@ module ClientOptions : sig
 end
 
 module ExecutableOptions : sig
-  include Js.T
+  include Ojs.T
 
   val cwd : t -> string option
 
@@ -126,7 +126,7 @@ module ExecutableOptions : sig
 end
 
 module Executable : sig
-  include Js.T
+  include Ojs.T
 
   val command : t -> string
 
@@ -145,11 +145,11 @@ end
 module ServerOptions = Executable
 
 module InitializeParams : sig
-  include Js.T
+  include Ojs.T
 end
 
 module ClientCapabilities : sig
-  include Js.T
+  include Ojs.T
 
   val experimental : t -> Jsonoo.t or_undefined
 
@@ -157,7 +157,7 @@ module ClientCapabilities : sig
 end
 
 module StaticFeature : sig
-  include Js.T
+  include Ojs.T
 
   val make :
        ?fillInitializeParams:(params:InitializeParams.t -> unit)
@@ -172,13 +172,13 @@ module StaticFeature : sig
 end
 
 module DidChangeConfiguration : sig
-  include Js.T
+  include Ojs.T
 
   val create : settings:OcamllspSettings.t -> unit -> t
 end
 
 module LanguageClient : sig
-  include Js.T
+  include Ojs.T
 
   val make :
        id:string

--- a/src/cm_editor.ml
+++ b/src/cm_editor.ml
@@ -12,14 +12,13 @@ module Cm_document : sig
   val create : uri:Uri.t -> t
 end = struct
   include CustomDocument
-  module OnDidChange = Event.Make (Js.Unit)
 
   include
     [%js:
-    val onDidChange : t -> OnDidChange.t [@@js.get]
+    val onDidChange : t -> unit Event.t [@@js.get]
 
     val create :
-      uri:Uri.t -> onDidChange:OnDidChange.t -> dispose:(unit -> unit) -> t
+      uri:Uri.t -> onDidChange:unit Event.t -> dispose:(unit -> unit) -> t
     [@@js.builder]]
 
   let content t ~instance =

--- a/src/treeview_sandbox.ml
+++ b/src/treeview_sandbox.ml
@@ -107,7 +107,7 @@ module Command = struct
           in
           let* result =
             Vscode.Window.withProgress
-              (module Interop.Js.Result (Interop.Js.Unit) (Interop.Js.String))
+              (module Interop.Js.Result (Interop.Js.Unit) (Ojs.String))
               ~options
               ~task
           in


### PR DESCRIPTION
Ever since https://github.com/LexiFi/gen_js_api/pull/166, many of the modules that are defined in our `interop` library have become redundant.

In this PR, I replace the custom modules with those available from `gen_js_api`, where possible. For the generic function bindings, it was also possible to have `gen_js_api` generate the module-handling code.

I removed the previous `generic` type aliases since they make the code more confusing for very little added convenience. After doing this, I realized most of the functor applications in the bindings are unnecessary since they are only needed to call methods.

Eventually, I would still like to use [ts2ocaml](https://github.com/ocsigen/ts2ocaml), but these changes make our current bindings simpler for the time being. 