### PR TITLE
Make it a warning if ocamlc is missing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@
 - Add `ocaml.copy-type-under-cursor` to copy, in the clipboard the type of 
   the expression under the cursor (#1582)
 
+- Make it a warning if ocamlc is missing (#1642)
+
 ## 1.20.1
 
 - This was a version bump only, there were no changes

--- a/src/extension_instance.ml
+++ b/src/extension_instance.ml
@@ -372,7 +372,7 @@ let update_ocaml_info t =
     | `Ocamlc_missing ->
       let (_ : unit Promise.t) =
         let+ maybe_choice =
-          Window.showErrorMessage
+          Window.showWarningMessage
             ~message:
               "OCaml bytecode compiler `ocamlc` was not found in the current \
                sandbox. Do you have OCaml installed in the current sandbox?"


### PR DESCRIPTION
If you're using the dune developer preview then ocamlc won't be globally installed. It's a bit offputting to have the plugin pop up with an error every time vscode starts, especially since the plugin seems to work fine without it. This downgrades it to a warning and adds an "Ignore" button.