### PR TITLE
recompute env dict on every command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 # Unreleased
 
+- Fix direnv compatibility by loading the process.env on every command (#1322)
+
 ## 1.14.2
 
 - Add `1.17.0` to the list of known versions of ocamllsp

--- a/src-bindings/node/node.ml
+++ b/src-bindings/node/node.ml
@@ -44,7 +44,7 @@ module Process = struct
 
     let set k v = Ojs.set_prop_ascii env k ([%js.of: string] v)
 
-    include [%js: val env : string Interop.Dict.t [@@js.global "process.env"]]
+    let env () = Interop.Dict.t_of_js [%js.to: string] env
   end
 end
 

--- a/src-bindings/node/node.mli
+++ b/src-bindings/node/node.mli
@@ -32,7 +32,7 @@ module Process : sig
 
     val set : string -> string -> unit
 
-    val env : string Interop.Dict.t
+    val env : unit -> string Interop.Dict.t
   end
 end
 

--- a/src/extension_instance.ml
+++ b/src/extension_instance.ml
@@ -62,7 +62,7 @@ end = struct
       in
       Interop.Dict.union
         (fun _k _v1 v2 -> Some v2)
-        Process.Env.env
+        (Process.Env.env ())
         extra_env_vars
     in
     match command with


### PR DESCRIPTION
## Context

Extensions may mutate the `process.env` this is especially true for https://github.com/direnv/direnv-vscode which will reset every property.

But currently the `process.env` is copied once during the load of the extension, making so that OCaml Platform and direnv are incompatible or need to be hacked around.

![failure while loading OCaml LSP](https://github.com/ocamllabs/vscode-ocaml-platform/assets/3393115/93cd0e6d-c545-4906-8fb8-1b64ba3728d9)


