### PR TITLE
Refactor type enclosing

### DIFF
--- a/src/custom_requests.ml
+++ b/src/custom_requests.ml
@@ -71,7 +71,7 @@ module Type_enclosing = struct
     let uri_position = DocumentPosition.encode { uri; position = at } in
     let index = ("index", int index) in
     let verbosity = ("verbosity", int verbosity) in
-    object_ (uri_position @ [ index; verbosity ])
+    object_ (index :: verbosity :: uri_position)
 
   let decode_response response =
     let open Jsonoo.Decode in

--- a/src/custom_requests.ml
+++ b/src/custom_requests.ml
@@ -20,11 +20,11 @@ module DocumentPosition = struct
     ; position : [ `Position of Position.t | `Range of Range.t ]
     }
 
-  let encode { uri; position } =
+  let encode { uri; position } ~pos_name =
     let open Jsonoo.Encode in
     let uri = ("uri", string @@ Uri.toString uri ()) in
     let position =
-      ( "position"
+      ( pos_name
       , match position with
         | `Position p -> Position.json_of_t p
         | `Range r -> Range.json_of_t r )
@@ -68,7 +68,9 @@ module Type_enclosing = struct
 
   let encode_params { uri; at; index; verbosity } =
     let open Jsonoo.Encode in
-    let uri_position = DocumentPosition.encode { uri; position = at } in
+    let uri_position =
+      DocumentPosition.encode { uri; position = at } ~pos_name:"at"
+    in
     let index = ("index", int index) in
     let verbosity = ("verbosity", int verbosity) in
     object_ (index :: verbosity :: uri_position)

--- a/src/custom_requests.mli
+++ b/src/custom_requests.mli
@@ -22,17 +22,20 @@ val inferIntf : (string, string) custom_request
 val typedHoles : (Uri.t, Range.t list) custom_request
 
 module Type_enclosing : sig
+  type params
+
   type response =
     { index : int
     ; type_ : string
     ; enclosings : Range.t list
     }
 
-  val send :
+  val make :
        uri:Uri.t
     -> at:[ `Position of Position.t | `Range of Range.t ]
     -> index:int
     -> verbosity:int
-    -> LanguageClient.t
-    -> response Promise.t
+    -> params
+
+  val request : (params, response) custom_request
 end

--- a/src/extension_commands.ml
+++ b/src/extension_commands.ml
@@ -489,12 +489,15 @@ module Copy_type_under_cursor = struct
     let doc = TextEditor.document text_editor in
     let uri = TextDocument.uri doc in
     let selection = TextEditor.selection text_editor in
-    Custom_requests.Type_enclosing.send
-      ~uri
-      ~at:(`Range (Selection.to_range selection))
-      ~index:0
-      ~verbosity:0
-      client
+    Custom_requests.(
+      send_request
+        client
+        Type_enclosing.request
+        (Type_enclosing.make
+           ~uri
+           ~at:(`Range (Selection.to_range selection))
+           ~index:0
+           ~verbosity:0))
 
   let _copy_type_under_cursor =
     let handler (instance : Extension_instance.t) ~args:_ =


### PR DESCRIPTION
cc @voodoos 
This PR refactors `Type_enclosing` custom request to a uniform structure which will be adopted by subsequent custom request implementations as seen in #1619 