### PR TITLE
pass --no-dependencies to vsce package

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -72,7 +72,7 @@ watch: ## Watch for the filesystem and rebuild on every change
 
 .PHONY: pkg
 pkg: build # Builds and packages the extension for installment
-	yarn vsce package --out ./test_extension.vsix
+	yarn vsce package --out ./test_extension.vsix --yarn --no-dependencies
 
 .PHONY: install
 install: pkg # Builds, packages, and installs the extension to your VS Code


### PR DESCRIPTION
To work around an issue with [`vsce` not being compatible with `yarn` > 1](https://github.com/microsoft/vscode-vsce/issues/517#issuecomment-1853832670). Also similar to what we do in `package.json`

https://github.com/ocamllabs/vscode-ocaml-platform/blob/15568114a7924854a535a680ec13bb91f002643f/package.json#L30