### PR TITLE
Search By Type or Polarity

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 # Unreleased
 
+- Add `ocaml.search-by-type` to search for values using their type signature (#1626)
+
 ## 1.24.0
 
 - Add `ocaml.commands.construct.recursiveCalls` setting to configure construct chaining. (#1673)

--- a/README.md
+++ b/README.md
@@ -254,7 +254,7 @@ prefix `OCaml:`:
 ![commands](./doc/commands.png)
 
 | Name                           | Description                                 | Keyboard Shortcuts |
-| -------------------------------| ------------------------------------------- | ------------------ |
+| ------------------------------ | ------------------------------------------- | ------------------ |
 | `ocaml.select-sandbox`         | Select sandbox for this workspace           |                    |
 | `ocaml.server.restart`         | Restart language server                     |                    |
 | `ocaml.open-terminal`          | Open a terminal (current sandbox)           |                    |
@@ -264,6 +264,7 @@ prefix `OCaml:`:
 | `ocaml.open-repl`              | Open REPL                                   |                    |
 | `ocaml.evaluate-selection`     | Evaluate Selection                          | `Shift+Enter`      |
 | `ocaml.copy-type-under-cursor` | Copy the type under the cursor              |                    |
+| `ocaml.search-by-type`         | Search a value by type or polarity          | `Alt+F`            |
 
 ## Debugging OCaml programs (experimental)
 

--- a/package.json
+++ b/package.json
@@ -262,6 +262,11 @@
         "command": "ocaml.jump",
         "category": "OCaml",
         "title": "List possible parent targets for jumping"
+      },
+      {
+        "command": "ocaml.search-by-type",
+        "category": "OCaml",
+        "title": "Search a value by type or polarity"
       }
     ],
     "configuration": {
@@ -776,6 +781,11 @@
         "command": "ocaml.switch-hover-mode",
         "key": "Alt+H",
         "when": "editorTextFocus && editorLangId == ocaml || editorLangId == ocaml.interface "
+      },
+      {
+        "command": "ocaml.search-by-type",
+        "key": "Alt+F",
+        "when": "editorLangId == ocaml || editorLangId == ocaml.interface || editorLangId == reason || editorLangId == ocaml.ocamllex"
       }
     ],
     "languages": [
@@ -1066,6 +1076,10 @@
         },
         {
           "command": "ocaml.construct",
+          "when": "editorLangId == ocaml || editorLangId == ocaml.interface || editorLangId == reason || editorLangId == ocaml.ocamllex"
+        },
+        {
+          "command": "ocaml.search-by-type",
           "when": "editorLangId == ocaml || editorLangId == ocaml.interface || editorLangId == reason || editorLangId == ocaml.ocamllex"
         }
       ],

--- a/src-bindings/vscode/vscode.ml
+++ b/src-bindings/vscode/vscode.ml
@@ -178,6 +178,49 @@ module Uri = struct
   let equal a b = String.equal (toString a ()) (toString b ())
 end
 
+module LightDarkIcon = struct
+  type t =
+    { light : ([ `String of string | `Uri of Uri.t ][@js.union])
+    ; dark : ([ `String of string | `Uri of Uri.t ][@js.union])
+    }
+  [@@js]
+
+  let t_of_js js_val =
+    let light_js = Ojs.get_prop_ascii js_val "light" in
+    let dark_js = Ojs.get_prop_ascii js_val "dark" in
+    let light =
+      if Ojs.has_property light_js "parse"
+      then `Uri ([%js.to: Uri.t] light_js)
+      else `String ([%js.to: string] light_js)
+    in
+    let dark =
+      if Ojs.has_property dark_js "parse"
+      then `Uri ([%js.to: Uri.t] dark_js)
+      else `String ([%js.to: string] dark_js)
+    in
+    { light; dark }
+  ;;
+end
+
+module ThemeColor = struct
+  include Class.Make ()
+  include [%js: val make : id:string -> t [@@js.new "vscode.ThemeColor"]]
+end
+
+module ThemeIcon = struct
+  include Class.Make ()
+
+  include
+    [%js:
+      val make : id:string -> ?color:ThemeColor.t -> unit -> t
+      [@@js.new "vscode.ThemeIcon"]
+
+      val file : t [@@js.global "vscode.ThemeIcon.File"]
+      val folder : t [@@js.global "vscode.ThemeIcon.Folder"]
+      val id : t -> string [@@js.get]
+      val color : t -> ThemeColor.t or_undefined [@@js.get]]
+end
+
 module TextDocument = struct
   include Interface.Make ()
 
@@ -423,11 +466,6 @@ module MarkdownString = struct
       val appendText : t -> value:string -> t [@@js.call]
       val appendMarkdown : t -> value:string -> t [@@js.call]
       val appendCodeblock : t -> value:string -> ?language:string -> unit -> t [@@js.call]]
-end
-
-module ThemeColor = struct
-  include Class.Make ()
-  include [%js: val make : id:string -> t [@@js.new "vscode.ThemeColor"]]
 end
 
 module ThemableDecorationAttachmentRenderOptions = struct
@@ -897,6 +935,34 @@ module CancellationToken = struct
       [@@js.builder]]
 end
 
+module QuickInputButton = struct
+  include Interface.Make ()
+
+  type iconPath =
+    ([ `Uri of Uri.t
+     | `LightDark of LightDarkIcon.t
+     | `ThemeIcon of ThemeIcon.t
+     ]
+    [@js.union])
+  [@@js]
+
+  let iconPath_of_js js_val =
+    if Ojs.has_property js_val "path"
+    then `Uri ([%js.to: Uri.t] js_val)
+    else if Ojs.has_property js_val "id"
+    then `ThemeIcon ([%js.to: ThemeIcon.t] js_val)
+    else if Ojs.has_property js_val "light"
+    then `LightDark ([%js.to: LightDarkIcon.t] js_val)
+    else assert false
+  ;;
+
+  include
+    [%js:
+      val iconPath : t -> iconPath [@@js.get]
+      val tooltip : t -> string or_undefined [@@js.get]
+      val create : iconPath:iconPath -> ?tooltip:string -> unit -> t [@@js.builder]]
+end
+
 module QuickPickItem = struct
   include Interface.Make ()
 
@@ -958,6 +1024,98 @@ module QuickPickOptions = struct
       [@@js.builder]]
 end
 
+module QuickPick = struct
+  module G = Interface.Generic (Ojs) ()
+  include G
+
+  module Make (T : Ojs.T) = struct
+    type t = T.t G.t [@@js]
+
+    include
+      [%js:
+        val onDidAccept : t -> unit Event.t [@@js.get]
+        val onDidChangeActive : t -> T.t list Event.t [@@js.get]
+        val onDidChangeSelection : t -> T.t list Event.t [@@js.get]
+        val onDidChangeValue : t -> string Event.t [@@js.get]
+        val onDidHide : t -> unit Event.t [@@js.get]
+        val onDidTriggerButton : t -> QuickInputButton.t Event.t [@@js.get]
+        val activeItems : t -> T.t list or_undefined [@@js.get]
+        val set_activeItems : t -> T.t list or_undefined -> unit [@@js.set]
+        val busy : t -> bool or_undefined [@@js.get]
+        val set_busy : t -> bool or_undefined -> unit [@@js.set]
+        val buttons : t -> QuickInputButton.t list or_undefined [@@js.get]
+        val set_buttons : t -> QuickInputButton.t list or_undefined -> unit [@@js.set]
+        val canSelectMany : t -> bool or_undefined [@@js.get]
+        val set_canSelectMany : t -> bool or_undefined -> unit [@@js.set]
+        val enabled : t -> bool or_undefined [@@js.get]
+        val set_enabled : t -> bool or_undefined -> unit [@@js.set]
+        val ignoreFocusOut : t -> bool or_undefined [@@js.get]
+        val set_ignoreFocusOut : t -> bool or_undefined -> unit [@@js.set]
+        val items : t -> T.t list or_undefined [@@js.get]
+        val set_items : t -> T.t list or_undefined -> unit [@@js.set]
+        val keepScrollPosition : t -> bool or_undefined [@@js.get]
+        val set_keepScrollPosition : t -> bool or_undefined -> unit [@@js.set]
+        val matchOnDescription : t -> bool or_undefined [@@js.get]
+        val set_matchOnDescription : t -> bool or_undefined -> unit [@@js.set]
+        val matchOnDetail : t -> bool or_undefined [@@js.get]
+        val set_matchOnDetail : t -> bool or_undefined -> unit [@@js.set]
+        val placeholder : t -> string or_undefined [@@js.get]
+        val set_placeholder : t -> string or_undefined -> unit [@@js.set]
+        val selectedItems : t -> T.t list or_undefined [@@js.get]
+        val set_selectedItems : t -> T.t list or_undefined -> unit [@@js.set]
+        val step : t -> int or_undefined [@@js.get]
+        val set_step : t -> int or_undefined -> unit [@@js.set]
+        val title : t -> string or_undefined [@@js.get]
+        val set_title : t -> string or_undefined -> unit [@@js.set]
+        val totalSteps : t -> int or_undefined [@@js.get]
+        val set_totalSteps : t -> int or_undefined -> unit [@@js.set]
+        val value : t -> string or_undefined [@@js.get]
+        val set_value : t -> string or_undefined -> unit [@@js.set]
+        val dispose : t -> unit [@@js.call]
+        val hide : t -> unit [@@js.call]
+        val show : t -> unit [@@js.call]]
+
+    let set
+          t
+          ?activeItems
+          ?busy
+          ?buttons
+          ?canSelectMany
+          ?enabled
+          ?ignoreFocusOut
+          ?items
+          ?keepScrollPosition
+          ?matchOnDescription
+          ?matchOnDetail
+          ?placeholder
+          ?selectedItems
+          ?step
+          ?title
+          ?totalSteps
+          ?value
+          ()
+      =
+      set_activeItems t activeItems;
+      set_busy t busy;
+      set_buttons t buttons;
+      set_canSelectMany t canSelectMany;
+      set_enabled t enabled;
+      set_ignoreFocusOut t ignoreFocusOut;
+      set_items t items;
+      set_keepScrollPosition t keepScrollPosition;
+      set_matchOnDescription t matchOnDescription;
+      set_matchOnDetail t matchOnDetail;
+      set_placeholder t placeholder;
+      set_selectedItems t selectedItems;
+      set_step t step;
+      set_title t title;
+      set_totalSteps t totalSteps;
+      set_value t value;
+      t
+    ;;
+  end
+end
+
 module ProviderResult = struct
   type 'a t =
     [ `Value of 'a or_undefined
@@ -974,6 +1132,26 @@ module ProviderResult = struct
     then `Promise (Promise.t_of_js (or_undefined_of_js ml_of_js) js_val)
     else `Value (or_undefined_of_js ml_of_js js_val)
   ;;
+end
+
+module InputBoxValidationSeverity = struct
+  type t =
+    | Info [@js 1]
+    | Warning [@js 2]
+    | Error [@js 3]
+  [@@js.enum] [@@js]
+end
+
+module InputBoxValidationMessage = struct
+  include Interface.Make ()
+
+  include
+    [%js:
+      val message : t -> string [@@js.get]
+      val severity : t -> InputBoxValidationSeverity.t [@@js.get]
+
+      val create : message:string -> severity:InputBoxValidationSeverity.t -> unit -> t
+      [@@js.builder]]
 end
 
 module InputBoxOptions = struct
@@ -1002,6 +1180,63 @@ module InputBoxOptions = struct
         -> unit
         -> t
       [@@js.builder]]
+end
+
+module InputBox = struct
+  include Interface.Make ()
+
+  include
+    [%js:
+      val title : t -> string or_undefined [@@js.get]
+      val set_title : t -> string or_undefined -> unit [@@js.set]
+      val enabled : t -> bool [@@js.get]
+      val set_enabled : t -> bool -> unit [@@js.set]
+      val busy : t -> bool [@@js.get]
+      val set_busy : t -> bool -> unit [@@js.set]
+      val ignoreFocusOut : t -> bool or_undefined [@@js.get]
+      val set_ignoreFocusOut : t -> bool or_undefined -> unit [@@js.set]
+      val onDidHide : t -> unit Event.t [@@js.get]
+      val value : t -> string or_undefined [@@js.get]
+      val set_value : t -> string or_undefined -> unit [@@js.set]
+      val valueSelection : t -> (int * int) or_undefined [@@js.get]
+      val set_valueSelection : t -> (int * int) or_undefined -> unit [@@js.set]
+      val placeholder : t -> string or_undefined [@@js.get]
+      val set_placeholder : t -> string or_undefined -> unit [@@js.set]
+      val password : t -> bool or_undefined [@@js.get]
+      val set_password : t -> bool or_undefined -> unit [@@js.set]
+      val onDidChangeValue : t -> string Event.t [@@js.get]
+      val onDidAccept : t -> unit Event.t [@@js.get]
+      val prompt : t -> string or_undefined [@@js.get]
+      val set_prompt : t -> string or_undefined -> unit [@@js.set]
+      val validationMessage : t -> InputBoxValidationMessage.t or_undefined [@@js.get]
+
+      val set_validationMessage : t -> InputBoxValidationMessage.t or_undefined -> unit
+      [@@js.set]
+
+      val show : t -> unit [@@js.call]]
+
+  let set
+        t
+        ?title
+        ?ignoreFocusOut
+        ?value
+        ?valueSelection
+        ?placeholder
+        ?password
+        ?prompt
+        ?validationMessage
+        ()
+    =
+    set_title t title;
+    set_ignoreFocusOut t ignoreFocusOut;
+    set_value t value;
+    set_valueSelection t valueSelection;
+    set_placeholder t placeholder;
+    set_password t password;
+    set_prompt t prompt;
+    set_validationMessage t validationMessage;
+    t
+  ;;
 end
 
 module OpenDialogOptions = struct
@@ -2169,20 +2404,6 @@ module TreeItemLabel = struct
       [@@js.builder]]
 end
 
-module ThemeIcon = struct
-  include Class.Make ()
-
-  include
-    [%js:
-      val make : id:string -> ?color:ThemeColor.t -> unit -> t
-      [@@js.new "vscode.ThemeIcon"]
-
-      val file : t [@@js.global "vscode.ThemeIcon.File"]
-      val folder : t [@@js.global "vscode.ThemeIcon.Folder"]
-      val id : t -> string [@@js.get]
-      val color : t -> ThemeColor.t or_undefined [@@js.get]]
-end
-
 module TreeItem = struct
   include Class.Make ()
 
@@ -2200,30 +2421,6 @@ module TreeItem = struct
     then `TreeItemLabel ([%js.to: TreeItemLabel.t] js_val)
     else assert false
   ;;
-
-  module LightDarkIcon = struct
-    type t =
-      { light : ([ `String of string | `Uri of Uri.t ][@js.union])
-      ; dark : ([ `String of string | `Uri of Uri.t ][@js.union])
-      }
-    [@@js]
-
-    let t_of_js js_val =
-      let light_js = Ojs.get_prop_ascii js_val "light" in
-      let dark_js = Ojs.get_prop_ascii js_val "dark" in
-      let light =
-        if Ojs.has_property light_js "parse"
-        then `Uri ([%js.to: Uri.t] light_js)
-        else `String ([%js.to: string] light_js)
-      in
-      let dark =
-        if Ojs.has_property dark_js "parse"
-        then `Uri ([%js.to: Uri.t] dark_js)
-        else `String ([%js.to: string] dark_js)
-      in
-      { light; dark }
-    ;;
-  end
 
   type iconPath =
     ([ `String of string
@@ -2758,6 +2955,12 @@ module Window = struct
         -> MessageItem.t or_undefined Promise.t
       [@@js.global "vscode.window.showErrorMessage"]
 
+      val createQuickPick
+        :  ((module Ojs.T with type t = 'a)[@js])
+        -> unit
+        -> 'a QuickPick.t
+      [@@js.global "vscode.window.createQuickPick"]
+
       val showQuickPickItems
         :  choices:QuickPickItem.t list
         -> ?options:QuickPickOptions.t
@@ -2774,12 +2977,17 @@ module Window = struct
         -> string or_undefined Promise.t
       [@@js.global "vscode.window.showQuickPick"]
 
+      val quickInputButtonBack : QuickInputButton.t
+      [@@js.global "vscode.QuickInputButtons.Back"]
+
       val showInputBox
         :  ?options:InputBoxOptions.t
         -> ?token:CancellationToken.t
         -> unit
         -> string or_undefined Promise.t
       [@@js.global "vscode.window.showInputBox"]
+
+      val createInputBox : unit -> InputBox.t [@@js.global "vscode.window.createInputBox"]
 
       val showOpenDialog
         :  ?options:OpenDialogOptions.t

--- a/src-bindings/vscode/vscode.mli
+++ b/src-bindings/vscode/vscode.mli
@@ -144,6 +144,31 @@ module Uri : sig
   val equal : t -> t -> bool
 end
 
+module LightDarkIcon : sig
+  type t =
+    { light : [ `String of string | `Uri of Uri.t ]
+    ; dark : [ `String of string | `Uri of Uri.t ]
+    }
+
+  include Ojs.T with type t := t
+end
+
+module ThemeColor : sig
+  include Ojs.T
+
+  val make : id:string -> t
+end
+
+module ThemeIcon : sig
+  include Ojs.T
+
+  val make : id:string -> ?color:ThemeColor.t -> unit -> t
+  val file : t
+  val folder : t
+  val id : t -> string
+  val color : t -> ThemeColor.t option
+end
+
 module TextDocument : sig
   include Ojs.T
 
@@ -329,12 +354,6 @@ module MarkdownString : sig
   val appendText : t -> value:string -> t
   val appendMarkdown : t -> value:string -> t
   val appendCodeblock : t -> value:string -> ?language:string -> unit -> t
-end
-
-module ThemeColor : sig
-  include Ojs.T
-
-  val make : id:string -> t
 end
 
 module ThemableDecorationAttachmentRenderOptions : sig
@@ -668,6 +687,20 @@ module CustomDocument : sig
   val create : uri:Uri.t -> dispose:(unit -> unit) -> t
 end
 
+module QuickInputButton : sig
+  include Ojs.T
+
+  type iconPath =
+    [ `Uri of Uri.t
+    | `LightDark of LightDarkIcon.t
+    | `ThemeIcon of ThemeIcon.t
+    ]
+
+  val iconPath : t -> iconPath
+  val tooltip : t -> string option
+  val create : iconPath:iconPath -> ?tooltip:string -> unit -> t
+end
+
 module QuickPickItem : sig
   include Ojs.T
 
@@ -715,6 +748,77 @@ module QuickPickOptions : sig
     -> t
 end
 
+module QuickPick : sig
+  include Js.Generic
+
+  module Make (T : Ojs.T) : sig
+    type nonrec t = T.t t
+
+    val onDidAccept : t -> unit Event.t
+    val onDidChangeActive : t -> T.t list Event.t
+    val onDidChangeSelection : t -> T.t list Event.t
+    val onDidChangeValue : t -> string Event.t
+    val onDidHide : t -> unit Event.t
+    val onDidTriggerButton : t -> QuickInputButton.t Event.t
+    val activeItems : t -> T.t list option
+    val set_activeItems : t -> T.t list option -> unit
+    val busy : t -> bool option
+    val set_busy : t -> bool option -> unit
+    val buttons : t -> QuickInputButton.t list option
+    val set_buttons : t -> QuickInputButton.t list option -> unit
+    val canSelectMany : t -> bool option
+    val set_canSelectMany : t -> bool option -> unit
+    val enabled : t -> bool option
+    val set_enabled : t -> bool option -> unit
+    val ignoreFocusOut : t -> bool option
+    val set_ignoreFocusOut : t -> bool option -> unit
+    val items : t -> T.t list option
+    val set_items : t -> T.t list option -> unit
+    val keepScrollPosition : t -> bool option
+    val set_keepScrollPosition : t -> bool option -> unit
+    val matchOnDescription : t -> bool option
+    val set_matchOnDescription : t -> bool option -> unit
+    val matchOnDetail : t -> bool option
+    val set_matchOnDetail : t -> bool option -> unit
+    val placeholder : t -> string option
+    val set_placeholder : t -> string option -> unit
+    val selectedItems : t -> T.t list option
+    val set_selectedItems : t -> T.t list option -> unit
+    val step : t -> int option
+    val set_step : t -> int option -> unit
+    val title : t -> string option
+    val set_title : t -> string option -> unit
+    val totalSteps : t -> int option
+    val set_totalSteps : t -> int option -> unit
+    val value : t -> string option
+    val set_value : t -> string option -> unit
+    val dispose : t -> unit
+    val hide : t -> unit
+    val show : t -> unit
+
+    val set
+      :  t
+      -> ?activeItems:T.t list
+      -> ?busy:bool
+      -> ?buttons:QuickInputButton.t list
+      -> ?canSelectMany:bool
+      -> ?enabled:bool
+      -> ?ignoreFocusOut:bool
+      -> ?items:T.t list
+      -> ?keepScrollPosition:bool
+      -> ?matchOnDescription:bool
+      -> ?matchOnDetail:bool
+      -> ?placeholder:string
+      -> ?selectedItems:T.t list
+      -> ?step:int
+      -> ?title:string
+      -> ?totalSteps:int
+      -> ?value:string
+      -> unit
+      -> t
+  end
+end
+
 module ProviderResult : sig
   type 'a t =
     [ `Value of 'a option
@@ -722,6 +826,23 @@ module ProviderResult : sig
     ]
 
   include Js.Generic with type 'a t := 'a t
+end
+
+module InputBoxValidationSeverity : sig
+  type t =
+    | Info
+    | Warning
+    | Error
+
+  include Ojs.T with type t := t
+end
+
+module InputBoxValidationMessage : sig
+  include Ojs.T
+
+  val message : t -> string
+  val severity : t -> InputBoxValidationSeverity.t
+  val create : message:string -> severity:InputBoxValidationSeverity.t -> unit -> t
 end
 
 module InputBoxOptions : sig
@@ -745,6 +866,48 @@ module InputBoxOptions : sig
     -> ?password:bool
     -> ?ignoreFocusOut:bool
     -> ?validateInput:(value:string -> string option Promise.t)
+    -> unit
+    -> t
+end
+
+module InputBox : sig
+  include Ojs.T
+
+  val title : t -> string option
+  val set_title : t -> string option -> unit
+  val enabled : t -> bool
+  val set_enabled : t -> bool -> unit
+  val busy : t -> bool
+  val set_busy : t -> bool -> unit
+  val ignoreFocusOut : t -> bool option
+  val set_ignoreFocusOut : t -> bool option -> unit
+  val onDidHide : t -> unit Event.t
+  val value : t -> string option
+  val set_value : t -> string option -> unit
+  val valueSelection : t -> (int * int) option
+  val set_valueSelection : t -> (int * int) option -> unit
+  val placeholder : t -> string option
+  val set_placeholder : t -> string option -> unit
+  val password : t -> bool option
+  val set_password : t -> bool option -> unit
+  val onDidChangeValue : t -> string Event.t
+  val onDidAccept : t -> unit Event.t
+  val prompt : t -> string option
+  val set_prompt : t -> string option -> unit
+  val validationMessage : t -> InputBoxValidationMessage.t or_undefined
+  val set_validationMessage : t -> InputBoxValidationMessage.t or_undefined -> unit
+  val show : t -> unit
+
+  val set
+    :  t
+    -> ?title:string
+    -> ?ignoreFocusOut:bool
+    -> ?value:string
+    -> ?valueSelection:int * int
+    -> ?placeholder:string
+    -> ?password:bool
+    -> ?prompt:string
+    -> ?validationMessage:InputBoxValidationMessage.t
     -> unit
     -> t
 end
@@ -1562,16 +1725,6 @@ module TreeItemLabel : sig
   val highlights : t -> (int * int) list option
 end
 
-module ThemeIcon : sig
-  include Ojs.T
-
-  val make : id:string -> ?color:ThemeColor.t -> unit -> t
-  val file : t
-  val folder : t
-  val id : t -> string
-  val color : t -> ThemeColor.t option
-end
-
 module TreeItem : sig
   include Ojs.T
 
@@ -1579,15 +1732,6 @@ module TreeItem : sig
     [ `String of string
     | `TreeItemLabel of TreeItemLabel.t
     ]
-
-  module LightDarkIcon : sig
-    type t =
-      { light : [ `String of string | `Uri of Uri.t ]
-      ; dark : [ `String of string | `Uri of Uri.t ]
-      }
-
-    include Ojs.T with type t := t
-  end
 
   type iconPath =
     [ `String of string
@@ -1986,6 +2130,9 @@ module Window : sig
     -> unit
     -> 'a option Promise.t
 
+  val createQuickPick : 'a Js.t -> unit -> 'a QuickPick.t
+  val quickInputButtonBack : QuickInputButton.t
+
   val showQuickPick
     :  items:string list
     -> ?options:QuickPickOptions.t
@@ -1999,6 +2146,7 @@ module Window : sig
     -> unit
     -> string option Promise.t
 
+  val createInputBox : unit -> InputBox.t
   val showOpenDialog : ?options:OpenDialogOptions.t -> unit -> Uri.t list option Promise.t
   val createOutputChannel : name:string -> OutputChannel.t
 

--- a/src/custom_requests.mli
+++ b/src/custom_requests.mli
@@ -64,3 +64,29 @@ module Merlin_jump : sig
   val make : uri:Uri.t -> position:Position.t -> params
   val request : (params, response) custom_request
 end
+
+module Type_search : sig
+  type type_search_result =
+    { name : string
+    ; typ : string
+    ; loc : Range.t
+    ; doc : MarkupContent.t option
+    ; cost : int
+    ; constructible : string
+    }
+
+  type params
+  type response = type_search_result list
+
+  val make
+    :  uri:Uri.t
+    -> position:Position.t
+    -> limit:int
+    -> query:string
+    -> with_doc:bool
+    -> ?doc_format:MarkupKind.t option
+    -> unit
+    -> params
+
+  val request : (params, response) custom_request
+end

--- a/src/extension_consts.ml
+++ b/src/extension_consts.ml
@@ -35,6 +35,7 @@ module Commands = struct
   let copy_type_under_cursor = ocaml_prefixed "copy-type-under-cursor"
   let construct = ocaml_prefixed "construct"
   let merlin_jump = ocaml_prefixed "jump"
+  let search_by_type = ocaml_prefixed "search-by-type"
 end
 
 module Command_errors = struct

--- a/src/import.ml
+++ b/src/import.ml
@@ -76,7 +76,7 @@ let show_message kind fmt =
     match kind with
     | `Warn -> Window.showWarningMessage ~message ()
     | `Info -> Window.showInformationMessage ~message ()
-    | `Error -> Window.showInformationMessage ~message ()
+    | `Error -> Window.showErrorMessage ~message ()
   in
   Printf.ksprintf
     (fun x ->
@@ -175,6 +175,40 @@ module Range = struct
   ;;
 
   include Vscode.Range
+end
+
+module MarkupKind = struct
+  type t =
+    | PlainText
+    | Markdown
+
+  let json_of_t (t : t) : Jsonoo.t =
+    match t with
+    | PlainText -> Jsonoo.Encode.string "plaintext"
+    | Markdown -> Jsonoo.Encode.string "markdown"
+  ;;
+
+  let t_of_json (json : Jsonoo.t) : t =
+    match Jsonoo.Decode.string json with
+    | "plaintext" -> PlainText
+    | "markdown" -> Markdown
+    (* Default to plaintext *)
+    | _ -> PlainText
+  ;;
+end
+
+module MarkupContent = struct
+  type t =
+    { kind : MarkupKind.t
+    ; value : string
+    }
+
+  let t_of_json json =
+    let open Jsonoo.Decode in
+    let kind = field "kind" MarkupKind.t_of_json json in
+    let value = field "value" string json in
+    { kind; value }
+  ;;
 end
 
 module Promise = struct

--- a/src/ocaml_lsp.ml
+++ b/src/ocaml_lsp.ml
@@ -42,6 +42,7 @@ module Experimental_capabilities = struct
     ; handleTypeEnclosing : bool
     ; handleConstruct : bool
     ; handleJump : bool
+    ; handleSearchByType : bool
     }
 
   let default =
@@ -51,6 +52,7 @@ module Experimental_capabilities = struct
     ; handleTypeEnclosing = false
     ; handleConstruct = false
     ; handleJump = false
+    ; handleSearchByType = false
     }
   ;;
 
@@ -65,6 +67,7 @@ module Experimental_capabilities = struct
       let handleInferIntf = has_capability "handleInferIntf" in
       let handleTypedHoles = has_capability "handleTypedHoles" in
       let handleTypeEnclosing = has_capability "handleTypeEnclosing" in
+      let handleSearchByType = has_capability "handleTypeSearch" in
       let handleConstruct = has_capability "handleConstruct" in
       let handleJump = has_capability "handleJump" in
       { handleSwitchImplIntf
@@ -73,6 +76,7 @@ module Experimental_capabilities = struct
       ; handleTypeEnclosing
       ; handleConstruct
       ; handleJump
+      ; handleSearchByType
       }
     with
     | Jsonoo.Decode_error err ->
@@ -238,3 +242,4 @@ let can_handle_typed_holes t = t.experimental_capabilities.handleTypedHoles
 let can_handle_type_enclosing t = t.experimental_capabilities.handleTypeEnclosing
 let can_handle_construct t = t.experimental_capabilities.handleConstruct
 let can_handle_merlin_jump t = t.experimental_capabilities.handleJump
+let can_handle_search_by_type t = t.experimental_capabilities.handleSearchByType

--- a/src/ocaml_lsp.mli
+++ b/src/ocaml_lsp.mli
@@ -10,6 +10,7 @@ val can_handle_typed_holes : t -> bool
 val can_handle_type_enclosing : t -> bool
 val can_handle_construct : t -> bool
 val can_handle_merlin_jump : t -> bool
+val can_handle_search_by_type : t -> bool
 
 module OcamllspSettingEnable : sig
   include Ojs.T

--- a/src/treeview_commands.ml
+++ b/src/treeview_commands.ml
@@ -1,7 +1,7 @@
 let select_sandbox_item =
   let icon =
     `LightDark
-      Vscode.TreeItem.LightDarkIcon.
+      Vscode.LightDarkIcon.
         { light = `String (Path.asset "collection-light.svg" |> Path.to_string)
         ; dark = `String (Path.asset "collection-dark.svg" |> Path.to_string)
         }
@@ -19,7 +19,7 @@ let select_sandbox_item =
 let terminal_item =
   let icon =
     `LightDark
-      Vscode.TreeItem.LightDarkIcon.
+      Vscode.LightDarkIcon.
         { light = `String (Path.asset "terminal-light.svg" |> Path.to_string)
         ; dark = `String (Path.asset "terminal-dark.svg" |> Path.to_string)
         }
@@ -66,7 +66,28 @@ let jump_item =
   item
 ;;
 
-let items = [ select_sandbox_item; terminal_item; construct_item; jump_item ]
+let type_search_item =
+  let icon = `ThemeIcon (Vscode.ThemeIcon.make ~id:"search-view-icon" ()) in
+  let label =
+    `TreeItemLabel
+      (Vscode.TreeItemLabel.create ~label:"Search a value by type or polarity" ())
+  in
+  let item = Vscode.TreeItem.make_label ~label () in
+  let command =
+    Vscode.Command.create
+      ~title:"Search a value by type or polarity"
+      ~command:"ocaml.search-by-type"
+      ()
+  in
+  Vscode.TreeItem.set_iconPath item icon;
+  Vscode.TreeItem.set_command item command;
+  item
+;;
+
+let items =
+  [ select_sandbox_item; terminal_item; construct_item; jump_item; type_search_item ]
+;;
+
 let getTreeItem ~element = `Value element
 
 let getChildren ?element () =

--- a/src/treeview_help.ml
+++ b/src/treeview_help.ml
@@ -1,7 +1,7 @@
 let discord_item =
   let icon =
     `LightDark
-      Vscode.TreeItem.LightDarkIcon.
+      Vscode.LightDarkIcon.
         { light = `String (Path.asset "discord-light.svg" |> Path.to_string)
         ; dark = `String (Path.asset "discord-dark.svg" |> Path.to_string)
         }
@@ -24,7 +24,7 @@ let discord_item =
 let discuss_item =
   let icon =
     `LightDark
-      Vscode.TreeItem.LightDarkIcon.
+      Vscode.LightDarkIcon.
         { light = `String (Path.asset "chat-light.svg" |> Path.to_string)
         ; dark = `String (Path.asset "chat-dark.svg" |> Path.to_string)
         }
@@ -49,7 +49,7 @@ let discuss_item =
 let github_item =
   let icon =
     `LightDark
-      Vscode.TreeItem.LightDarkIcon.
+      Vscode.LightDarkIcon.
         { light = `String (Path.asset "github-light.svg" |> Path.to_string)
         ; dark = `String (Path.asset "github-dark.svg" |> Path.to_string)
         }

--- a/src/treeview_sandbox.ml
+++ b/src/treeview_sandbox.ml
@@ -10,7 +10,7 @@ module Dependency = struct
   let tooltip t = Sandbox.Package.synopsis t
 
   let icon _ =
-    TreeItem.LightDarkIcon.
+    LightDarkIcon.
       { light = `String (Path.asset "number-light.svg" |> Path.to_string)
       ; dark = `String (Path.asset "number-dark.svg" |> Path.to_string)
       }

--- a/src/treeview_switches.ml
+++ b/src/treeview_switches.ml
@@ -43,7 +43,7 @@ module Dependency = struct
     match dependency with
     | Switch _ ->
       let selected = if is_current_sandbox then "-selected" else "" in
-      TreeItem.LightDarkIcon.
+      LightDarkIcon.
         { light =
             `String
               (Path.asset @@ "dependency-light" ^ selected ^ ".svg" |> Path.to_string)
@@ -51,7 +51,7 @@ module Dependency = struct
             `String (Path.asset @@ "dependency-dark" ^ selected ^ ".svg" |> Path.to_string)
         }
     | Package _ ->
-      TreeItem.LightDarkIcon.
+      LightDarkIcon.
         { light = `String (Path.asset "number-light.svg" |> Path.to_string)
         ; dark = `String (Path.asset "number-dark.svg" |> Path.to_string)
         }


### PR DESCRIPTION
# Search By Type or Polarity

## Introduction
This PR implements the [Search By Type or Polarity Custom Requests](https://github.com/ocaml/ocaml-lsp/pull/1369).

## UI
The UI uses a [QuickInput](https://code.visualstudio.com/api/references/vscode-api#QuickInput) component which provides a textbox for the user to enter the search query. 
The results are displayed in a [QuickPick](https://code.visualstudio.com/api/ux-guidelines/quick-picks) component where upon selection, the value is inserted into the document at the cursor location.

The QuickInput and QuickPick components are ideal for this use case given they are lightweight and offer robust performance as compared to webviews. 
They also offer easy navigation and are suitable for both mouse and keyboard usage.

## UX
The entire workflow is done in 3 steps:
### Step 1:  Triggering the command: 
The command can be triggered using one of three ways:

   - 1. With your cursor in the editor, use the keyboard shortcut `Alt + F`

OR
   
   - 2. From the command pallet, select `OCaml: Search a value by type or polarity` 
![image](https://github.com/user-attachments/assets/1443f236-863e-420e-988a-207519768c1f)

OR

   - 3. Click a button from the extension treeview under the section `LSP Custom Requests`
![image](https://github.com/user-attachments/assets/f9039b62-a463-479c-9a8a-6b56460b4c8c)

### Step 2: Entering the search query
Type what you are searching for. You can use type signatures or polarities.
- `int -> string` 
- `-int +string`

![image](https://github.com/user-attachments/assets/355a7eec-ad50-4679-a336-c86a0a576052)

### Step 3: Selecting a value from the results
After entering the search term and hitting enter, the results are displayed in a `QuickPick` component where you can select the specific value you are looking for.  It also includes a textbox which can be used to filter the values.
Upon selection, the value is inserted into the document at the cursor position.

#### Going back
You can use the back button to go back to the search input box and change your query. If the results are empty, it automatically takes you back to the search input box as well.

![image](https://github.com/user-attachments/assets/7a8b98e3-22ce-49d8-832f-a729e4ff0eea)


## Notifications
- `Ocamllsp warning`: If `ocamllsp` is not running at the time the command is invoked, this notification is displayed.
- `No support for requests`: If the version of ocamllsp doesn't publish the `ocamllsp/typeSearch` capability then this notification is displayed. 

## Commands
One command is published `ocaml.search-by-type` which triggers the process.

## Demo

https://github.com/user-attachments/assets/cba6f3ed-21d0-4278-882d-d4659be279e3

## Note
The [Search by Type PR](https://github.com/ocaml/ocaml-lsp/pull/1369) on Ocaml-lsp is unmerged, so to test pin `ocaml-lsp-server` to [https://github.com/PizieDust/ocaml-lsp.git#polarity_search](https://github.com/PizieDust/ocaml-lsp.git#polarity_search)

## References
- QuickPick : [https://code.visualstudio.com/api/ux-guidelines/quick-picks](https://code.visualstudio.com/api/ux-guidelines/quick-picks)
- QuickInput: [https://code.visualstudio.com/api/references/vscode-api#QuickInput](https://code.visualstudio.com/api/references/vscode-api#QuickInput)

cc @voodoos 