### PR TITLE
Fix md code block bug

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 # Unreleased
 
+- Fix non-ocaml markdown code block syntax highlighting being influenced (issue #1288, #1369)
+
 ## 1.16.1
 
 - No longer color comments starting three stars or more as ocamldoc comments (#1355)

--- a/syntaxes/ocaml-markdown-codeblock.json
+++ b/syntaxes/ocaml-markdown-codeblock.json
@@ -4,9 +4,9 @@
   "patterns": [{ "include": "#ocaml-code-block" }],
   "repository": {
     "ocaml-code-block": {
-      "begin": "(^|\\G)(\\s*)(\\`{3,}|~{3,})\\s*(?i:(ml|ocaml)(\\s+[^`~]*)?$)",
+      "begin": "(^|\\G)([[:space:]]*)(\\`{3,}|~{3,})[[:space:]]*(?i:(ml|ocaml)([[:space:]]+[^`~]*)?$)",
       "name": "markup.fenced_code.block.markdown",
-      "end": "(^|\\G)(\\2|\\s{0,3})(\\3)\\s*$",
+      "end": "(^|\\G)(\\2|[[:space:]]{0,3})(\\3)[[:space:]]*$",
       "beginCaptures": {
         "3": { "name": "punctuation.definition.markdown" },
         "4": { "name": "fenced_code.block.language.markdown" },
@@ -17,8 +17,8 @@
       },
       "patterns": [
         {
-          "begin": "(^|\\G)(\\s*)(.*)",
-          "while": "(^|\\G)(?!\\s*([`~]{3,})\\s*$)",
+          "begin": "(^|\\G)([[:space:]]*)(.*)",
+          "while": "(^|\\G)(?![[:space:]]*([`~]{3,})[[:space:]]*$)",
           "contentName": "meta.embedded.block.ocaml",
           "patterns": [
             {

--- a/syntaxes/ocaml-markdown-codeblock.json
+++ b/syntaxes/ocaml-markdown-codeblock.json
@@ -1,11 +1,20 @@
 {
   "fileTypes": [],
-  "injectionSelector": "L:markup.fenced_code.block.markdown",
+  "injectionSelector": "L:text.html.markdown",
   "patterns": [{ "include": "#ocaml-code-block" }],
   "repository": {
     "ocaml-code-block": {
-      "begin": "(ml|ocaml)(\\s+[^`~]*)?$",
-      "end": "(^|\\G)(?=\\s*[`~]{3,}\\s*$)",
+      "begin": "(^|\\G)(\\s*)(\\`{3,}|~{3,})\\s*(?i:(ml|ocaml)(\\s+[^`~]*)?$)",
+      "name": "markup.fenced_code.block.markdown",
+      "end": "(^|\\G)(\\2|\\s{0,3})(\\3)\\s*$",
+      "beginCaptures": {
+        "3": { "name": "punctuation.definition.markdown" },
+        "4": { "name": "fenced_code.block.language.markdown" },
+        "5": { "name": "fenced_code.block.language.attributes.markdown" }
+      },
+      "endCaptures": {
+        "3": { "name": "punctuation.definition.markdown" }
+      },
       "patterns": [
         {
           "begin": "(^|\\G)(\\s*)(.*)",

--- a/syntaxes/reason-markdown-codeblock.json
+++ b/syntaxes/reason-markdown-codeblock.json
@@ -4,9 +4,9 @@
   "patterns": [{ "include": "#reason-code-block" }],
   "repository": {
     "reason-code-block": {
-      "begin": "(^|\\G)(\\s*)(\\`{3,}|~{3,})\\s*(?i:(re|reason|reasonml)(\\s+[^`~]*)?$)",
+      "begin": "(^|\\G)([[:space:]]*)(\\`{3,}|~{3,})[[:space:]]*(?i:(re|reason|reasonml)([[:space:]]+[^`~]*)?$)",
       "name": "markup.fenced_code.block.markdown",
-      "end": "(^|\\G)(\\2|\\s{0,3})(\\3)\\s*$",
+      "end": "(^|\\G)(\\2|[[:space:]]{0,3})(\\3)[[:space:]]*$",
       "beginCaptures": {
         "3": { "name": "punctuation.definition.markdown" },
         "4": { "name": "fenced_code.block.language.markdown" },
@@ -17,8 +17,8 @@
       },
       "patterns": [
         {
-          "begin": "(^|\\G)(\\s*)(.*)",
-          "while": "(^|\\G)(?!\\s*([`~]{3,})\\s*$)",
+          "begin": "(^|\\G)([[:space:]]*)(.*)",
+          "while": "(^|\\G)(?![[:space:]]*([`~]{3,})[[:space:]]*$)",
           "contentName": "meta.embedded.block.reason",
           "patterns": [
             {

--- a/syntaxes/reason-markdown-codeblock.json
+++ b/syntaxes/reason-markdown-codeblock.json
@@ -1,11 +1,20 @@
 {
   "fileTypes": [],
-  "injectionSelector": "L:markup.fenced_code.block.markdown",
+  "injectionSelector": "L:text.html.markdown",
   "patterns": [{ "include": "#reason-code-block" }],
   "repository": {
     "reason-code-block": {
-      "begin": "(re|reason|reasonml)(\\s+[^`~]*)?$",
-      "end": "(^|\\G)(?=\\s*[`~]{3,}\\s*$)",
+      "begin": "(^|\\G)(\\s*)(\\`{3,}|~{3,})\\s*(?i:(re|reason|reasonml)(\\s+[^`~]*)?$)",
+      "name": "markup.fenced_code.block.markdown",
+      "end": "(^|\\G)(\\2|\\s{0,3})(\\3)\\s*$",
+      "beginCaptures": {
+        "3": { "name": "punctuation.definition.markdown" },
+        "4": { "name": "fenced_code.block.language.markdown" },
+        "5": { "name": "fenced_code.block.language.attributes.markdown" }
+      },
+      "endCaptures": {
+        "3": { "name": "punctuation.definition.markdown" }
+      },
       "patterns": [
         {
           "begin": "(^|\\G)(\\s*)(.*)",


### PR DESCRIPTION
This fixes #1288. I copied code structure from https://github.com/mjbvz/vscode-fenced-code-block-grammar-injection-example. The short description of this fix is: "don't inject `ml <code>` in an md codeblock, instead inject ```` ```ml\n <code>\n``` ```` in md directly".