### PR TITLE
Reduce use of Js.Unit module

### DIFF
--- a/src-bindings/interop/interop.ml
+++ b/src-bindings/interop/interop.ml
@@ -97,11 +97,7 @@ module Js = struct
   end
 
   module Unit = struct
-    type t = unit
-
-    let t_of_js _ = ()
-
-    let t_to_js _ = undefined
+    type t = unit [@@js]
   end
 
   module Result (Ok : Ojs.T) (Error : Ojs.T) = struct

--- a/src-bindings/vscode/vscode.ml
+++ b/src-bindings/vscode/vscode.ml
@@ -2858,17 +2858,17 @@ module CustomTextEditorProvider = struct
   module ResolvedEditor = struct
     type t =
       ([ `Promise of unit Promise.t
-       | `Unit of Js.Unit.t
+       | `Unit of unit
        ]
       [@js.union])
     [@@js]
 
     let t_of_js js_val =
-      if Ojs.is_null js_val then `Unit ([%js.to: Js.Unit.t] js_val)
+      if Ojs.is_null js_val then `Unit ([%js.to: unit] js_val)
       else `Promise ([%js.to: unit Promise.t] js_val)
 
     let t_to_js = function
-      | `Unit v -> Js.Unit.t_to_js v
+      | `Unit v -> [%js.of: unit] v
       | `Promise p -> [%js.of: unit Promise.t] p
   end
 

--- a/src-bindings/vscode/vscode.mli
+++ b/src-bindings/vscode/vscode.mli
@@ -2189,7 +2189,7 @@ module WebviewPanel : sig
 
   val create :
        onDidChangeViewState:WebviewPanelOnDidChangeViewStateEvent.t Event.t
-    -> onDidDispose:Js.Unit.t Event.t
+    -> onDidDispose:unit Event.t
     -> active:bool
     -> options:WebviewPanelOptions.t
     -> title:string
@@ -2208,7 +2208,7 @@ module CustomTextEditorProvider : sig
   module ResolvedEditor : sig
     type t =
       [ `Promise of unit Promise.t
-      | `Unit of Js.Unit.t
+      | `Unit of unit
       ]
 
     val t_to_js : t -> Ojs.t

--- a/src/cm_editor.ml
+++ b/src/cm_editor.ml
@@ -7,7 +7,7 @@ module Cm_document : sig
   val content :
     t -> instance:Extension_instance.t -> (string, string) result Promise.t
 
-  val onDidChange : t -> Js.Unit.t Event.t
+  val onDidChange : t -> unit Event.t
 
   val create : uri:Uri.t -> t
 end = struct


### PR DESCRIPTION
As mentioned in https://github.com/ocamllabs/vscode-ocaml-platform/pull/1402#pullrequestreview-1916685023, gen_js_api has included conversion functions for the `unit` type for a while. That means we can reduce the use of our `Js.Unit.t` type and reference the `unit` type directly instead.

There are still a couple of remaining reference to `Js.Unit` where the module is used as an argument to a functor. gen_js_api doesn't have a `Unit` module, so we can't replace that type of use case yet.