### PR TITLE
Notify LSP of workspace config when starting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 # Unreleased
 
 - Fix direnv compatibility by loading the process.env on every command (#1322)
+- Fix server settings missing on LSP startup (#1321)
 
 ## 1.14.2
 

--- a/src/extension_instance.mli
+++ b/src/extension_instance.mli
@@ -2,7 +2,7 @@ open Import
 
 type t
 
-val make : unit -> t
+val make : ?codelens:bool -> ?extended_hover:bool -> unit -> t
 
 val sandbox : t -> Sandbox.t
 
@@ -22,6 +22,9 @@ val lsp_client : t -> (LanguageClient.t * Ocaml_lsp.t) option
 val ocaml_version_exn : t -> Ocaml_version.t
 
 val start_language_server : t -> unit Promise.t
+
+val set_configuration :
+  t -> ?codelens:bool -> ?extended_hover:bool -> unit -> unit
 
 val open_terminal : Sandbox.t -> unit
 

--- a/src/vscode_ocaml_platform.ml
+++ b/src/vscode_ocaml_platform.ml
@@ -23,34 +23,9 @@ let suggest_to_pick_sandbox () =
 let notify_configuration_changes instance =
   Workspace.onDidChangeConfiguration
     ~listener:(fun _event ->
-      match Extension_instance.language_client instance with
-      | None -> ()
-      | Some client ->
-        let codelens =
-          Option.map
-            Settings.(get server_codelens_setting)
-            ~f:(fun enable ->
-              LanguageClient.OcamllspSettingEnable.create ~enable ())
-        in
-        let extendedHover =
-          Option.map
-            Settings.(get server_extendedHover_setting)
-            ~f:(fun enable ->
-              LanguageClient.OcamllspSettingEnable.create ~enable ())
-        in
-        let settings =
-          LanguageClient.OcamllspSettings.create ?codelens ?extendedHover ()
-        in
-        let payload =
-          let settings =
-            LanguageClient.DidChangeConfiguration.create ~settings ()
-          in
-          LanguageClient.DidChangeConfiguration.t_to_js settings
-        in
-        LanguageClient.sendNotification
-          client
-          "workspace/didChangeConfiguration"
-          payload)
+      let codelens = Settings.(get server_codelens_setting) in
+      let extended_hover = Settings.(get server_extendedHover_setting) in
+      Extension_instance.set_configuration instance ?codelens ?extended_hover ())
     ()
 
 let activate (extension : ExtensionContext.t) =


### PR DESCRIPTION
## Context

Currently the extension doesn't notify the LSP of configurations, this means that since https://github.com/ocaml/ocaml-lsp/pull/1134 codelens are disabled whenever you start VSCode, even if you explicitly opt-in to codelens.

This is also true for disabling dune diagnostics like #1320.

## Warning

This PR enables codelens again by default, as they're enabled in the manifest of the extension, I feel like this may be desirable anyway so I didn't change it, but if the extension wants to disable it by default, is just a matter of changing this https://github.com/ocamllabs/vscode-ocaml-platform/blob/master/package.json#L267

## Related

- #1320