### PR TITLE
Add syntax for `dune-project.package.allow_empty`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,10 +3,11 @@
 # Unreleased
 
 - Fix syntax for `dune-project.package.(depends|conflicts|depopts)` (#1543)
+- Add syntax for `dune-project.package.allow_empty` (#1542)
 
 ## 1.19.2
 
-- Fix variable.other.declaration.dune-project to allow wider range of characters
+- Fix `variable.other.declaration.dune-project` to allow wider range of characters
   (#1517)
 
 ## 1.19.1

--- a/syntaxes/dune-project.json
+++ b/syntaxes/dune-project.json
@@ -220,6 +220,16 @@
               "patterns": [{ "include": "source.dune#general" }]
             },
 
+            {
+              "comment": "allow_empty",
+              "begin": "\\([[:space:]]*(allow_empty)\\b",
+              "end": "\\)",
+              "beginCaptures": {
+                "1": { "name": "keyword.language.dune-project" }
+              },
+              "patterns": [{ "include": "source.dune#general" }]
+            },
+
             { "include": "#opam-metadata" },
             { "include": "source.dune#general" }
           ]


### PR DESCRIPTION
This is not mentioned in the dune documentation somehow, but it's a valid syntax and is used here: https://github.com/ocamllabs/vscode-ocaml-platform/blob/523baffdc34eea32dd7b07eed49546fd71d0a830/dune-project#L27
