### PR TITLE
Run ocamllsp -version in workspace dir

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,9 +2,9 @@
 
 # Unreleased
 
-- Add `ocaml.copy-type-under-cursor` to copy, in the clipboard the type of 
+- Add `ocaml.copy-type-under-cursor` to copy, in the clipboard the type of
   the expression under the cursor (#1582)
-
+- Run ocamllsp -version in workspace dir (#1641)
 - Make it a warning if ocamlc is missing (#1642)
 
 ## 1.20.1

--- a/src/extension_instance.ml
+++ b/src/extension_instance.ml
@@ -140,7 +140,13 @@ end = struct
     let ocaml_lsp_version sandbox =
       Sandbox.get_command sandbox "ocamllsp" [ "--version" ]
     in
-    Cmd.output (ocaml_lsp_version sandbox)
+    let cwd =
+      match Workspace.workspaceFolders () with
+      | [ cwd ] ->
+        Some (cwd |> WorkspaceFolder.uri |> Uri.path |> Path.of_string)
+      | _ -> None
+    in
+    Cmd.output ?cwd (ocaml_lsp_version sandbox)
     |> Promise.Result.fold
          ~ok:(fun (_ : string) -> ())
          ~error:(fun (_ : string) ->


### PR DESCRIPTION
This is needed when dune is managing the installation of ocamllsp, as it needs to determine which version of ocamllsp to run by looking in the current project's lockdir.