### PR TITLE
feat: Copy type under cursor

### DIFF
--- a/package.json
+++ b/package.json
@@ -250,6 +250,11 @@
         "command": "ocaml.goto-closure-code-location",
         "category": "OCaml",
         "title": "Goto Closure Code Location"
+      },
+      {
+        "command": "ocaml.copy-type-under-cursor",
+	"category": "OCaml",
+	"title": "Copy Type Under Cursor"
       }
     ],
     "configuration": {
@@ -1034,6 +1039,10 @@
         {
           "command": "ocaml.goto-closure-code-location",
           "when": "false"
+        },
+	{
+          "command": "ocaml.copy-type-under-cursor",
+          "when": "editorLangId == ocaml || editorLangId == ocaml.interface || editorLangId == reason || editorLangId == ocaml.ocamllex"
         }
       ],
       "editor/title": [

--- a/src-bindings/vscode/vscode.ml
+++ b/src-bindings/vscode/vscode.ml
@@ -329,6 +329,16 @@ module Selection = struct
     val isReversed : t -> bool [@@js.get]]
 end
 
+module Clipboard = struct
+  include Interface.Make ()
+
+  include
+    [%js:
+    val readText : t -> string Promise.t [@@js.get]
+
+    val writeText : t -> string -> unit Promise.t [@@js.call]]
+end
+
 module TextEditorEdit = struct
   include Interface.Make ()
 
@@ -3235,7 +3245,11 @@ module Tasks = struct
 end
 
 module Env = struct
-  include [%js: val shell : unit -> string [@@js.get "vscode.env.shell"]]
+  include
+    [%js:
+    val shell : unit -> string [@@js.get "vscode.env.shell"]
+
+    val clipboard : unit -> Clipboard.t [@@js.get "vscode.env.clipboard"]]
 end
 
 module DebugAdapterExecutableOptions = struct

--- a/src-bindings/vscode/vscode.mli
+++ b/src-bindings/vscode/vscode.mli
@@ -280,6 +280,14 @@ module Selection : sig
   val isReversed : t -> bool
 end
 
+module Clipboard : sig
+  include Ojs.T
+
+  val readText : t -> string Promise.t
+
+  val writeText : t -> string -> unit Promise.t
+end
+
 module TextEditorEdit : sig
   include Ojs.T
 
@@ -2459,6 +2467,8 @@ end
 
 module Env : sig
   val shell : unit -> string
+
+  val clipboard : unit -> Clipboard.t
 end
 
 module DebugAdapterExecutableOptions : sig

--- a/src/custom_requests.ml
+++ b/src/custom_requests.ml
@@ -33,3 +33,27 @@ let typedHoles =
         Jsonoo.Encode.(object_ [ ("uri", string @@ Uri.toString uri ()) ]))
   ; decode_response = Jsonoo.Decode.list Range.t_of_json
   }
+
+let typeEnclosing =
+  { meth = ocamllsp_prefixed "typeEnclosing"
+  ; encode_params =
+      (fun (uri, at, index, verbosity) ->
+        let open Jsonoo.Encode in
+        let uri = ("uri", string @@ Uri.toString uri ()) in
+        let at =
+          match at with
+          | `Position p -> Position.json_of_t p
+          | `Range r -> Range.json_of_t r
+        in
+        let at = ("at", at) in
+        let index = ("index", int index) in
+        let verbosity = ("verbosity", int verbosity) in
+        object_ [ uri; at; index; verbosity ])
+  ; decode_response =
+      (fun response ->
+        let open Jsonoo.Decode in
+        let index = field "index" int response in
+        let type_ = field "type" string response in
+        let enclosings = field "enclosings" (list Range.t_of_json) response in
+        (index, type_, enclosings))
+  }

--- a/src/custom_requests.mli
+++ b/src/custom_requests.mli
@@ -20,3 +20,8 @@ val switchImplIntf : (string, string array) custom_request
 val inferIntf : (string, string) custom_request
 
 val typedHoles : (Uri.t, Range.t list) custom_request
+
+val typeEnclosing :
+  ( Uri.t * [ `Range of Range.t | `Position of Position.t ] * int * int
+  , int * string * Range.t list )
+  custom_request

--- a/src/extension_commands.ml
+++ b/src/extension_commands.ml
@@ -468,6 +468,64 @@ end = struct
     command Extension_consts.Commands.goto_closure_code_location handler
 end
 
+module Copy_type_under_cursor = struct
+  let extension_name = "Copy Type Under Cursor"
+
+  let ocaml_lsp_doesnt_support_type_enclosing instance ocaml_lsp =
+    match
+      Ocaml_lsp.is_version_up_to_date
+        ocaml_lsp
+        (Extension_instance.ocaml_version_exn instance)
+    with
+    | Ok () -> ()
+    | Error (`Msg msg) ->
+      show_message
+        `Warn
+        "The installed version of `ocamllsp` does not support type enclosings. \
+         %s"
+        msg
+
+  let get_enclosings text_editor client =
+    let doc = TextEditor.document text_editor in
+    let uri = TextDocument.uri doc in
+    let selection = TextEditor.selection text_editor in
+    let position = Selection.active selection in
+    Custom_requests.(
+      send_request client typeEnclosing (uri, `Position position, 0, 0))
+
+  let _copy_type_under_cursor =
+    let handler (instance : Extension_instance.t) ~args:_ =
+      let copy_type_under_cursor () =
+        match Window.activeTextEditor () with
+        | None ->
+          Extension_consts.Command_errors.text_editor_must_be_active
+            extension_name
+            ~expl:"The command copy the type of the expression under cursor"
+          |> show_message `Error "%s" |> Promise.return
+        | Some text_editor -> (
+          match Extension_instance.lsp_client instance with
+          | None ->
+            show_message `Warn "ocamllsp is not running" |> Promise.return
+          | Some (_, ocaml_lsp)
+            when not (Ocaml_lsp.can_handle_type_enclosing ocaml_lsp) ->
+            ocaml_lsp_doesnt_support_type_enclosing instance ocaml_lsp
+            |> Promise.return
+          | Some (client, _) ->
+            let clipboard = Env.clipboard () in
+            let open Promise.Syntax in
+            let* _, type_, _ = get_enclosings text_editor client in
+            if String.equal type_ "<no information>" then
+              show_message `Warn "No type information" |> Promise.return
+            else
+              let+ () = Clipboard.writeText clipboard type_ in
+              show_message `Info "Type copied")
+      in
+      let (_ : unit Promise.t) = copy_type_under_cursor () in
+      ()
+    in
+    command Extension_consts.Commands.copy_type_under_cursor handler
+end
+
 let register extension instance = function
   | Command { id; handler } ->
     let callback = handler instance in

--- a/src/extension_consts.ml
+++ b/src/extension_consts.ml
@@ -66,6 +66,8 @@ module Commands = struct
   let goto_closure_code_location = ocaml_prefixed "goto-closure-code-location"
 
   let ask_debug_program = ocaml_prefixed "ask-debug-program"
+
+  let copy_type_under_cursor = ocaml_prefixed "copy-type-under-cursor"
 end
 
 module Command_errors = struct

--- a/src/ocaml_lsp.ml
+++ b/src/ocaml_lsp.ml
@@ -44,6 +44,7 @@ module Experimental_capabilities = struct
     ; handleSwitchImplIntf : bool
     ; handleInferIntf : bool
     ; handleTypedHoles : bool
+    ; handleTypeEnclosing : bool
     }
 
   let default =
@@ -51,6 +52,7 @@ module Experimental_capabilities = struct
     ; handleSwitchImplIntf = false
     ; handleInferIntf = false
     ; handleTypedHoles = false
+    ; handleTypeEnclosing = false
     }
 
   (** Creates [t] given a JSON of form [{ 'handleSwitchImplIntf' : true, .... }] *)
@@ -65,10 +67,12 @@ module Experimental_capabilities = struct
       let handleSwitchImplIntf = has_capability "handleSwitchImplIntf" in
       let handleInferIntf = has_capability "handleInferIntf" in
       let handleTypedHoles = has_capability "handleTypedHoles" in
+      let handleTypeEnclosing = has_capability "handleTypeEnclosing" in
       { interfaceSpecificLangId
       ; handleSwitchImplIntf
       ; handleInferIntf
       ; handleTypedHoles
+      ; handleTypeEnclosing
       }
     with Jsonoo.Decode_error err ->
       show_message
@@ -230,3 +234,6 @@ let can_handle_switch_impl_intf t =
 let can_handle_infer_intf t = t.experimental_capabilities.handleSwitchImplIntf
 
 let can_handle_typed_holes t = t.experimental_capabilities.handleTypedHoles
+
+let can_handle_type_enclosing t =
+  t.experimental_capabilities.handleTypeEnclosing

--- a/src/ocaml_lsp.mli
+++ b/src/ocaml_lsp.mli
@@ -13,6 +13,8 @@ val can_handle_infer_intf : t -> bool
 
 val can_handle_typed_holes : t -> bool
 
+val can_handle_type_enclosing : t -> bool
+
 module OcamllspSettingEnable : sig
   include Ojs.T
 


### PR DESCRIPTION
The following patch add the command `copy-type-under-cursor` that copy, in the clipboard, the computed type under the cursor. The feature relay on the `TypeEnclosing` custom request.