### PR TITLE
Add syntax color to ocamldoc markup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 # Unreleased
 
 - Fix non-ocaml markdown code block syntax highlighting being influenced (issue #1288, #1369)
+- Add syntax color to ocamldoc and odoc markup (#1365)
 
 ## 1.16.1
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - Fix non-ocaml markdown code block syntax highlighting being influenced (issue #1288, #1369)
 - Add syntax color to ocamldoc and odoc markup (#1365)
+- Remove comment color from mld files (but keep markup color) (issue #1014, #1365)
 
 ## 1.16.1
 

--- a/syntaxes/ocamldoc.json
+++ b/syntaxes/ocamldoc.json
@@ -15,7 +15,7 @@
       "patterns": [
         {
           "comment": "ocamldoc documentation tag @raise",
-          "match": "(\\@raises?)\\s+(\\S+)",
+          "match": "(@raises?)\\s+(\\S+)",
           "captures": {
             "1": { "name": "keyword.doc-tag.ocamldoc" },
             "2": {
@@ -25,7 +25,7 @@
         },
         {
           "comment": "ocamldoc documentation tag @param",
-          "match": "(\\@param)\\s+(\\S+)",
+          "match": "(@param)\\s+(\\S+)",
           "captures": {
             "1": { "name": "keyword.doc-tag.ocamldoc" },
             "2": {
@@ -35,7 +35,7 @@
         },
         {
           "comment": "ocamldoc documentation tag @see",
-          "match": "(\\@see)\\s+(<.*?>|\".*?\"|'.*?')",
+          "match": "(@see)\\s+(<.*?>|\".*?\"|'.*?')",
           "captures": {
             "1": { "name": "keyword.doc-tag.ocamldoc" },
             "2": {
@@ -46,7 +46,7 @@
         {
           "comment": "ocamldoc documentation tag",
           "name": "keyword.doc-tag.ocamldoc",
-          "match": "\\@[[:lower:]]+"
+          "match": "@[[:lower:]]+"
         },
         {
           "comment": "embedded ocaml source",
@@ -66,7 +66,7 @@
         },
         {
           "comment": "embedded other language source",
-          "begin": "(?<!\\\\)\\{\\@\\S+?\\[",
+          "begin": "(?<!\\\\)\\{@\\S+?\\[",
           "end": "(?<!\\\\)\\]\\}",
           "name": "markup.inline.raw.odoc",
           "contentName": "source.embedded.odoc"

--- a/syntaxes/ocamldoc.json
+++ b/syntaxes/ocamldoc.json
@@ -95,7 +95,7 @@
         },
         {
           "comment": "ocamldoc heading tag",
-          "begin": "(?<!\\\\){[0-9]+[[:space:]]",
+          "begin": "(?<!\\\\){[[:digit:]]+[[:space:]]",
           "end": "(?<!\\\\)}",
           "name": "markup.heading.ocamldoc",
           "patterns": [{ "include": "#markup" }]

--- a/syntaxes/ocamldoc.json
+++ b/syntaxes/ocamldoc.json
@@ -120,7 +120,7 @@
           "end": "((?<!\\\\)})",
           "beginCaptures": {
             "1": {
-              "name":"punctuation.definition.list.begin.markdown.ocamldoc"
+              "name": "punctuation.definition.list.begin.markdown.ocamldoc"
             }
           },
           "endCaptures": {

--- a/syntaxes/ocamldoc.json
+++ b/syntaxes/ocamldoc.json
@@ -22,10 +22,146 @@
           "comment": "embedded ocaml source",
           "begin": "(?<!\\\\)\\[",
           "end": "(?<!\\\\)\\]",
+          "name": "markup.inline.raw.ocamldoc",
           "contentName": "source.embedded.ocamldoc",
           "patterns": [{ "include": "source.ocaml" }]
+        },
+        {
+          "comment": "embedded preformatted ocaml source",
+          "begin": "(?<!\\\\)\\{\\[",
+          "end": "(?<!\\\\)\\]\\}",
+          "name": "markup.inline.raw.ocamldoc",
+          "contentName": "source.embedded.ocamldoc",
+          "patterns": [{ "include": "source.ocaml" }]
+        },
+        {
+          "comment": "embedded other language source",
+          "begin": "(?<!\\\\)\\{\\@\\S+?\\[",
+          "end": "(?<!\\\\)\\]\\}",
+          "name": "markup.inline.raw.odoc",
+          "contentName": "source.embedded.odoc"
+        },
+        {
+          "comment": "cross-reference",
+          "begin": "(?<!\\\\)\\{!((modules?|modtype|class|classtype|val|type|exception|attribute|method|section|const|recfield):)?",
+          "end": "(?<!\\\\)\\}",
+          "name": "markup.inline.raw.ocamldoc",
+          "contentName": "source.embedded.ocamldoc",
+          "patterns": [{ "include": "source.ocaml" }]
+        },
+        {
+          "comment": "cross-reference with alt text",
+          "begin": "(?<!\\\\)\\{(\\{!((module|modtype|class|classtype|val|type|exception|attribute|method|section|const|recfield):)?)",
+          "end": "(\\}).*?(?<!\\\\)\\}",
+          "name": "markup.underline.link.ocamldoc meta.link.ocamldoc",
+          "contentName": "markup.inline.raw.ocamldoc source.embedded.ocamldoc",
+          "patterns": [{ "include": "source.ocaml" }],
+          "beginCaptures": {
+            "1": {"name":"markup.inline.raw.ocamldoc"}
+          },
+          "endCaptures": {
+            "1": {"name":"markup.inline.raw.ocamldoc"}
+          }
+        },
+        {
+          "comment": "ocamldoc heading tag",
+          "begin": "(?<!\\\\){[0-9]+\\s",
+          "end": "(?<!\\\\)}",
+          "name": "markup.heading.ocamldoc"
+        },
+        {
+          "comment": "ocamldoc bold",
+          "begin": "(?<!\\\\){b\\s",
+          "end": "(?<!\\\\)}",
+          "name": "markup.bold.ocamldoc"
+        },
+        {
+          "comment": "ocamldoc italic/emph",
+          "begin": "(?<!\\\\){(i|e)\\s",
+          "end": "(?<!\\\\)}",
+          "name": "markup.italic.ocamldoc"
+        },
+        {
+          "comment": "ocamldoc verbatim",
+          "begin": "(?<!\\\\){v\\s",
+          "end": "\\bv}",
+          "name": "markup.inline.raw.ocamldoc"
+        },
+        {
+          "comment": "ocamldoc exponent/index",
+          "begin": "(?<!\\\\){(\\^|\\_)\\s",
+          "end": "(?<!\\\\)}",
+          "name": "markup.exponent.ocamldoc"
+        },
+        {
+          "comment": "odoc inline math",
+          "begin": "(?<!\\\\){m\\s",
+          "end": "(?<!\\\\)\\}",
+          "name": "support.class.math.odoc markup.math.inline.odoc meta.math.inline.odoc"
+        },
+        {
+          "comment": "odoc math block",
+          "begin": "(?<!\\\\){math\\s",
+          "end": "(?<!\\\\)\\}",
+          "name": "support.class.math.odoc markup.math.block.odoc meta.math.block.odoc"
+        },
+        {
+          "comment": "ocamldoc simple lists",
+          "match": "^\\s*(\\-|\\+)",
+          "name": "punctuation.definition.list.begin.markdown.ocamldoc"
+        },
+        {
+          "comment": "ocamldoc lists",
+          "begin": "((?<!\\\\){(ul|ol)\\s)",
+          "end": "((?<!\\\\)})",
+          "beginCaptures": {
+            "1": {"name":"punctuation.definition.list.begin.markdown.ocamldoc"}
+          },
+          "endCaptures": {
+            "1": {"name":"punctuation.definition.list.begin.markdown.ocamldoc"}
+          },
+          "patterns": [{ "include": "#lists" }]
+        },
+        {
+          "comment": "ocamldoc links",
+          "begin": "(?<!\\\\){({:\\s.*?})",
+          "beginCaptures": {
+            "1": {"name":"string.other.link.title.markdown.ocamldoc"}
+          },
+          "end": "(?<!\\\\)\\}",
+          "patterns": [{ "include": "#markup" }],
+          "name": "markup.underline.link.ocamldoc meta.link.ocamldoc"
+        },
+        {
+          "comment": "ocamldoc latex",
+          "begin": "(?<!\\\\){\\%(\\s|latex:)",
+          "end": "\\%}",
+          "name": "markup.inline.raw.ocamldoc",
+          "patterns": [{ "include": "text.tex.latex" }]
+        },
+        {
+          "comment": "ocamldoc html",
+          "begin": "(?<!\\\\){\\%html:",
+          "end": "\\%}",
+          "name": "markup.inline.raw.ocamldoc",
+          "patterns": [{ "include": "text.html.derivative" }]
         }
       ]
-    }
+    },
+    "lists": {
+      "patterns": [
+        {
+          "comment": "ocamldoc list element",
+          "begin": "((?<!\\\\){(\\-|li)\\s)",
+          "end": "((?<!\\\\)})",
+          "beginCaptures": {
+            "1": {"name":"punctuation.definition.list.begin.markdown.ocamldoc"}
+          },
+          "endCaptures": {
+            "1": {"name":"punctuation.definition.list.begin.markdown.ocamldoc"}
+          },
+          "patterns": [{ "include": "#markup" }]
+        }
+      ]}
   }
 }

--- a/syntaxes/ocamldoc.json
+++ b/syntaxes/ocamldoc.json
@@ -18,8 +18,8 @@
           "match": "(\\@raises?)\\s+(\\S+)",
           "captures": {
             "1": { "name": "keyword.doc-tag.ocamldoc" },
-            "2": { 
-              "name": "markup.inline.raw.ocamldoc source.embedded.ocamldoc constant.language.capital-identifier.ocaml" 
+            "2": {
+              "name": "markup.inline.raw.ocamldoc source.embedded.ocamldoc constant.language.capital-identifier.ocaml"
             }
           }
         },
@@ -28,8 +28,8 @@
           "match": "(\\@param)\\s+(\\S+)",
           "captures": {
             "1": { "name": "keyword.doc-tag.ocamldoc" },
-            "2": { 
-              "name": "markup.inline.raw.ocamldoc source.embedded.ocamldoc" 
+            "2": {
+              "name": "markup.inline.raw.ocamldoc source.embedded.ocamldoc"
             }
           }
         },
@@ -38,8 +38,8 @@
           "match": "(\\@see)\\s+(<.*?>|\".*?\"|'.*?')",
           "captures": {
             "1": { "name": "keyword.doc-tag.ocamldoc" },
-            "2": { 
-              "name": "markup.underline.link.ocamldoc meta.link.ocamldoc" 
+            "2": {
+              "name": "markup.underline.link.ocamldoc meta.link.ocamldoc"
             }
           }
         },

--- a/syntaxes/ocamldoc.json
+++ b/syntaxes/ocamldoc.json
@@ -15,7 +15,7 @@
       "patterns": [
         {
           "comment": "ocamldoc documentation tag @raise",
-          "match": "(@raises?)\\s+(\\S+)",
+          "match": "(@raises?)[[:space:]]+([^[:space:]]+)",
           "captures": {
             "1": { "name": "keyword.doc-tag.ocamldoc" },
             "2": {
@@ -25,7 +25,7 @@
         },
         {
           "comment": "ocamldoc documentation tag @param",
-          "match": "(@param)\\s+(\\S+)",
+          "match": "(@param)[[:space:]]+([^[:space:]]+)",
           "captures": {
             "1": { "name": "keyword.doc-tag.ocamldoc" },
             "2": {
@@ -35,7 +35,7 @@
         },
         {
           "comment": "ocamldoc documentation tag @see",
-          "match": "(@see)\\s+(<.*?>|\".*?\"|'.*?')",
+          "match": "(@see)[[:space:]]+(<.*?>|\".*?\"|'.*?')",
           "captures": {
             "1": { "name": "keyword.doc-tag.ocamldoc" },
             "2": {
@@ -66,7 +66,7 @@
         },
         {
           "comment": "embedded other language source",
-          "begin": "(?<!\\\\)\\{@\\S+?\\[",
+          "begin": "(?<!\\\\)\\{@[^[:space:]]+?\\[",
           "end": "(?<!\\\\)\\]\\}",
           "name": "markup.inline.raw.odoc",
           "contentName": "source.embedded.odoc"
@@ -95,58 +95,58 @@
         },
         {
           "comment": "ocamldoc heading tag",
-          "begin": "(?<!\\\\){[0-9]+\\s",
+          "begin": "(?<!\\\\){[0-9]+[[:space:]]",
           "end": "(?<!\\\\)}",
           "name": "markup.heading.ocamldoc",
           "patterns": [{ "include": "#markup" }]
         },
         {
           "comment": "ocamldoc bold",
-          "begin": "(?<!\\\\){b\\s",
+          "begin": "(?<!\\\\){b[[:space:]]",
           "end": "(?<!\\\\)}",
           "name": "markup.bold.ocamldoc",
           "patterns": [{ "include": "#markup" }]
         },
         {
           "comment": "ocamldoc italic/emph",
-          "begin": "(?<!\\\\){(i|e)\\s",
+          "begin": "(?<!\\\\){(i|e)[[:space:]]",
           "end": "(?<!\\\\)}",
           "name": "markup.italic.ocamldoc",
           "patterns": [{ "include": "#markup" }]
         },
         {
           "comment": "ocamldoc verbatim",
-          "begin": "(?<!\\\\){v\\s",
+          "begin": "(?<!\\\\){v[[:space:]]",
           "end": "\\bv}",
           "name": "markup.inline.raw.ocamldoc"
         },
         {
           "comment": "ocamldoc exponent/index",
-          "begin": "(?<!\\\\){(\\^|\\_)\\s",
+          "begin": "(?<!\\\\){(\\^|\\_)[[:space:]]",
           "end": "(?<!\\\\)}",
           "name": "markup.exponent.ocamldoc",
           "patterns": [{ "include": "#markup" }]
         },
         {
           "comment": "odoc inline math",
-          "begin": "(?<!\\\\){m\\s",
+          "begin": "(?<!\\\\){m[[:space:]]",
           "end": "(?<!\\\\)\\}",
           "name": "support.class.math.odoc markup.math.inline.odoc meta.math.inline.odoc"
         },
         {
           "comment": "odoc math block",
-          "begin": "(?<!\\\\){math\\s",
+          "begin": "(?<!\\\\){math[[:space:]]",
           "end": "(?<!\\\\)\\}",
           "name": "support.class.math.odoc markup.math.block.odoc meta.math.block.odoc"
         },
         {
           "comment": "ocamldoc simple lists",
-          "match": "^\\s*(\\-|\\+)",
+          "match": "^[[:space:]]*(\\-|\\+)",
           "name": "punctuation.definition.list.begin.markdown.ocamldoc"
         },
         {
           "comment": "ocamldoc lists",
-          "begin": "((?<!\\\\){(ul|ol)\\s)",
+          "begin": "((?<!\\\\){(ul|ol)[[:space:]])",
           "end": "((?<!\\\\)})",
           "beginCaptures": {
             "1": {
@@ -162,7 +162,7 @@
         },
         {
           "comment": "ocamldoc links",
-          "begin": "(?<!\\\\){({:\\s.*?})",
+          "begin": "(?<!\\\\){({:[[:space:]].*?})",
           "beginCaptures": {
             "1": { "name": "string.other.link.title.markdown.ocamldoc" }
           },
@@ -172,7 +172,7 @@
         },
         {
           "comment": "ocamldoc latex",
-          "begin": "(?<!\\\\){\\%(\\s|latex:)",
+          "begin": "(?<!\\\\){\\%([[:space:]]|latex:)",
           "end": "\\%}",
           "name": "markup.inline.raw.ocamldoc",
           "patterns": [{ "include": "text.tex.latex" }]
@@ -190,7 +190,7 @@
       "patterns": [
         {
           "comment": "ocamldoc list element",
-          "begin": "((?<!\\\\){(\\-|li)\\s)",
+          "begin": "((?<!\\\\){(\\-|li)[[:space:]])",
           "end": "((?<!\\\\)})",
           "beginCaptures": {
             "1": {

--- a/syntaxes/ocamldoc.json
+++ b/syntaxes/ocamldoc.json
@@ -57,10 +57,10 @@
           "contentName": "markup.inline.raw.ocamldoc source.embedded.ocamldoc",
           "patterns": [{ "include": "source.ocaml" }],
           "beginCaptures": {
-            "1": {"name":"markup.inline.raw.ocamldoc"}
+            "1": { "name": "markup.inline.raw.ocamldoc" }
           },
           "endCaptures": {
-            "1": {"name":"markup.inline.raw.ocamldoc"}
+            "1": { "name": "markup.inline.raw.ocamldoc" }
           }
         },
         {
@@ -115,10 +115,14 @@
           "begin": "((?<!\\\\){(ul|ol)\\s)",
           "end": "((?<!\\\\)})",
           "beginCaptures": {
-            "1": {"name":"punctuation.definition.list.begin.markdown.ocamldoc"}
+            "1": {
+              "name":"punctuation.definition.list.begin.markdown.ocamldoc"
+            }
           },
           "endCaptures": {
-            "1": {"name":"punctuation.definition.list.begin.markdown.ocamldoc"}
+            "1": {
+              "name": "punctuation.definition.list.begin.markdown.ocamldoc"
+            }
           },
           "patterns": [{ "include": "#lists" }]
         },
@@ -126,7 +130,7 @@
           "comment": "ocamldoc links",
           "begin": "(?<!\\\\){({:\\s.*?})",
           "beginCaptures": {
-            "1": {"name":"string.other.link.title.markdown.ocamldoc"}
+            "1": { "name": "string.other.link.title.markdown.ocamldoc" }
           },
           "end": "(?<!\\\\)\\}",
           "patterns": [{ "include": "#markup" }],
@@ -155,13 +159,18 @@
           "begin": "((?<!\\\\){(\\-|li)\\s)",
           "end": "((?<!\\\\)})",
           "beginCaptures": {
-            "1": {"name":"punctuation.definition.list.begin.markdown.ocamldoc"}
+            "1": {
+              "name": "punctuation.definition.list.begin.markdown.ocamldoc"
+            }
           },
           "endCaptures": {
-            "1": {"name":"punctuation.definition.list.begin.markdown.ocamldoc"}
+            "1": {
+              "name": "punctuation.definition.list.begin.markdown.ocamldoc"
+            }
           },
           "patterns": [{ "include": "#markup" }]
         }
-      ]}
+      ]
+    }
   }
 }

--- a/syntaxes/ocamldoc.json
+++ b/syntaxes/ocamldoc.json
@@ -14,6 +14,36 @@
     "markup": {
       "patterns": [
         {
+          "comment": "ocamldoc documentation tag @raise",
+          "match": "(\\@raises?)\\s+(\\S+)",
+          "captures": {
+            "1": { "name": "keyword.doc-tag.ocamldoc" },
+            "2": { 
+              "name": "markup.inline.raw.ocamldoc source.embedded.ocamldoc constant.language.capital-identifier.ocaml" 
+            }
+          }
+        },
+        {
+          "comment": "ocamldoc documentation tag @param",
+          "match": "(\\@param)\\s+(\\S+)",
+          "captures": {
+            "1": { "name": "keyword.doc-tag.ocamldoc" },
+            "2": { 
+              "name": "markup.inline.raw.ocamldoc source.embedded.ocamldoc" 
+            }
+          }
+        },
+        {
+          "comment": "ocamldoc documentation tag @see",
+          "match": "(\\@see)\\s+(<.*?>|\".*?\"|'.*?')",
+          "captures": {
+            "1": { "name": "keyword.doc-tag.ocamldoc" },
+            "2": { 
+              "name": "markup.underline.link.ocamldoc meta.link.ocamldoc" 
+            }
+          }
+        },
+        {
           "comment": "ocamldoc documentation tag",
           "name": "keyword.doc-tag.ocamldoc",
           "match": "\\@[[:lower:]]+"

--- a/syntaxes/ocamldoc.json
+++ b/syntaxes/ocamldoc.json
@@ -1,15 +1,8 @@
 {
   "scopeName": "source.ocaml.ocamldoc",
-  "name": "comment.other.ocamldoc",
+  "name": "OCamldoc",
   "fileTypes": ["mld"],
-  "patterns": [
-    {
-      "name": "comment.other.ocamldoc",
-      "begin": "",
-      "end": "",
-      "patterns": [{ "include": "#markup" }]
-    }
-  ],
+  "patterns": [{ "include": "#markup" }],
   "repository": {
     "markup": {
       "patterns": [

--- a/syntaxes/ocamldoc.json
+++ b/syntaxes/ocamldoc.json
@@ -67,19 +67,22 @@
           "comment": "ocamldoc heading tag",
           "begin": "(?<!\\\\){[0-9]+\\s",
           "end": "(?<!\\\\)}",
-          "name": "markup.heading.ocamldoc"
+          "name": "markup.heading.ocamldoc",
+          "patterns": [{ "include": "#markup" }]
         },
         {
           "comment": "ocamldoc bold",
           "begin": "(?<!\\\\){b\\s",
           "end": "(?<!\\\\)}",
-          "name": "markup.bold.ocamldoc"
+          "name": "markup.bold.ocamldoc",
+          "patterns": [{ "include": "#markup" }]
         },
         {
           "comment": "ocamldoc italic/emph",
           "begin": "(?<!\\\\){(i|e)\\s",
           "end": "(?<!\\\\)}",
-          "name": "markup.italic.ocamldoc"
+          "name": "markup.italic.ocamldoc",
+          "patterns": [{ "include": "#markup" }]
         },
         {
           "comment": "ocamldoc verbatim",
@@ -91,7 +94,8 @@
           "comment": "ocamldoc exponent/index",
           "begin": "(?<!\\\\){(\\^|\\_)\\s",
           "end": "(?<!\\\\)}",
-          "name": "markup.exponent.ocamldoc"
+          "name": "markup.exponent.ocamldoc",
+          "patterns": [{ "include": "#markup" }]
         },
         {
           "comment": "odoc inline math",

--- a/syntaxes/ocamldoc.json
+++ b/syntaxes/ocamldoc.json
@@ -43,7 +43,7 @@
         },
         {
           "comment": "cross-reference",
-          "begin": "(?<!\\\\)\\{!((modules?|modtype|class|classtype|val|type|exception|attribute|method|section|const|recfield):)?",
+          "begin": "(?<!\\\\)\\{!((modules?|modtype|module-type|class|classtype|class-type|val|value|type|exception|exn|attribute|method|section|const|recfield|field|extension|extension-decl|instance-variable|label|page):)?",
           "end": "(?<!\\\\)\\}",
           "name": "markup.inline.raw.ocamldoc",
           "contentName": "source.embedded.ocamldoc",
@@ -51,7 +51,7 @@
         },
         {
           "comment": "cross-reference with alt text",
-          "begin": "(?<!\\\\)\\{(\\{!((module|modtype|class|classtype|val|type|exception|attribute|method|section|const|recfield):)?)",
+          "begin": "(?<!\\\\)\\{(\\{!((module|modtype|module-type|class|classtype|class-type|val|value|type|exception|exn|attribute|method|section|const|recfield|field|extension|extension-decl|instance-variable|label|page):)?)",
           "end": "(\\}).*?(?<!\\\\)\\}",
           "name": "markup.underline.link.ocamldoc meta.link.ocamldoc",
           "contentName": "markup.inline.raw.ocamldoc source.embedded.ocamldoc",


### PR DESCRIPTION
A few ocamldoc markup had syntax color, but most didn't. This PR adds color to most markup, using the similar markup in markdown for the textmate scope. For reference, I used the following:
- ocamldoc syntax reference: https://v2.ocaml.org/manual/ocamldoc.html#s%3Aocamldoc-comments
- odoc syntax reference: https://ocaml.github.io/odoc/odoc_for_authors.html
- odoc differences with ocamldoc: https://ocaml.github.io/odoc/ocamldoc_differences.html

## Changes

Before this PR, only few constructs had syntax coloring:
- `@tags`
- `[inline code]` (note that inline code is rendered using ocaml's syntax highlighting, and not semantic highlighting. Depending on theme, the colors may be very different from the rest of the file).

I added the following:
- `{b bold]` `{1 heading]` `{i italic]` `{e emph}` (colored the same as their markdown equivalents)
- `{^ exponent}` `{_ index}`, likely not colored in most themes (named `markup.exponent.ocamldoc`)
- `{m math}` and `{math math-block}`, odoc extension, colored the same as latex math (which is `support.class` for some reason...)
- `{[ocaml code block]}`
- `{v verbatim v}` and `{@lang[ other language code block]}` (odoc extension), colored as markdown code block
- `{{: link}link-text}`
- `{!reference}` and `{!type:reference]`, as well as `{{!reference}alt-text}`. I'm not really satisfied with the later though, as I can't color both `reference` as ocaml code and `alt-text` as markup (tm grammar don't have a `begin`/`middle`/`end` sadly).
- Lists both simple (leading `-`) and complex `{ul {li item}}`
- Target specific formatting `{%latex: latex code%}` and `{%html: html code %}` as well as others (rendered as verbatim code)
- tags specific syntaxes for `@raise Exn`, `@raises Exn`, `@param id`, `@see "document"`, `@see 'file'` and `@see <url>` 

I haven't added the following:
- `{C center}`, `{L left}` and `{R right}` (not supported by odoc)
- `{!indexlist}` (not supported by odoc)
- html tags (not supported by odoc)


## Test comment

Here is a comment showing off the new color highlights that can be used to test them with different themes:
```ocaml
(** This is a test documentation comment:
  @see <https://v2.ocaml.org/manual/ocamldoc.html#s%3Aocamldoc-comments>
       for ocamldoc syntax reference
  @see <https://ocaml.github.io/odoc/odoc_for_authors.html>
       for odoc (implementation of the reference, plus a few extensions, like math)

  Basic markup:
    {1 heading}
    {b bold} {i italic} {e emph} {m math}
    {^ exponent} {_ index} (these are maked, but not colored by most themes)
    {v verbatim v}
    {C center} {R right} {L left} (There are unmarked and uncolored)
    {math
      math block
    }

  Tags:
    @tag
    @raise Exn description    @raises Exn description
    @param id description
    @see 'filename'           @see "document-name"       @see <link>

  Code:
    [let foo x = x]
    {[
      let foo x = x
    ]}
    Other language are an odoc extension. I haven't added any language specific
    code, so this python snippet isn't highlighted as python, only as verbatim.
    {@python[
      def hello() -> None:
          print("hello world!")
    ]}

  References and links:
    [foo] {!foo} {!module:Foo} {!modules: Foo Bar}
    {{: https://example.com}Example link}
    {{!foo}The foo function}
    {{!module:Foo} the Foo module}

  Lists:
    - simple
    - unorderd list
    + simple
    + numbered list
    {ul {- full}
        {li list {b with bold text} }}
    {ol {- ordered}
        {li list}}

  Target specific blocks:
    {% here is some latex \foo $1$ %}
    {%latex: some more latex $x = x+1$ %}
    {%html: <p>hello</p><a href="https://example.com">example link</a> %}
*)
```