### PR TITLE
Fix extension crashing after restarting the language server

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 # Unreleased
 
+- Fix extension crashing after restarting the language server (#1262)
+
 ## 1.13.3
 
 - Set the VSCode lower bound to 1.82.0 and set the build target to es2022 to get

--- a/src-bindings/vscode_languageclient/vscode_languageclient.ml
+++ b/src-bindings/vscode_languageclient/vscode_languageclient.ml
@@ -199,7 +199,7 @@ module StaticFeature = struct
            (   capabilities:ServerCapabilities.t
             -> documentSelector:DocumentSelector.t or_undefined
             -> unit)
-      -> dispose:(unit -> unit)
+      -> clear:(unit -> unit)
       -> unit
       -> t
     [@@js.builder]]

--- a/src-bindings/vscode_languageclient/vscode_languageclient.mli
+++ b/src-bindings/vscode_languageclient/vscode_languageclient.mli
@@ -166,7 +166,7 @@ module StaticFeature : sig
          (   capabilities:ServerCapabilities.t
           -> documentSelector:DocumentSelector.t or_undefined
           -> unit)
-    -> dispose:(unit -> unit)
+    -> clear:(unit -> unit)
     -> unit
     -> t
 end

--- a/src/extension_instance.ml
+++ b/src/extension_instance.ml
@@ -99,11 +99,11 @@ end = struct
         (Some experimental)
     in
     let initialize ~capabilities:_ ~documentSelector:_ = () in
-    let dispose () = () in
+    let clear () = () in
     LanguageClient.StaticFeature.make
       ~fillClientCapabilities
       ~initialize
-      ~dispose
+      ~clear
       ()
 
   let start_language_server t =


### PR DESCRIPTION
Fixes #1261 

Version 9 of vscode-languageclient renamed the `dispose` field to `clear`. The extension was crashing after the language server restarts and the undefined `clear` function is called.