### PR TITLE
Jump Custom Request Client Implementation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,7 @@
 - Run ocamllsp -version in workspace dir (#1641)
 - Make it a warning if ocamlc is missing (#1642)
 - Add `1.18.0`, `1.19.0` and `1.20.0~5.3preview` to the list of known versions
-  of ocamllsp (#1644)
+  of ocamllsp (#1644) 
 
 ## 1.20.1
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,11 +2,12 @@
 
 # Unreleased
 
+- Add `ocaml.jump` to jump to a specific target. (#1654)
+
 ## 1.22.0
 
 - Fix formatting of cwd path on windows (#1650)
 - Add `ocaml.construct` to construct an expression from a typedhole. (#1646)
-- Add `ocaml.jump` to jump to a specific target. (#1654)
 
 ## 1.21.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,7 @@
 - Run ocamllsp -version in workspace dir (#1641)
 - Make it a warning if ocamlc is missing (#1642)
 - Add `1.18.0`, `1.19.0` and `1.20.0~5.3preview` to the list of known versions
-  of ocamllsp (#1644) 
+  of ocamllsp (#1644)
 
 ## 1.20.1
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 - Fix formatting of cwd path on windows (#1650)
 - Add `ocaml.construct` to construct an expression from a typedhole. (#1646)
+- Add `ocaml.jump` to jump to a specific target. (#1654)
 
 ## 1.21.0
 

--- a/package.json
+++ b/package.json
@@ -261,7 +261,7 @@
       {
         "command": "ocaml.jump",
         "category": "OCaml",
-        "title": "Jump to a specific target"
+        "title": "List possible parent targets for jumping"
       }
     ],
     "configuration": {

--- a/package.json
+++ b/package.json
@@ -737,7 +737,7 @@
         "args": {
           "kind": "jump"
         },
-        "when": "editorLangId == ocaml || editorLangId == reason"
+        "when": "editorLangId == ocaml || editorLangId == ocaml.interface || editorLangId == reason"
       },
       {
         "command": "editor.action.codeAction",

--- a/package.json
+++ b/package.json
@@ -257,6 +257,11 @@
         "command": "ocaml.construct",
         "category": "OCaml",
         "title": "List values that can fill the selected typed-hole"
+      },
+      {
+        "command": "ocaml.jump",
+        "category": "OCaml",
+        "title": "Jump to a specific target"
       }
     ],
     "configuration": {
@@ -723,6 +728,14 @@
         "key": "Alt+C",
         "args": {
           "kind": "construct"
+        },
+        "when": "editorLangId == ocaml || editorLangId == reason"
+      },
+      {
+        "command": "ocaml.jump",
+        "key": "Alt+J",
+        "args": {
+          "kind": "jump"
         },
         "when": "editorLangId == ocaml || editorLangId == reason"
       },

--- a/src/custom_requests.ml
+++ b/src/custom_requests.ml
@@ -120,3 +120,34 @@ module Construct = struct
   let request =
     { meth = ocamllsp_prefixed "construct"; encode_params; decode_response }
 end
+
+module Merlin_jump = struct
+  type params =
+    { uri : Uri.t
+    ; position : Position.t
+    ; target : string
+    }
+
+  type response =
+    { uri : Uri.t
+    ; position : Position.t
+    }
+
+  let encode_params { uri; position; target } =
+    let open Jsonoo.Encode in
+    let uri = ("uri", string @@ Uri.toString uri ()) in
+    let position = ("position", Position.json_of_t position) in
+    let target = ("target", string target) in
+    object_ [ uri; position; target ]
+
+  let decode_response response =
+    let open Jsonoo.Decode in
+    let position = field "position" Position.t_of_json response in
+    let uri = field "uri" Jsonoo.t_to_js response |> Uri.t_of_js in
+    { uri; position }
+
+  let make ~uri ~position ~target () = { uri; position; target }
+
+  let request =
+    { meth = ocamllsp_prefixed "jump"; encode_params; decode_response }
+end

--- a/src/custom_requests.ml
+++ b/src/custom_requests.ml
@@ -127,7 +127,7 @@ module Merlin_jump = struct
     ; position : Position.t
     }
 
-  type response = (string * Position.t) list option
+  type response = (string * Position.t) list
 
   let encode_params { uri; position } =
     let open Jsonoo.Encode in
@@ -139,17 +139,13 @@ module Merlin_jump = struct
 
   let decode_response (response : Jsonoo.t) : response =
     let open Jsonoo.Decode in
-    match
-      field
-        "jumps"
-        (list (fun item ->
-             let target = field "target" string item in
-             let position = field "position" Position.t_of_json item in
-             (target, position)))
-        response
-    with
-    | _ :: _ as items -> Some items
-    | _ -> None
+    field
+      "jumps"
+      (list (fun item ->
+           let target = field "target" string item in
+           let position = field "position" Position.t_of_json item in
+           (target, position)))
+      response
 
   let make ~uri ~position = { uri; position }
 

--- a/src/custom_requests.mli
+++ b/src/custom_requests.mli
@@ -62,7 +62,7 @@ end
 module Merlin_jump : sig
   type params
 
-  type response = (string * Position.t) list option
+  type response = (string * Position.t) list
 
   val make : uri:Uri.t -> position:Position.t -> params
 

--- a/src/custom_requests.mli
+++ b/src/custom_requests.mli
@@ -62,12 +62,9 @@ end
 module Merlin_jump : sig
   type params
 
-  type response =
-    { uri : Uri.t
-    ; position : Position.t
-    }
+  type response = (string * Position.t) list option
 
-  val make : uri:Uri.t -> position:Position.t -> target:string -> unit -> params
+  val make : uri:Uri.t -> position:Position.t -> params
 
   val request : (params, response) custom_request
 end

--- a/src/custom_requests.mli
+++ b/src/custom_requests.mli
@@ -58,3 +58,16 @@ module Construct : sig
 
   val request : (params, response) custom_request
 end
+
+module Merlin_jump : sig
+  type params
+
+  type response =
+    { uri : Uri.t
+    ; position : Position.t
+    }
+
+  val make : uri:Uri.t -> position:Position.t -> target:string -> unit -> params
+
+  val request : (params, response) custom_request
+end

--- a/src/extension_commands.ml
+++ b/src/extension_commands.ml
@@ -701,7 +701,8 @@ module MerlinJump = struct
       ()
 
   let jump_to_position text_editor position =
-    let _ =
+    let open Promise.Syntax in
+    let* _ =
       Window.showTextDocument
         ~document:(TextEditor.document text_editor)
         ~preserveFocus:true
@@ -715,7 +716,7 @@ module MerlinJump = struct
       ~range:(Range.makePositions ~start:position ~end_:position)
       ~revealType:TextEditorRevealType.InCenterIfOutsideViewport
       ();
-    ()
+    Promise.return ()
 
   let process_jump position text_editor client =
     let open Promise.Syntax in
@@ -724,8 +725,7 @@ module MerlinJump = struct
     in
     let* selected_target = display_results successful_targets in
     match selected_target with
-    | Some (_res, position) ->
-      jump_to_position text_editor position |> Promise.return
+    | Some (_res, position) -> jump_to_position text_editor position
     | None -> Promise.return ()
 
   let _jump =

--- a/src/extension_commands.ml
+++ b/src/extension_commands.ml
@@ -702,7 +702,7 @@ module MerlinJump = struct
 
   let jump_to_position text_editor position =
     let open Promise.Syntax in
-    let* _ =
+    let+ _ =
       Window.showTextDocument
         ~document:(TextEditor.document text_editor)
         ~preserveFocus:true
@@ -716,7 +716,7 @@ module MerlinJump = struct
       ~range:(Range.makePositions ~start:position ~end_:position)
       ~revealType:TextEditorRevealType.InCenterIfOutsideViewport
       ();
-    Promise.return ()
+    ()
 
   let process_jump position text_editor client =
     let open Promise.Syntax in

--- a/src/extension_commands.ml
+++ b/src/extension_commands.ml
@@ -686,9 +686,7 @@ module MerlinJump = struct
       match results with
       | Some results ->
         List.map results ~f:(fun (target, pos) ->
-            ( (QuickPickItem.create
-                 ~label:("Jump to " ^ String.uppercase target))
-                ()
+            ( (QuickPickItem.create ~label:("Jump to nearest " ^ target)) ()
             , (target, pos) ))
       | None -> []
     in
@@ -708,7 +706,14 @@ module MerlinJump = struct
       text_editor
       ~range:(Range.makePositions ~start:position ~end_:position)
       ~revealType:TextEditorRevealType.InCenterIfOutsideViewport
-      ()
+      ();
+    let _ =
+      Window.showTextDocument
+        ~document:(TextEditor.document text_editor)
+        ~preserveFocus:true
+        ()
+    in
+    ()
 
   let process_jump position text_editor client =
     let open Promise.Syntax in

--- a/src/extension_commands.ml
+++ b/src/extension_commands.ml
@@ -715,8 +715,7 @@ module MerlinJump = struct
       text_editor
       ~range:(Range.makePositions ~start:position ~end_:position)
       ~revealType:TextEditorRevealType.InCenterIfOutsideViewport
-      ();
-    ()
+      ()
 
   let process_jump position text_editor client =
     let open Promise.Syntax in

--- a/src/extension_consts.ml
+++ b/src/extension_consts.ml
@@ -70,6 +70,8 @@ module Commands = struct
   let copy_type_under_cursor = ocaml_prefixed "copy-type-under-cursor"
 
   let construct = ocaml_prefixed "construct"
+
+  let merlin_jump = ocaml_prefixed "jump"
 end
 
 module Command_errors = struct

--- a/src/ocaml_lsp.ml
+++ b/src/ocaml_lsp.ml
@@ -45,6 +45,7 @@ module Experimental_capabilities = struct
     ; handleTypedHoles : bool
     ; handleTypeEnclosing : bool
     ; handleConstruct : bool
+    ; handleJump : bool
     }
 
   let default =
@@ -53,6 +54,7 @@ module Experimental_capabilities = struct
     ; handleTypedHoles = false
     ; handleTypeEnclosing = false
     ; handleConstruct = false
+    ; handleJump = false
     }
 
   (** Creates [t] given a JSON of form [{ 'handleSwitchImplIntf' : true, .... }] *)
@@ -68,11 +70,13 @@ module Experimental_capabilities = struct
       let handleTypedHoles = has_capability "handleTypedHoles" in
       let handleTypeEnclosing = has_capability "handleTypeEnclosing" in
       let handleConstruct = has_capability "handleConstruct" in
+      let handleJump = has_capability "handleJump" in
       { handleSwitchImplIntf
       ; handleInferIntf
       ; handleTypedHoles
       ; handleTypeEnclosing
       ; handleConstruct
+      ; handleJump
       }
     with Jsonoo.Decode_error err ->
       show_message
@@ -242,3 +246,5 @@ let can_handle_type_enclosing t =
   t.experimental_capabilities.handleTypeEnclosing
 
 let can_handle_construct t = t.experimental_capabilities.handleConstruct
+
+let can_handle_merlin_jump t = t.experimental_capabilities.handleJump

--- a/src/ocaml_lsp.mli
+++ b/src/ocaml_lsp.mli
@@ -17,6 +17,8 @@ val can_handle_type_enclosing : t -> bool
 
 val can_handle_construct : t -> bool
 
+val can_handle_merlin_jump : t -> bool
+
 module OcamllspSettingEnable : sig
   include Ojs.T
 

--- a/src/treeview_commands.ml
+++ b/src/treeview_commands.ml
@@ -60,7 +60,7 @@ let construct_item =
   item
 
 let jump_item =
-  let icon = `ThemeIcon (Vscode.ThemeIcon.make ~id:"tools" ()) in
+  let icon = `ThemeIcon (Vscode.ThemeIcon.make ~id:"fold-up" ()) in
   let label =
     `TreeItemLabel
       (Vscode.TreeItemLabel.create ~label:"Jump to a specific target" ())

--- a/src/treeview_commands.ml
+++ b/src/treeview_commands.ml
@@ -59,7 +59,21 @@ let construct_item =
   Vscode.TreeItem.set_command item command;
   item
 
-let items = [ select_sandbox_item; terminal_item; construct_item ]
+let jump_item =
+  let icon = `ThemeIcon (Vscode.ThemeIcon.make ~id:"tools" ()) in
+  let label =
+    `TreeItemLabel
+      (Vscode.TreeItemLabel.create ~label:"Jump to a specific target" ())
+  in
+  let item = Vscode.TreeItem.make_label ~label () in
+  let command =
+    Vscode.Command.create ~title:"MerlinJump" ~command:"ocaml.jump" ()
+  in
+  Vscode.TreeItem.set_iconPath item icon;
+  Vscode.TreeItem.set_command item command;
+  item
+
+let items = [ select_sandbox_item; terminal_item; construct_item; jump_item ]
 
 let getTreeItem ~element = `Value element
 


### PR DESCRIPTION
# Advanced Navigation 

## Introduction
This PR implements the [Jump Custom Requests](https://github.com/ocaml/ocaml-lsp/pull/1374).

## UI
Jump results are displayed in a [QuickPick](https://code.visualstudio.com/api/ux-guidelines/quick-picks) component where upon selection, the jump is made to the selected target.

## UX
This command can be triggered from the command pallet or with the keyboard binding `Alt +J`

## Notifications
- `Ocamllsp warning`: If `ocamllsp` is not running at the time the command is invoked, this notification is displayed.
- `No support for requests`: If the version of ocamllsp doesn't publish the `ocamllsp/jump` capability then this notification is displayed. 

## Commands
One command is published `ocaml.jump` which triggers the process.

## Demo

https://github.com/user-attachments/assets/84734598-c322-407f-960e-3649b05543a5

## References
- QuickPick : [https://code.visualstudio.com/api/ux-guidelines/quick-picks](https://code.visualstudio.com/api/ux-guidelines/quick-picks)

cc @voodoos 