### PR TITLE
Add `ocaml.server.duneDiagnostics` to disable dune diagnostics reporting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@
 
 - Fix server settings missing on LSP startup (#1321)
 
+- Add config to disabling dune diagnostics (#1320)
+
 ## 1.14.2
 
 - Add `1.17.0` to the list of known versions of ocamllsp (#1326)

--- a/package.json
+++ b/package.json
@@ -272,6 +272,11 @@
           "default": false,
           "markdownDescription": "Enable/Disable extended hover"
         },
+        "ocaml.server.duneDiagnostics": {
+          "type": "boolean",
+          "default": true,
+          "markdownDescription": "Enable/Disable dune diagnostics"
+        },
         "ocaml.dune.autoDetect": {
           "type": "boolean",
           "default": true,

--- a/src-bindings/vscode_languageclient/vscode_languageclient.ml
+++ b/src-bindings/vscode_languageclient/vscode_languageclient.ml
@@ -97,9 +97,12 @@ module OcamllspSettings = struct
 
     val extendedHover : t -> OcamllspSettingEnable.t or_undefined [@@js.get]
 
+    val duneDiagnostics : t -> OcamllspSettingEnable.t or_undefined [@@js.get]
+
     val create :
          ?codelens:OcamllspSettingEnable.t
       -> ?extendedHover:OcamllspSettingEnable.t
+      -> ?duneDiagnostics:OcamllspSettingEnable.t
       -> unit
       -> t
     [@@js.builder]]

--- a/src-bindings/vscode_languageclient/vscode_languageclient.mli
+++ b/src-bindings/vscode_languageclient/vscode_languageclient.mli
@@ -78,9 +78,12 @@ module OcamllspSettings : sig
 
   val extendedHover : t -> OcamllspSettingEnable.t option
 
+  val duneDiagnostics : t -> OcamllspSettingEnable.t option
+
   val create :
        ?codelens:OcamllspSettingEnable.t
     -> ?extendedHover:OcamllspSettingEnable.t
+    -> ?duneDiagnostics:OcamllspSettingEnable.t
     -> unit
     -> t
 end

--- a/src/extension_instance.mli
+++ b/src/extension_instance.mli
@@ -24,7 +24,11 @@ val ocaml_version_exn : t -> Ocaml_version.t
 val start_language_server : t -> unit Promise.t
 
 val set_configuration :
-  t -> codelens:bool option -> extended_hover:bool option -> unit
+     t
+  -> codelens:bool option
+  -> extended_hover:bool option
+  -> dune_diagnostics:bool option
+  -> unit
 
 val open_terminal : Sandbox.t -> unit
 

--- a/src/settings.ml
+++ b/src/settings.ml
@@ -127,3 +127,10 @@ let server_extendedHover_setting =
     ~key:"ocaml.server.extendedHover"
     ~of_json:Jsonoo.Decode.bool
     ~to_json:Jsonoo.Encode.bool
+
+let server_duneDiagnostics_setting =
+  create_setting
+    ~scope:ConfigurationTarget.Workspace
+    ~key:"ocaml.server.duneDiagnostics"
+    ~of_json:Jsonoo.Decode.bool
+    ~to_json:Jsonoo.Encode.bool

--- a/src/settings.mli
+++ b/src/settings.mli
@@ -41,3 +41,5 @@ val server_args_setting : string list setting
 val server_codelens_setting : bool setting
 
 val server_extendedHover_setting : bool setting
+
+val server_duneDiagnostics_setting : bool setting

--- a/src/vscode_ocaml_platform.ml
+++ b/src/vscode_ocaml_platform.ml
@@ -25,7 +25,12 @@ let notify_configuration_changes instance =
     ~listener:(fun _event ->
       let codelens = Settings.(get server_codelens_setting) in
       let extended_hover = Settings.(get server_extendedHover_setting) in
-      Extension_instance.set_configuration instance ~codelens ~extended_hover)
+      let dune_diagnostics = Settings.(get server_duneDiagnostics_setting) in
+      Extension_instance.set_configuration
+        instance
+        ~codelens
+        ~extended_hover
+        ~dune_diagnostics)
     ()
 
 let activate (extension : ExtensionContext.t) =


### PR DESCRIPTION
## Context

I would like to disable dune diagnostics as mentioned in 
https://github.com/ocaml/ocaml-lsp/pull/1221

This also shines light in a bug, currently "vscode-ocaml-platform" doesn't push the configs when starting the server, making so that the config is only pushed when you change them. I will fix this in a future PR.

## Related

- https://github.com/ocaml/ocaml-lsp/pull/1221