### PR TITLE
Fix syntax for `dune-project.package.(depends|conflicts|depopts)`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 # Unreleased
 
+- Fix syntax for `dune-project.package.(depends|conflicts|depopts)` (#1543)
+
 ## 1.19.2
 
 - Fix variable.other.declaration.dune-project to allow wider range of characters

--- a/syntaxes/dune-project.json
+++ b/syntaxes/dune-project.json
@@ -184,11 +184,11 @@
                 {
                   "comment": "dependency",
                   "name": "variable.other.declaration.dune-project",
-                  "match": "\\b([[:alpha:]_-]+)\\b"
+                  "match": "\\b([[:word:]-]+)\\b"
                 },
                 {
                   "comment": "dependency constraint",
-                  "begin": "\\([[:space:]]*([[:alpha:]_-]+)\\b",
+                  "begin": "\\([[:space:]]*([[:word:]-]+)\\b",
                   "end": "\\)",
                   "beginCaptures": {
                     "1": { "name": "variable.other.declaration.dune-project" }


### PR DESCRIPTION
This change is needed for packages such as `ISO8601` 🤷‍♂️