### PR TITLE
refactor: move ocamllsp settings to extension

### DIFF
--- a/src-bindings/vscode_languageclient/vscode_languageclient.ml
+++ b/src-bindings/vscode_languageclient/vscode_languageclient.ml
@@ -78,36 +78,6 @@ module DocumentSelector = struct
     `Filter (DocumentFilter.createLanguage ~language:l ~scheme ?pattern ())
 end
 
-module OcamllspSettingEnable = struct
-  include Interface.Make ()
-
-  include
-    [%js:
-    val enable : t -> bool or_undefined [@@js.get]
-
-    val create : enable:bool -> unit -> t [@@js.builder]]
-end
-
-module OcamllspSettings = struct
-  include Interface.Make ()
-
-  include
-    [%js:
-    val codelens : t -> OcamllspSettingEnable.t or_undefined [@@js.get]
-
-    val extendedHover : t -> OcamllspSettingEnable.t or_undefined [@@js.get]
-
-    val duneDiagnostics : t -> OcamllspSettingEnable.t or_undefined [@@js.get]
-
-    val create :
-         ?codelens:OcamllspSettingEnable.t
-      -> ?extendedHover:OcamllspSettingEnable.t
-      -> ?duneDiagnostics:OcamllspSettingEnable.t
-      -> unit
-      -> t
-    [@@js.builder]]
-end
-
 module ClientOptions = struct
   include Interface.Make ()
 
@@ -211,9 +181,7 @@ end
 module DidChangeConfiguration = struct
   include Interface.Make ()
 
-  include
-    [%js:
-    val create : settings:OcamllspSettings.t -> unit -> t [@@js.builder]]
+  include [%js: val create : settings:Ojs.t -> unit -> t [@@js.builder]]
 end
 
 module LanguageClient = struct

--- a/src-bindings/vscode_languageclient/vscode_languageclient.mli
+++ b/src-bindings/vscode_languageclient/vscode_languageclient.mli
@@ -63,31 +63,6 @@ module DocumentSelector : sig
   val language : ?scheme:string -> ?pattern:string -> string -> selector
 end
 
-module OcamllspSettingEnable : sig
-  include Ojs.T
-
-  val enable : t -> bool option
-
-  val create : enable:bool -> unit -> t
-end
-
-module OcamllspSettings : sig
-  include Ojs.T
-
-  val codelens : t -> OcamllspSettingEnable.t option
-
-  val extendedHover : t -> OcamllspSettingEnable.t option
-
-  val duneDiagnostics : t -> OcamllspSettingEnable.t option
-
-  val create :
-       ?codelens:OcamllspSettingEnable.t
-    -> ?extendedHover:OcamllspSettingEnable.t
-    -> ?duneDiagnostics:OcamllspSettingEnable.t
-    -> unit
-    -> t
-end
-
 module ClientOptions : sig
   include Ojs.T
 
@@ -177,7 +152,7 @@ end
 module DidChangeConfiguration : sig
   include Ojs.T
 
-  val create : settings:OcamllspSettings.t -> unit -> t
+  val create : settings:Ojs.t -> unit -> t
 end
 
 module LanguageClient : sig

--- a/src/extension_instance.ml
+++ b/src/extension_instance.ml
@@ -29,25 +29,25 @@ let ocaml_version_exn t = Option.value_exn t.ocaml_version
 let send_configuration ~codelens ~extended_hover ~dune_diagnostics client =
   let codelens =
     Option.map codelens ~f:(fun enable ->
-        LanguageClient.OcamllspSettingEnable.create ~enable ())
+        Ocaml_lsp.OcamllspSettingEnable.create ~enable)
   in
   let extendedHover =
     Option.map extended_hover ~f:(fun enable ->
-        LanguageClient.OcamllspSettingEnable.create ~enable ())
+        Ocaml_lsp.OcamllspSettingEnable.create ~enable)
   in
   let duneDiagnostics =
     Option.map dune_diagnostics ~f:(fun enable ->
-        LanguageClient.OcamllspSettingEnable.create ~enable ())
+        Ocaml_lsp.OcamllspSettingEnable.create ~enable)
   in
   let settings =
-    LanguageClient.OcamllspSettings.create
-      ?codelens
-      ?extendedHover
-      ?duneDiagnostics
-      ()
+    Ocaml_lsp.OcamllspSettings.create ~codelens ~extendedHover ~duneDiagnostics
   in
   let payload =
-    let settings = LanguageClient.DidChangeConfiguration.create ~settings () in
+    let settings =
+      LanguageClient.DidChangeConfiguration.create
+        ~settings:(Ocaml_lsp.OcamllspSettings.t_to_js settings)
+        ()
+    in
     LanguageClient.DidChangeConfiguration.t_to_js settings
   in
   LanguageClient.sendNotification

--- a/src/ocaml_lsp.ml
+++ b/src/ocaml_lsp.ml
@@ -1,4 +1,38 @@
 open! Import
+open Interop
+
+module OcamllspSettingEnable = struct
+  include Interface.Make ()
+
+  include
+    [%js:
+    val enable : t -> bool or_undefined [@@js.get]
+
+    val create : enable:bool -> t [@@js.builder]]
+end
+
+module OcamllspSettings = struct
+  include Interface.Make ()
+
+  include
+    [%js:
+    val codelens : t -> OcamllspSettingEnable.t or_undefined [@@js.get]
+
+    val extendedHover : t -> OcamllspSettingEnable.t or_undefined [@@js.get]
+
+    val duneDiagnostics : t -> OcamllspSettingEnable.t or_undefined [@@js.get]
+
+    val create :
+         ?codelens:OcamllspSettingEnable.t
+      -> ?extendedHover:OcamllspSettingEnable.t
+      -> ?duneDiagnostics:OcamllspSettingEnable.t
+      -> unit
+      -> t
+    [@@js.builder]]
+
+  let create ~codelens ~extendedHover ~duneDiagnostics =
+    create ?codelens ?extendedHover ?duneDiagnostics ()
+end
 
 module Experimental_capabilities = struct
   type t =

--- a/src/ocaml_lsp.mli
+++ b/src/ocaml_lsp.mli
@@ -12,3 +12,27 @@ val can_handle_switch_impl_intf : t -> bool
 val can_handle_infer_intf : t -> bool
 
 val can_handle_typed_holes : t -> bool
+
+module OcamllspSettingEnable : sig
+  include Ojs.T
+
+  val enable : t -> bool option
+
+  val create : enable:bool -> t
+end
+
+module OcamllspSettings : sig
+  include Ojs.T
+
+  val codelens : t -> OcamllspSettingEnable.t option
+
+  val extendedHover : t -> OcamllspSettingEnable.t option
+
+  val duneDiagnostics : t -> OcamllspSettingEnable.t option
+
+  val create :
+       codelens:OcamllspSettingEnable.t option
+    -> extendedHover:OcamllspSettingEnable.t option
+    -> duneDiagnostics:OcamllspSettingEnable.t option
+    -> t
+end


### PR DESCRIPTION
These aren't any general purpose bindings, they should live in the
extension

Signed-off-by: Rudi Grinberg <me@rgrinberg.com>

<!-- ps-id: 54027297-8cd7-44d9-ac77-c358741660d8 -->