### PR TITLE
support switch between impl and intf in reason

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 # Unreleased
 
+- Support switching between impl and intf in reason (#1274)
+
 ## 1.13.4
 
 - Fix extension crashing after restarting the language server (#1262)

--- a/src/switch_impl_intf.ml
+++ b/src/switch_impl_intf.ml
@@ -2,7 +2,10 @@ open Import
 
 let insert_inferred_intf ~source_uri client text_editor =
   let open Promise.Syntax in
-  match String.is_suffix source_uri ~suffix:".ml" || String.is_suffix source_uri ~suffix:".re" with
+  match
+    String.is_suffix source_uri ~suffix:".ml"
+    || String.is_suffix source_uri ~suffix:".re"
+  with
   | false -> Promise.return ()
   | true ->
     (* If the source file was a .ml or .re, infer the interface *)

--- a/src/switch_impl_intf.ml
+++ b/src/switch_impl_intf.ml
@@ -2,11 +2,10 @@ open Import
 
 let insert_inferred_intf ~source_uri client text_editor =
   let open Promise.Syntax in
-  (* XXX this seems sketchy. shouldn't it work for reason as well? *)
-  match String.is_suffix source_uri ~suffix:".ml" with
+  match String.is_suffix source_uri ~suffix:".ml" || String.is_suffix source_uri ~suffix:".re" with
   | false -> Promise.return ()
   | true ->
-    (* If the source file was a .ml, infer the interface *)
+    (* If the source file was a .ml or .re, infer the interface *)
     let* inferred_intf =
       Custom_requests.send_request client Custom_requests.inferIntf source_uri
     in


### PR DESCRIPTION
I tried including `re` extensions in the switch impl/intf functionality, and it works perfectly fine, including Melange projects:

![generate-rei](https://github.com/ocamllabs/vscode-ocaml-platform/assets/220424/dbd16a04-a6fd-4b63-9c50-0300500ad063)
