### PR TITLE
Fix esy sandbox setup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ## 1.14.0
 
 - Support switching between impl and intf in reason (#1274)
+- Fix incorrect esy sandbox docs (#1297)
 
 ## 1.13.4
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,10 +2,11 @@
 
 # Unreleased
 
+- Fix incorrect esy sandbox docs (#1297)
+
 ## 1.14.0
 
 - Support switching between impl and intf in reason (#1274)
-- Fix incorrect esy sandbox docs (#1297)
 
 ## 1.13.4
 

--- a/README.md
+++ b/README.md
@@ -522,7 +522,7 @@ _Local switch_
 {
   "ocaml.sandbox": {
     "kind": "esy",
-    "root": "${workspaceFolder:vscode-ocaml-platform}"
+    "root": "${firstWorkspaceFolder}"
   }
 }
 ```


### PR DESCRIPTION
This wasn't working for me, and I eventually found this https://github.com/ocamllabs/vscode-ocaml-platform/issues/1222#issuecomment-1732451170

```
{
  "ocaml.sandbox": {
    "kind": "esy",
    "root": "${firstWorkspaceFolder}"
  }
}
```

Is the correct way to do this by default