### PR TITLE
refactor: more optional argument removal

### DIFF
--- a/src/extension_instance.ml
+++ b/src/extension_instance.ml
@@ -26,7 +26,7 @@ let lsp_client t = t.lsp_client
 
 let ocaml_version_exn t = Option.value_exn t.ocaml_version
 
-let send_configuration ?codelens ?extended_hover ?dune_diagnostics client =
+let send_configuration ~codelens ~extended_hover ~dune_diagnostics client =
   let codelens =
     Option.map codelens ~f:(fun enable ->
         LanguageClient.OcamllspSettingEnable.create ~enable ())
@@ -62,7 +62,7 @@ let set_configuration t ~codelens ~extended_hover ~dune_diagnostics =
   match t.lsp_client with
   | None -> ()
   | Some (client, (_ : Ocaml_lsp.t)) ->
-    send_configuration ?codelens ?extended_hover ?dune_diagnostics client
+    send_configuration ~codelens ~extended_hover ~dune_diagnostics client
 
 let stop_server t =
   match t.lsp_client with
@@ -176,9 +176,9 @@ end = struct
       | Error (`Msg m) -> show_message `Warn "%s" m);
       send_configuration
         client
-        ?codelens:t.codelens
-        ?extended_hover:t.extended_hover
-        ?dune_diagnostics:t.dune_diagnostics;
+        ~codelens:t.codelens
+        ~extended_hover:t.extended_hover
+        ~dune_diagnostics:t.dune_diagnostics;
       Ok ()
     in
     match res with


### PR DESCRIPTION
We always pass these arguments, so there's no need for "optionality"

Signed-off-by: Rudi Grinberg <me@rgrinberg.com>

<!-- ps-id: 008208af-8fa6-44a0-ac25-f4b794ad6d18 -->