### PR TITLE
Fix the build status badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # VSCode OCaml Platform
 
-[![Main workflow](https://img.shields.io/github/workflow/status/ocamllabs/vscode-ocaml-platform/Main%20workflow?branch=master)](https://github.com/ocamllabs/vscode-ocaml-platform/actions?query=workflow%3A%22Main+workflow%22+branch%3Amaster)
+[![Main workflow](https://github.com/ocamllabs/vscode-ocaml-platform/actions/workflows/main.yml/badge.svg)](https://github.com/ocamllabs/vscode-ocaml-platform/actions/workflows/main.yml)
 
 Visual Studio Code extension for OCaml and relevant tools.
 


### PR DESCRIPTION
Previously, official GHA badges were not allowed to be used, but that seems to have been fixed already now: https://github.com/microsoft/vscode-vsce/issues/389#issuecomment-643961423