### PR TITLE
Odoc markup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 # Unreleased
 
 - Add new syntax patterns for dune(-project) files (#1391)
+- Add syntax color to odoc tables and headings with labels (#1465)
 
 ## 1.18.1
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,8 @@
 # Unreleased
 
 - Add new syntax patterns for dune(-project) files (#1391)
-- Add syntax color to odoc tables and headings with labels (#1465)
+- Add syntax color to odoc tables, odoc headings with labels, and odoc code
+  blocks with attributes (#1465)
 
 ## 1.18.1
 

--- a/syntaxes/ocamldoc.json
+++ b/syntaxes/ocamldoc.json
@@ -1,8 +1,14 @@
 {
   "scopeName": "source.ocaml.ocamldoc",
   "name": "OCamldoc",
-  "fileTypes": ["mld"],
-  "patterns": [{ "include": "#markup" }],
+  "fileTypes": [
+    "mld"
+  ],
+  "patterns": [
+    {
+      "include": "#markup"
+    }
+  ],
   "repository": {
     "markup": {
       "patterns": [
@@ -10,7 +16,9 @@
           "comment": "ocamldoc documentation tag @raise",
           "match": "(@raises?)[[:space:]]+([^[:space:]]+)",
           "captures": {
-            "1": { "name": "keyword.doc-tag.ocamldoc" },
+            "1": {
+              "name": "keyword.doc-tag.ocamldoc"
+            },
             "2": {
               "name": "markup.inline.raw.ocamldoc source.embedded.ocamldoc constant.language.capital-identifier.ocaml"
             }
@@ -20,7 +28,9 @@
           "comment": "ocamldoc documentation tag @param",
           "match": "(@param)[[:space:]]+([^[:space:]]+)",
           "captures": {
-            "1": { "name": "keyword.doc-tag.ocamldoc" },
+            "1": {
+              "name": "keyword.doc-tag.ocamldoc"
+            },
             "2": {
               "name": "markup.inline.raw.ocamldoc source.embedded.ocamldoc"
             }
@@ -30,7 +40,9 @@
           "comment": "ocamldoc documentation tag @see",
           "match": "(@see)[[:space:]]+(<.*?>|\".*?\"|'.*?')",
           "captures": {
-            "1": { "name": "keyword.doc-tag.ocamldoc" },
+            "1": {
+              "name": "keyword.doc-tag.ocamldoc"
+            },
             "2": {
               "name": "markup.underline.link.ocamldoc meta.link.ocamldoc"
             }
@@ -47,7 +59,11 @@
           "end": "(?<!\\\\)\\]",
           "name": "markup.inline.raw.ocamldoc",
           "contentName": "source.embedded.ocamldoc",
-          "patterns": [{ "include": "source.ocaml" }]
+          "patterns": [
+            {
+              "include": "source.ocaml"
+            }
+          ]
         },
         {
           "comment": "embedded preformatted ocaml source",
@@ -55,11 +71,15 @@
           "end": "(?<!\\\\)\\]\\}",
           "name": "markup.inline.raw.ocamldoc",
           "contentName": "source.embedded.ocamldoc",
-          "patterns": [{ "include": "source.ocaml" }]
+          "patterns": [
+            {
+              "include": "source.ocaml"
+            }
+          ]
         },
         {
           "comment": "embedded other language source",
-          "begin": "(?<!\\\\)\\{@[^[:space:]]+?\\[",
+          "begin": "(?<!\\\\)\\{@.+?\\[",
           "end": "(?<!\\\\)\\]\\}",
           "name": "markup.inline.raw.odoc",
           "contentName": "source.embedded.odoc"
@@ -70,7 +90,11 @@
           "end": "(?<!\\\\)\\}",
           "name": "markup.inline.raw.ocamldoc",
           "contentName": "source.embedded.ocamldoc",
-          "patterns": [{ "include": "source.ocaml" }]
+          "patterns": [
+            {
+              "include": "source.ocaml"
+            }
+          ]
         },
         {
           "comment": "cross-reference with alt text",
@@ -78,12 +102,20 @@
           "end": "(\\}).*?(?<!\\\\)\\}",
           "name": "markup.underline.link.ocamldoc meta.link.ocamldoc",
           "contentName": "markup.inline.raw.ocamldoc source.embedded.ocamldoc",
-          "patterns": [{ "include": "source.ocaml" }],
+          "patterns": [
+            {
+              "include": "source.ocaml"
+            }
+          ],
           "beginCaptures": {
-            "1": { "name": "markup.inline.raw.ocamldoc" }
+            "1": {
+              "name": "markup.inline.raw.ocamldoc"
+            }
           },
           "endCaptures": {
-            "1": { "name": "markup.inline.raw.ocamldoc" }
+            "1": {
+              "name": "markup.inline.raw.ocamldoc"
+            }
           }
         },
         {
@@ -91,9 +123,15 @@
           "begin": "(?<!\\\\){[[:digit:]]+(:[^[:space:]]*)?[[:space:]]",
           "end": "(?<!\\\\)}",
           "name": "markup.heading.ocamldoc",
-          "patterns": [{ "include": "#markup" }],
+          "patterns": [
+            {
+              "include": "#markup"
+            }
+          ],
           "beginCaptures": {
-            "1": { "name": "meta.link.label.ocamldoc" }
+            "1": {
+              "name": "meta.link.label.ocamldoc"
+            }
           }
         },
         {
@@ -101,14 +139,22 @@
           "begin": "(?<!\\\\){b[[:space:]]",
           "end": "(?<!\\\\)}",
           "name": "markup.bold.ocamldoc",
-          "patterns": [{ "include": "#markup" }]
+          "patterns": [
+            {
+              "include": "#markup"
+            }
+          ]
         },
         {
           "comment": "ocamldoc italic/emph",
           "begin": "(?<!\\\\){(i|e)[[:space:]]",
           "end": "(?<!\\\\)}",
           "name": "markup.italic.ocamldoc",
-          "patterns": [{ "include": "#markup" }]
+          "patterns": [
+            {
+              "include": "#markup"
+            }
+          ]
         },
         {
           "comment": "ocamldoc verbatim",
@@ -121,7 +167,11 @@
           "begin": "(?<!\\\\){(\\^|\\_)[[:space:]]",
           "end": "(?<!\\\\)}",
           "name": "markup.exponent.ocamldoc",
-          "patterns": [{ "include": "#markup" }]
+          "patterns": [
+            {
+              "include": "#markup"
+            }
+          ]
         },
         {
           "comment": "odoc inline math",
@@ -154,7 +204,11 @@
               "name": "punctuation.definition.list.begin.markdown.ocamldoc"
             }
           },
-          "patterns": [{ "include": "#lists" }]
+          "patterns": [
+            {
+              "include": "#lists"
+            }
+          ]
         },
         {
           "comment": "ocamldoc tables",
@@ -170,7 +224,11 @@
               "name": "punctuation.definition.list.begin.markdown.table.ocamldoc"
             }
           },
-          "patterns": [{ "include": "#table" }]
+          "patterns": [
+            {
+              "include": "#table"
+            }
+          ]
         },
         {
           "comment": "ocamldoc light tables",
@@ -186,16 +244,26 @@
               "name": "punctuation.definition.list.begin.markdown.table.light.ocamldoc"
             }
           },
-          "patterns": [{ "include": "#lighttable" }]
+          "patterns": [
+            {
+              "include": "#lighttable"
+            }
+          ]
         },
         {
           "comment": "ocamldoc links",
           "begin": "(?<!\\\\){({:[[:space:]].*?})",
           "beginCaptures": {
-            "1": { "name": "string.other.link.title.markdown.ocamldoc" }
+            "1": {
+              "name": "string.other.link.title.markdown.ocamldoc"
+            }
           },
           "end": "(?<!\\\\)\\}",
-          "patterns": [{ "include": "#markup" }],
+          "patterns": [
+            {
+              "include": "#markup"
+            }
+          ],
           "name": "markup.underline.link.ocamldoc meta.link.ocamldoc"
         },
         {
@@ -203,14 +271,22 @@
           "begin": "(?<!\\\\){\\%([[:space:]]|latex:)",
           "end": "\\%}",
           "name": "markup.inline.raw.ocamldoc",
-          "patterns": [{ "include": "text.tex.latex" }]
+          "patterns": [
+            {
+              "include": "text.tex.latex"
+            }
+          ]
         },
         {
           "comment": "ocamldoc html",
           "begin": "(?<!\\\\){\\%html:",
           "end": "\\%}",
           "name": "markup.inline.raw.ocamldoc",
-          "patterns": [{ "include": "text.html.derivative" }]
+          "patterns": [
+            {
+              "include": "text.html.derivative"
+            }
+          ]
         }
       ]
     },
@@ -230,7 +306,11 @@
               "name": "punctuation.definition.list.begin.markdown.ocamldoc"
             }
           },
-          "patterns": [{ "include": "#markup" }]
+          "patterns": [
+            {
+              "include": "#markup"
+            }
+          ]
         }
       ]
     },
@@ -250,7 +330,11 @@
               "name": "punctuation.definition.list.begin.markdown.table.row.ocamldoc"
             }
           },
-          "patterns": [{ "include": "#tablerow" }]
+          "patterns": [
+            {
+              "include": "#tablerow"
+            }
+          ]
         }
       ]
     },
@@ -270,7 +354,11 @@
               "name": "punctuation.definition.list.begin.markdown.table.cell.ocamldoc"
             }
           },
-          "patterns": [{ "include": "#markup" }]
+          "patterns": [
+            {
+              "include": "#markup"
+            }
+          ]
         },
         {
           "comment": "ocamldoc table header cell",
@@ -287,13 +375,19 @@
               "name": "punctuation.definition.list.begin.markdown.tableheader.ocamldoc"
             }
           },
-          "patterns": [{ "include": "#markup" }]
+          "patterns": [
+            {
+              "include": "#markup"
+            }
+          ]
         }
       ]
     },
     "lighttable": {
       "patterns": [
-        { "include": "#markup" },
+        {
+          "include": "#markup"
+        },
         {
           "comment": "table characters",
           "match": "\\||(\\-\\-\\-+)|(:\\-\\-\\-+:)|(:\\-\\-+)|(\\-\\-+:)",

--- a/syntaxes/ocamldoc.json
+++ b/syntaxes/ocamldoc.json
@@ -173,6 +173,22 @@
           "patterns": [{ "include": "#table" }]
         },
         {
+          "comment": "ocamldoc light tables",
+          "begin": "((?<!\\\\){t[[:space:]])",
+          "end": "((?<!\\\\)})",
+          "beginCaptures": {
+            "1": {
+              "name": "punctuation.definition.list.begin.markdown.table.light.ocamldoc"
+            }
+          },
+          "endCaptures": {
+            "1": {
+              "name": "punctuation.definition.list.begin.markdown.table.light.ocamldoc"
+            }
+          },
+          "patterns": [{ "include": "#lighttable" }]
+        },
+        {
           "comment": "ocamldoc links",
           "begin": "(?<!\\\\){({:[[:space:]].*?})",
           "beginCaptures": {
@@ -272,6 +288,16 @@
             }
           },
           "patterns": [{ "include": "#markup" }]
+        }
+      ]
+    },
+    "lighttable": {
+      "patterns": [
+        { "include": "#markup" },
+        {
+          "comment": "table characters",
+          "match": "\\||(\\-\\-\\-+)|(:\\-\\-\\-+:)|(:\\-\\-+)|(\\-\\-+:)",
+          "name": "punctuation.definition.list.begin.markdown.tableheader.tablechars.ocamldoc"
         }
       ]
     }

--- a/syntaxes/ocamldoc.json
+++ b/syntaxes/ocamldoc.json
@@ -51,7 +51,7 @@
         },
         {
           "comment": "embedded preformatted ocaml source",
-          "begin": "(?<!\\\\)\\{\\[",
+          "begin": "(?<!\\\\)\\{(@ocaml([[:space:]].*?)?)?\\[",
           "end": "(?<!\\\\)\\]\\}",
           "name": "markup.inline.raw.ocamldoc",
           "contentName": "source.embedded.ocamldoc",

--- a/syntaxes/ocamldoc.json
+++ b/syntaxes/ocamldoc.json
@@ -88,10 +88,13 @@
         },
         {
           "comment": "ocamldoc heading tag",
-          "begin": "(?<!\\\\){[[:digit:]]+[[:space:]]",
+          "begin": "(?<!\\\\){[[:digit:]]+(:[^[:space:]]*)?[[:space:]]",
           "end": "(?<!\\\\)}",
           "name": "markup.heading.ocamldoc",
-          "patterns": [{ "include": "#markup" }]
+          "patterns": [{ "include": "#markup" }],
+          "beginCaptures": {
+            "1": { "name": "meta.link.label.ocamldoc" }
+          }
         },
         {
           "comment": "ocamldoc bold",

--- a/syntaxes/ocamldoc.json
+++ b/syntaxes/ocamldoc.json
@@ -1,14 +1,8 @@
 {
   "scopeName": "source.ocaml.ocamldoc",
   "name": "OCamldoc",
-  "fileTypes": [
-    "mld"
-  ],
-  "patterns": [
-    {
-      "include": "#markup"
-    }
-  ],
+  "fileTypes": ["mld"],
+  "patterns": [{ "include": "#markup" }],
   "repository": {
     "markup": {
       "patterns": [
@@ -16,9 +10,7 @@
           "comment": "ocamldoc documentation tag @raise",
           "match": "(@raises?)[[:space:]]+([^[:space:]]+)",
           "captures": {
-            "1": {
-              "name": "keyword.doc-tag.ocamldoc"
-            },
+            "1": { "name": "keyword.doc-tag.ocamldoc" },
             "2": {
               "name": "markup.inline.raw.ocamldoc source.embedded.ocamldoc constant.language.capital-identifier.ocaml"
             }
@@ -28,9 +20,7 @@
           "comment": "ocamldoc documentation tag @param",
           "match": "(@param)[[:space:]]+([^[:space:]]+)",
           "captures": {
-            "1": {
-              "name": "keyword.doc-tag.ocamldoc"
-            },
+            "1": { "name": "keyword.doc-tag.ocamldoc" },
             "2": {
               "name": "markup.inline.raw.ocamldoc source.embedded.ocamldoc"
             }
@@ -40,9 +30,7 @@
           "comment": "ocamldoc documentation tag @see",
           "match": "(@see)[[:space:]]+(<.*?>|\".*?\"|'.*?')",
           "captures": {
-            "1": {
-              "name": "keyword.doc-tag.ocamldoc"
-            },
+            "1": { "name": "keyword.doc-tag.ocamldoc" },
             "2": {
               "name": "markup.underline.link.ocamldoc meta.link.ocamldoc"
             }
@@ -59,11 +47,7 @@
           "end": "(?<!\\\\)\\]",
           "name": "markup.inline.raw.ocamldoc",
           "contentName": "source.embedded.ocamldoc",
-          "patterns": [
-            {
-              "include": "source.ocaml"
-            }
-          ]
+          "patterns": [{ "include": "source.ocaml" }]
         },
         {
           "comment": "embedded preformatted ocaml source",
@@ -71,11 +55,7 @@
           "end": "(?<!\\\\)\\]\\}",
           "name": "markup.inline.raw.ocamldoc",
           "contentName": "source.embedded.ocamldoc",
-          "patterns": [
-            {
-              "include": "source.ocaml"
-            }
-          ]
+          "patterns": [{ "include": "source.ocaml" }]
         },
         {
           "comment": "embedded other language source",
@@ -90,11 +70,7 @@
           "end": "(?<!\\\\)\\}",
           "name": "markup.inline.raw.ocamldoc",
           "contentName": "source.embedded.ocamldoc",
-          "patterns": [
-            {
-              "include": "source.ocaml"
-            }
-          ]
+          "patterns": [{ "include": "source.ocaml" }]
         },
         {
           "comment": "cross-reference with alt text",
@@ -102,20 +78,12 @@
           "end": "(\\}).*?(?<!\\\\)\\}",
           "name": "markup.underline.link.ocamldoc meta.link.ocamldoc",
           "contentName": "markup.inline.raw.ocamldoc source.embedded.ocamldoc",
-          "patterns": [
-            {
-              "include": "source.ocaml"
-            }
-          ],
+          "patterns": [{ "include": "source.ocaml" }],
           "beginCaptures": {
-            "1": {
-              "name": "markup.inline.raw.ocamldoc"
-            }
+            "1": { "name": "markup.inline.raw.ocamldoc" }
           },
           "endCaptures": {
-            "1": {
-              "name": "markup.inline.raw.ocamldoc"
-            }
+            "1": { "name": "markup.inline.raw.ocamldoc" }
           }
         },
         {
@@ -123,15 +91,9 @@
           "begin": "(?<!\\\\){[[:digit:]]+(:[^[:space:]]*)?[[:space:]]",
           "end": "(?<!\\\\)}",
           "name": "markup.heading.ocamldoc",
-          "patterns": [
-            {
-              "include": "#markup"
-            }
-          ],
+          "patterns": [{ "include": "#markup" }],
           "beginCaptures": {
-            "1": {
-              "name": "meta.link.label.ocamldoc"
-            }
+            "1": { "name": "meta.link.label.ocamldoc" }
           }
         },
         {
@@ -139,22 +101,14 @@
           "begin": "(?<!\\\\){b[[:space:]]",
           "end": "(?<!\\\\)}",
           "name": "markup.bold.ocamldoc",
-          "patterns": [
-            {
-              "include": "#markup"
-            }
-          ]
+          "patterns": [{ "include": "#markup" }]
         },
         {
           "comment": "ocamldoc italic/emph",
           "begin": "(?<!\\\\){(i|e)[[:space:]]",
           "end": "(?<!\\\\)}",
           "name": "markup.italic.ocamldoc",
-          "patterns": [
-            {
-              "include": "#markup"
-            }
-          ]
+          "patterns": [{ "include": "#markup" }]
         },
         {
           "comment": "ocamldoc verbatim",
@@ -167,11 +121,7 @@
           "begin": "(?<!\\\\){(\\^|\\_)[[:space:]]",
           "end": "(?<!\\\\)}",
           "name": "markup.exponent.ocamldoc",
-          "patterns": [
-            {
-              "include": "#markup"
-            }
-          ]
+          "patterns": [{ "include": "#markup" }]
         },
         {
           "comment": "odoc inline math",
@@ -204,11 +154,7 @@
               "name": "punctuation.definition.list.begin.markdown.ocamldoc"
             }
           },
-          "patterns": [
-            {
-              "include": "#lists"
-            }
-          ]
+          "patterns": [{ "include": "#lists" }]
         },
         {
           "comment": "ocamldoc tables",
@@ -224,11 +170,7 @@
               "name": "punctuation.definition.list.begin.markdown.table.ocamldoc"
             }
           },
-          "patterns": [
-            {
-              "include": "#table"
-            }
-          ]
+          "patterns": [{ "include": "#table" }]
         },
         {
           "comment": "ocamldoc light tables",
@@ -244,26 +186,16 @@
               "name": "punctuation.definition.list.begin.markdown.table.light.ocamldoc"
             }
           },
-          "patterns": [
-            {
-              "include": "#lighttable"
-            }
-          ]
+          "patterns": [{ "include": "#lighttable" }]
         },
         {
           "comment": "ocamldoc links",
           "begin": "(?<!\\\\){({:[[:space:]].*?})",
           "beginCaptures": {
-            "1": {
-              "name": "string.other.link.title.markdown.ocamldoc"
-            }
+            "1": { "name": "string.other.link.title.markdown.ocamldoc" }
           },
           "end": "(?<!\\\\)\\}",
-          "patterns": [
-            {
-              "include": "#markup"
-            }
-          ],
+          "patterns": [{ "include": "#markup" }],
           "name": "markup.underline.link.ocamldoc meta.link.ocamldoc"
         },
         {
@@ -271,22 +203,14 @@
           "begin": "(?<!\\\\){\\%([[:space:]]|latex:)",
           "end": "\\%}",
           "name": "markup.inline.raw.ocamldoc",
-          "patterns": [
-            {
-              "include": "text.tex.latex"
-            }
-          ]
+          "patterns": [{ "include": "text.tex.latex" }]
         },
         {
           "comment": "ocamldoc html",
           "begin": "(?<!\\\\){\\%html:",
           "end": "\\%}",
           "name": "markup.inline.raw.ocamldoc",
-          "patterns": [
-            {
-              "include": "text.html.derivative"
-            }
-          ]
+          "patterns": [{ "include": "text.html.derivative" }]
         }
       ]
     },
@@ -306,11 +230,7 @@
               "name": "punctuation.definition.list.begin.markdown.ocamldoc"
             }
           },
-          "patterns": [
-            {
-              "include": "#markup"
-            }
-          ]
+          "patterns": [{ "include": "#markup" }]
         }
       ]
     },
@@ -330,11 +250,7 @@
               "name": "punctuation.definition.list.begin.markdown.table.row.ocamldoc"
             }
           },
-          "patterns": [
-            {
-              "include": "#tablerow"
-            }
-          ]
+          "patterns": [{ "include": "#tablerow" }]
         }
       ]
     },
@@ -354,11 +270,7 @@
               "name": "punctuation.definition.list.begin.markdown.table.cell.ocamldoc"
             }
           },
-          "patterns": [
-            {
-              "include": "#markup"
-            }
-          ]
+          "patterns": [{ "include": "#markup" }]
         },
         {
           "comment": "ocamldoc table header cell",
@@ -375,19 +287,13 @@
               "name": "punctuation.definition.list.begin.markdown.tableheader.ocamldoc"
             }
           },
-          "patterns": [
-            {
-              "include": "#markup"
-            }
-          ]
+          "patterns": [{ "include": "#markup" }]
         }
       ]
     },
     "lighttable": {
       "patterns": [
-        {
-          "include": "#markup"
-        },
+        { "include": "#markup" },
         {
           "comment": "table characters",
           "match": "\\||(\\-\\-\\-+)|(:\\-\\-\\-+:)|(:\\-\\-+)|(\\-\\-+:)",

--- a/syntaxes/ocamldoc.json
+++ b/syntaxes/ocamldoc.json
@@ -157,6 +157,22 @@
           "patterns": [{ "include": "#lists" }]
         },
         {
+          "comment": "ocamldoc tables",
+          "begin": "((?<!\\\\){table[[:space:]])",
+          "end": "((?<!\\\\)})",
+          "beginCaptures": {
+            "1": {
+              "name": "punctuation.definition.list.begin.markdown.table.ocamldoc"
+            }
+          },
+          "endCaptures": {
+            "1": {
+              "name": "punctuation.definition.list.begin.markdown.table.ocamldoc"
+            }
+          },
+          "patterns": [{ "include": "#table" }]
+        },
+        {
           "comment": "ocamldoc links",
           "begin": "(?<!\\\\){({:[[:space:]].*?})",
           "beginCaptures": {
@@ -196,6 +212,63 @@
           "endCaptures": {
             "1": {
               "name": "punctuation.definition.list.begin.markdown.ocamldoc"
+            }
+          },
+          "patterns": [{ "include": "#markup" }]
+        }
+      ]
+    },
+    "table": {
+      "patterns": [
+        {
+          "comment": "ocamldoc table row",
+          "begin": "((?<!\\\\){tr[[:space:]])",
+          "end": "((?<!\\\\)})",
+          "beginCaptures": {
+            "1": {
+              "name": "punctuation.definition.list.begin.markdown.table.row.ocamldoc"
+            }
+          },
+          "endCaptures": {
+            "1": {
+              "name": "punctuation.definition.list.begin.markdown.table.row.ocamldoc"
+            }
+          },
+          "patterns": [{ "include": "#tablerow" }]
+        }
+      ]
+    },
+    "tablerow": {
+      "patterns": [
+        {
+          "comment": "ocamldoc table cell",
+          "begin": "((?<!\\\\){td[[:space:]])",
+          "end": "((?<!\\\\)})",
+          "beginCaptures": {
+            "1": {
+              "name": "punctuation.definition.list.begin.markdown.table.cell.ocamldoc"
+            }
+          },
+          "endCaptures": {
+            "1": {
+              "name": "punctuation.definition.list.begin.markdown.table.cell.ocamldoc"
+            }
+          },
+          "patterns": [{ "include": "#markup" }]
+        },
+        {
+          "comment": "ocamldoc table header cell",
+          "begin": "((?<!\\\\){th[[:space:]])",
+          "end": "((?<!\\\\)})",
+          "contentName": "markup.bold.tableheader.ocamldoc",
+          "beginCaptures": {
+            "1": {
+              "name": "punctuation.definition.list.begin.markdown.tableheader.ocamldoc"
+            }
+          },
+          "endCaptures": {
+            "1": {
+              "name": "punctuation.definition.list.begin.markdown.tableheader.ocamldoc"
             }
           },
           "patterns": [{ "include": "#markup" }]


### PR DESCRIPTION
Add syntax color to:
- odoc tables (added in odoc 2.3), 
- odoc headings with labels (`{1:label heading}`) 
- code block with attributes (used by [mdx](https://ocaml.org/p/mdx/latest)).
- also color `{@ocaml attr[` blocks as ocaml instead of verbatim (previously only `@{[` block were colored as ocaml).

Here is an example test comment:
```ocaml
(**

{1:label section}

{table
 {tr
  {td {b hello}}
  {th heading}
 }
}

{t
  | hello | there | header | text |
  | --- | :-- | :---: | --:
  | a | b | c | d
}

{@ocaml skip[
   let x = 5
]}

{@notocaml someattribute[
    this is just colored as verbatim
]}

*)
```