### PR TITLE
Fix improper coloring of ocamldoc comments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 # Unreleased
 
+- No longer color comments starting three stars or more as ocamldoc comments (#1355)
+
 ## 1.16.0
 
 - Add syntax documentation option (#1313)

--- a/syntaxes/ocaml.json
+++ b/syntaxes/ocaml.json
@@ -128,7 +128,7 @@
         {
           "comment": "ocamldoc comment",
           "name": "comment.doc.ocaml",
-          "begin": "\\(\\*\\*",
+          "begin": "\\(\\*\\*(?!\\*)",
           "end": "\\*\\)",
           "patterns": [
             { "include": "source.ocaml.ocamldoc#markup" },


### PR DESCRIPTION
Ocamldoc comments start with only two stars: https://v2.ocaml.org/manual/ocamldoc.html#s:ocamldoc-comments.
Previously, any comment starting with two stars or more was marked as ocamldoc. This PR fixes that, so comments starting with more stars are no longer marked as ocamldoc.

This is visible when using a theme that as a different color for doc comment, like [mine](https://github.com/dlesbre/vscode-embers), but also when putting ocamldoc syntax like `@tags` or `[code]`, which change color in doc comments but not in non-doc comments.