### PR TITLE
Use `macos-latest` again

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -24,8 +24,7 @@ jobs:
       fail-fast: false
       matrix:
         os:
-          # macos-14 is faster than latest
-          - macos-14
+          - macos-latest
           - ubuntu-latest
           # Disabled as discussed in
           # https://github.com/ocamllabs/vscode-ocaml-platform/pull/1106


### PR DESCRIPTION
https://github.blog/changelog/2024-04-01-macos-14-sonoma-is-generally-available-and-the-latest-macos-runner-image/