### PR TITLE
fallback to ocaml.org documentation page

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 # Unreleased
 
+- Fallback to `ocaml.org` package documentation page if there is no doc field in
+  the package's opam file (#1331)
+
 ## 1.17.3
 
 - Republish 1.17.2 (#1405)

--- a/package.json
+++ b/package.json
@@ -1065,12 +1065,12 @@
         },
         {
           "command": "ocaml.open-switches-documentation",
-          "when": "view == ocaml-switches && viewItem == package-with-doc",
+          "when": "view == ocaml-switches && viewItem == package",
           "group": "inline"
         },
         {
           "command": "ocaml.open-sandbox-documentation",
-          "when": "view == ocaml-sandbox && viewItem == package-with-doc",
+          "when": "view == ocaml-sandbox && viewItem == package",
           "group": "inline@1"
         },
         {

--- a/package.json
+++ b/package.json
@@ -1065,12 +1065,12 @@
         },
         {
           "command": "ocaml.open-switches-documentation",
-          "when": "view == ocaml-switches && viewItem == package",
+          "when": "view == ocaml-switches && viewItem == opam-package",
           "group": "inline"
         },
         {
           "command": "ocaml.open-sandbox-documentation",
-          "when": "view == ocaml-sandbox && viewItem == package",
+          "when": "view == ocaml-sandbox && viewItem == opam-package",
           "group": "inline@1"
         },
         {

--- a/src/treeview_sandbox.ml
+++ b/src/treeview_sandbox.ml
@@ -13,11 +13,6 @@ module Dependency = struct
 
   let tooltip t = Sandbox.Package.synopsis t
 
-  let context_value t =
-    match Sandbox.Package.documentation t with
-    | Some _ -> "package-with-doc"
-    | None -> "package"
-
   let icon _ =
     TreeItem.LightDarkIcon.
       { light = `String (Path.asset "number-light.svg" |> Path.to_string)
@@ -38,7 +33,7 @@ module Dependency = struct
     in
     let item = Vscode.TreeItem.make_label ~label ~collapsibleState () in
     Vscode.TreeItem.set_iconPath item icon;
-    TreeItem.set_contextValue item (context_value dependency);
+    TreeItem.set_contextValue item "package";
     let+ _ =
       Promise.Option.iter
         (fun desc -> TreeItem.set_description item (`String desc))
@@ -64,15 +59,25 @@ module Command = struct
         let dep = Dependency.t_of_js arg in
         let open Promise.Syntax in
         let doc = Sandbox.Package.documentation dep in
-        match doc with
-        | None -> Promise.return ()
-        | Some doc ->
-          let+ _ =
-            Vscode.Commands.executeCommand
-              ~command:"vscode.open"
-              ~args:[ Vscode.Uri.parse doc () |> Vscode.Uri.t_to_js ]
-          in
-          ()
+        let uri =
+          match doc with
+          | None ->
+            let name = Sandbox.Package.name dep in
+            let version = Sandbox.Package.version dep in
+            Vscode.Uri.parse
+              (Printf.sprintf
+                 "https://ocaml.org/p/%s/%s/doc/index.html"
+                 name
+                 version)
+              ()
+          | Some doc -> Vscode.Uri.parse doc ()
+        in
+        let+ _ =
+          Vscode.Commands.executeCommand
+            ~command:"vscode.open"
+            ~args:[ Vscode.Uri.t_to_js uri ]
+        in
+        ()
       in
       ()
     in

--- a/src/treeview_sandbox.ml
+++ b/src/treeview_sandbox.ml
@@ -33,7 +33,7 @@ module Dependency = struct
     in
     let item = Vscode.TreeItem.make_label ~label ~collapsibleState () in
     Vscode.TreeItem.set_iconPath item icon;
-    TreeItem.set_contextValue item "package";
+    TreeItem.set_contextValue item "opam-package";
     let+ _ =
       Promise.Option.iter
         (fun desc -> TreeItem.set_description item (`String desc))

--- a/src/treeview_switches.ml
+++ b/src/treeview_switches.ml
@@ -33,10 +33,7 @@ module Dependency = struct
 
   let context_value = function
     | Switch _ -> "opam-switch"
-    | Package dep -> (
-      match Opam.Package.documentation dep with
-      | Some _ -> "package-with-doc"
-      | None -> "package")
+    | Package _ -> "package"
 
   let icon dependency is_current_sandbox =
     match dependency with
@@ -171,18 +168,28 @@ module Command = struct
         | Switch _ ->
           Promise.return
           @@ show_message `Warn "Cannot open documentation of a switch."
-        | Package pkg -> (
+        | Package pkg ->
           let open Promise.Syntax in
           let doc = Opam.Package.documentation pkg in
-          match doc with
-          | None -> Promise.return ()
-          | Some doc ->
-            let+ (_ : Ojs.t option) =
-              Vscode.Commands.executeCommand
-                ~command:"vscode.open"
-                ~args:[ Vscode.Uri.parse doc () |> Vscode.Uri.t_to_js ]
-            in
-            ())
+          let uri =
+            match doc with
+            | None ->
+              let name = Opam.Package.name pkg in
+              let version = Opam.Package.version pkg in
+              Vscode.Uri.parse
+                (Printf.sprintf
+                   "https://ocaml.org/p/%s/%s/doc/index.html"
+                   name
+                   version)
+                ()
+            | Some doc -> Vscode.Uri.parse doc ()
+          in
+          let+ _ =
+            Vscode.Commands.executeCommand
+              ~command:"vscode.open"
+              ~args:[ Vscode.Uri.t_to_js uri ]
+          in
+          ()
       in
       ()
     in

--- a/src/treeview_switches.ml
+++ b/src/treeview_switches.ml
@@ -33,7 +33,7 @@ module Dependency = struct
 
   let context_value = function
     | Switch _ -> "opam-switch"
-    | Package _ -> "package"
+    | Package _ -> "opam-package"
 
   let icon dependency is_current_sandbox =
     match dependency with


### PR DESCRIPTION
Fallback to the `ocaml.org` package documentation page if there is no `doc` field in the package's opam file. Note that it doesn't currently check whether the page exists on `ocaml.org`, so it may return a `404` error.


https://github.com/ocamllabs/vscode-ocaml-platform/assets/5595092/20b71a45-c7ab-4115-be16-f6f75ea63e25

