### PR TITLE
Navigating Typed Holes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 # Unreleased
 
-- Add `ocaml.navigate-typed-holes` to navigate to different typed holes. (#1666)
+- Add `ocaml.navigate-typed-holes` to navigate between typed holes. (#1666)
 
 ## 1.25.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 # Unreleased
 
+- Add `ocaml.navigate-typed-holes` to navigate to different typed holes. (#1666)
+
 ## 1.25.0
 
 - Add `ocaml.search-by-type` to search for values using their type signature (#1626)

--- a/package.json
+++ b/package.json
@@ -267,6 +267,11 @@
         "command": "ocaml.search-by-type",
         "category": "OCaml",
         "title": "Search a value by type or polarity"
+      },
+      {
+        "command": "ocaml.navigate-typed-holes",
+        "category": "OCaml",
+        "title": "Lists typed holes in the file for navigation."
       }
     ],
     "configuration": {
@@ -310,6 +315,11 @@
           "type": "boolean",
           "default": false,
           "markdownDescription": "Enable/Disable syntax documentation"
+        },
+        "ocaml.commands.typedHoles.constructAfterNavigate": {
+          "type": "boolean",
+          "default": false,
+          "markdownDescription": "When enabled, list values that can fill a typed hole after navigating to it."
         },
         "ocaml.commands.construct.recursiveCalls": {
           "type": "boolean",
@@ -1081,6 +1091,10 @@
         {
           "command": "ocaml.search-by-type",
           "when": "editorLangId == ocaml || editorLangId == ocaml.interface || editorLangId == reason || editorLangId == ocaml.ocamllex"
+        },
+        {
+          "command": "ocaml.navigate-typed-holes",
+          "when": "editorLangId == ocaml || editorLangId == ocaml.interface || editorLangId == reason"
         }
       ],
       "editor/title": [

--- a/package.json
+++ b/package.json
@@ -271,7 +271,7 @@
       {
         "command": "ocaml.navigate-typed-holes",
         "category": "OCaml",
-        "title": "Lists typed holes in the file for navigation."
+        "title": "List typed holes in the file for navigation."
       }
     ],
     "configuration": {

--- a/package.json
+++ b/package.json
@@ -271,7 +271,7 @@
       {
         "command": "ocaml.navigate-typed-holes",
         "category": "OCaml",
-        "title": "List typed holes in the file for navigation."
+        "title": "List typed holes in the file for navigation"
       }
     ],
     "configuration": {

--- a/src/extension_commands.ml
+++ b/src/extension_commands.ml
@@ -993,15 +993,9 @@ module Navigate_holes = struct
     move_to_hole range text_editor
   ;;
 
-  let display_results
-        current_position
-        (results : Range.t list)
-        text_editor
-        client
-        instance
-    =
+  let display_results (results : Range.t list) text_editor client instance =
     let open Promise.Syntax in
-    let selected_item = ref None in
+    let selected_item = ref false in
     let text_document = TextEditor.document text_editor in
     let quickPickItems =
       List.map results ~f:(fun res ->
@@ -1062,7 +1056,7 @@ module Navigate_holes = struct
                   | Some range ->
                     let range = Range.t_of_json range in
                     let* () = jump_to_hole range text_editor in
-                    selected_item := Some range;
+                    selected_item := true;
                     QuickPick.hide quickPick;
                     (match
                        Settings.(get server_typedHolesConstructAfterNavigate_setting)
@@ -1080,31 +1074,33 @@ module Navigate_holes = struct
         ()
     in
     let _disposable =
+      let initial_selection = TextEditor.selection text_editor in
       QuickPick.onDidHide
         quickPick
         ~listener:(fun () ->
-          match !selected_item with
-          | None ->
+          if !selected_item
+          then ()
+          else
             ignore
-              (let* () =
-                 jump_to_hole
-                   (Range.makePositions ~start:current_position ~end_:current_position)
-                   text_editor
-               in
-               QuickPick.dispose quickPick |> Promise.return)
-          | Some _ -> QuickPick.dispose quickPick)
+              (TextEditor.set_selection text_editor initial_selection;
+               TextEditor.revealRange
+                 text_editor
+                 ~range:(Selection.to_range initial_selection)
+                 ~revealType:TextEditorRevealType.InCenterIfOutsideViewport
+                 ());
+          QuickPick.dispose quickPick)
         ()
     in
     QuickPick.show quickPick
   ;;
 
-  let handle_hole_navigation current_position text_editor client instance =
+  let handle_hole_navigation text_editor client instance =
     let open Promise.Syntax in
     let doc = TextEditor.document text_editor in
     let+ hole_positions = send_request_to_lsp client doc in
     match hole_positions with
     | [] -> show_message `Info "No typed holes found in the file."
-    | holes -> display_results current_position holes text_editor client instance
+    | holes -> display_results holes text_editor client instance
   ;;
 
   let _holes =
@@ -1131,8 +1127,7 @@ module Navigate_holes = struct
              `Warn
              "The installed version of `ocamllsp` does not support typed hole navigation"
          | Some (client, _) ->
-           let current_position = TextEditor.selection text_editor |> Selection.active in
-           let _ = handle_hole_navigation current_position text_editor client instance in
+           let _ = handle_hole_navigation text_editor client instance in
            ())
     in
     command Extension_consts.Commands.navigate_typed_holes handler

--- a/src/extension_commands.ml
+++ b/src/extension_commands.ml
@@ -968,14 +968,7 @@ module Navigate_holes = struct
     Custom_requests.send_request client Custom_requests.typedHoles uri
   ;;
 
-  let jump_to_hole range text_editor =
-    let open Promise.Syntax in
-    let+ _ =
-      Window.showTextDocument
-        ~document:(TextEditor.document text_editor)
-        ~preserveFocus:true
-        ()
-    in
+  let move_to_hole range text_editor =
     let new_selection =
       let anchor = Range.start range in
       let active = Range.end_ range in
@@ -989,12 +982,15 @@ module Navigate_holes = struct
       ()
   ;;
 
-  let move_to_hole range text_editor =
-    TextEditor.revealRange
-      text_editor
-      ~range
-      ~revealType:TextEditorRevealType.InCenterIfOutsideViewport
-      ()
+  let jump_to_hole range text_editor =
+    let open Promise.Syntax in
+    let+ _ =
+      Window.showTextDocument
+        ~document:(TextEditor.document text_editor)
+        ~preserveFocus:true
+        ()
+    in
+    move_to_hole range text_editor
   ;;
 
   let display_results (results : Range.t list) text_editor client instance =

--- a/src/extension_commands.ml
+++ b/src/extension_commands.ml
@@ -1038,7 +1038,7 @@ module Navigate_holes = struct
         ~enabled:true
         ~placeholder:"Use arrow keys to preview / Select to jump to it"
         ~selectedItems:[]
-        ~ignoreFocusOut:true
+        ~ignoreFocusOut:false
         ~items:quickPickItems
         ~buttons:[]
         ()

--- a/src/extension_commands.ml
+++ b/src/extension_commands.ml
@@ -853,7 +853,7 @@ module Search_by_type = struct
         ()
     in
     let _disposable =
-      QuickPick.onDidHide quickPick ~listener:(fun () -> QuickPick.dispose quickPick)
+      QuickPick.onDidHide quickPick ~listener:(fun () -> QuickPick.dispose quickPick) ()
     in
     QuickPick.show quickPick
 
@@ -1101,18 +1101,20 @@ module Navigate_holes = struct
         ()
     in
     let _disposable =
-      QuickPick.onDidHide quickPick ~listener:(fun () ->
-        match !selected_item with
-        | None ->
-          ignore
-            (let* () =
-               jump_to_hole
-                 (Range.makePositions ~start:current_position ~end_:current_position)
-                 text_editor
-             in
-             QuickPick.dispose quickPick |> Promise.return)
-        | Some _ ->
-          QuickPick.dispose quickPick)
+      QuickPick.onDidHide
+        quickPick
+        ~listener:(fun () ->
+          match !selected_item with
+          | None ->
+            ignore
+              (let* () =
+                 jump_to_hole
+                   (Range.makePositions ~start:current_position ~end_:current_position)
+                   text_editor
+               in
+               QuickPick.dispose quickPick |> Promise.return)
+          | Some _ -> QuickPick.dispose quickPick)
+        ()
     in
     QuickPick.show quickPick
   ;;

--- a/src/extension_commands.ml
+++ b/src/extension_commands.ml
@@ -853,7 +853,7 @@ module Search_by_type = struct
         ()
     in
     let _disposable =
-      QuickPick.onDidHide quickPick ~listener:(fun () -> QuickPick.dispose quickPick) ()
+      QuickPick.onDidHide quickPick ~listener:(fun () -> QuickPick.dispose quickPick)
     in
     QuickPick.show quickPick
 
@@ -1028,24 +1028,6 @@ module Navigate_holes = struct
         ~ignoreFocusOut:true
         ~items:quickPickItems
         ~buttons:[]
-        ()
-    in
-    let _disposable =
-      QuickPick.onDidChangeSelection
-        quickPick
-        ~listener:(fun selection ->
-          match selection with
-          | item :: _ ->
-            let range_string = QuickPickItem.description item in
-            (match range_string with
-             | Some r ->
-               (match Jsonoo.try_parse_opt r with
-                | Some range ->
-                  let range = Range.t_of_json range in
-                  move_to_hole range text_editor
-                | None -> ())
-             | _ -> ())
-          | _ -> ())
         ()
     in
     let _disposable =

--- a/src/extension_commands.ml
+++ b/src/extension_commands.ml
@@ -1086,14 +1086,11 @@ module Navigate_holes = struct
                        Settings.(get server_typedHolesConstructAfterNavigate_setting)
                      with
                      | Some true ->
-                       let+ _ =
-                         Construct.process_construct
-                           (Range.end_ range)
-                           text_editor
-                           client
-                           instance
-                       in
-                       ()
+                       Construct.process_construct
+                         (Range.end_ range)
+                         text_editor
+                         client
+                         instance
                      | Some false | None -> Promise.return ())
                   | None -> Promise.return ())
                | _ -> Promise.return ())

--- a/src/extension_commands.ml
+++ b/src/extension_commands.ml
@@ -1032,12 +1032,11 @@ module Navigate_holes = struct
             let range_string = QuickPickItem.description item in
             (match range_string with
              | Some r ->
-               ignore
-                 (match Jsonoo.try_parse_opt r with
-                  | Some range ->
-                    let range = Range.t_of_json range in
-                    move_to_hole range text_editor
-                  | None -> ())
+               (match Jsonoo.try_parse_opt r with
+                | Some range ->
+                  let range = Range.t_of_json range in
+                  move_to_hole range text_editor
+                | None -> ())
              | _ -> ())
           | _ -> ())
         ()
@@ -1051,12 +1050,11 @@ module Navigate_holes = struct
             let range_string = QuickPickItem.description item in
             (match range_string with
              | Some r ->
-               ignore
-                 (match Jsonoo.try_parse_opt r with
-                  | Some range ->
-                    let range = Range.t_of_json range in
-                    move_to_hole range text_editor
-                  | None -> ())
+               (match Jsonoo.try_parse_opt r with
+                | Some range ->
+                  let range = Range.t_of_json range in
+                  move_to_hole range text_editor
+                | None -> ())
              | _ -> ())
           | _ -> ())
         ()

--- a/src/extension_commands.ml
+++ b/src/extension_commands.ml
@@ -1124,12 +1124,8 @@ module Navigate_holes = struct
     let doc = TextEditor.document text_editor in
     let+ hole_positions = send_request_to_lsp client doc in
     match hole_positions with
-    | [] ->
-      show_message `Info "No typed holes found in the file.";
-      ()
-    | holes ->
-      let _ = display_results current_position holes text_editor client instance in
-      ()
+    | [] -> show_message `Info "No typed holes found in the file."
+    | holes -> display_results current_position holes text_editor client instance
   ;;
 
   let _holes =

--- a/src/extension_commands.ml
+++ b/src/extension_commands.ml
@@ -1040,6 +1040,7 @@ module Navigate_holes = struct
         ~selectedItems:[]
         ~ignoreFocusOut:false
         ~items:quickPickItems
+        ~matchOnDescription:true
         ~buttons:[]
         ()
     in

--- a/src/extension_consts.ml
+++ b/src/extension_consts.ml
@@ -36,6 +36,7 @@ module Commands = struct
   let construct = ocaml_prefixed "construct"
   let merlin_jump = ocaml_prefixed "jump"
   let search_by_type = ocaml_prefixed "search-by-type"
+  let navigate_typed_holes = ocaml_prefixed "navigate-typed-holes"
 end
 
 module Command_errors = struct

--- a/src/settings.ml
+++ b/src/settings.ml
@@ -149,6 +149,14 @@ let server_syntaxDocumentation_setting =
     ~to_json:Jsonoo.Encode.bool
 ;;
 
+let server_typedHolesConstructAfterNavigate_setting =
+  create_setting
+    ~scope:ConfigurationTarget.Workspace
+    ~key:"ocaml.commands.typedHoles.constructAfterNavigate"
+    ~of_json:Jsonoo.Decode.bool
+    ~to_json:Jsonoo.Encode.bool
+;;
+
 let server_constructRecursiveCalls_setting =
   create_setting
     ~scope:ConfigurationTarget.Workspace

--- a/src/settings.mli
+++ b/src/settings.mli
@@ -39,4 +39,5 @@ val server_codelens_setting : bool setting
 val server_extendedHover_setting : bool setting
 val server_duneDiagnostics_setting : bool setting
 val server_syntaxDocumentation_setting : bool setting
+val server_typedHolesConstructAfterNavigate_setting : bool setting
 val server_constructRecursiveCalls_setting : bool setting

--- a/src/treeview_commands.ml
+++ b/src/treeview_commands.ml
@@ -87,8 +87,7 @@ let type_search_item =
 let navigate_holes_item =
   let icon = `ThemeIcon (Vscode.ThemeIcon.make ~id:"breakpoints-activate" ()) in
   let label =
-    `TreeItemLabel
-      (Vscode.TreeItemLabel.create ~label:"Navigate between typed holes" ())
+    `TreeItemLabel (Vscode.TreeItemLabel.create ~label:"Navigate between typed holes" ())
   in
   let item = Vscode.TreeItem.make_label ~label () in
   let command =

--- a/src/treeview_commands.ml
+++ b/src/treeview_commands.ml
@@ -88,7 +88,7 @@ let navigate_holes_item =
   let icon = `ThemeIcon (Vscode.ThemeIcon.make ~id:"breakpoints-activate" ()) in
   let label =
     `TreeItemLabel
-      (Vscode.TreeItemLabel.create ~label:"Navigate to different typed holes" ())
+      (Vscode.TreeItemLabel.create ~label:"Navigate between typed holes" ())
   in
   let item = Vscode.TreeItem.make_label ~label () in
   let command =

--- a/src/treeview_commands.ml
+++ b/src/treeview_commands.ml
@@ -84,8 +84,32 @@ let type_search_item =
   item
 ;;
 
+let navigate_holes_item =
+  let icon = `ThemeIcon (Vscode.ThemeIcon.make ~id:"breakpoints-activate" ()) in
+  let label =
+    `TreeItemLabel
+      (Vscode.TreeItemLabel.create ~label:"Navigate to different typed holes" ())
+  in
+  let item = Vscode.TreeItem.make_label ~label () in
+  let command =
+    Vscode.Command.create
+      ~title:"Navigate typed holes"
+      ~command:"ocaml.navigate-typed-holes"
+      ()
+  in
+  Vscode.TreeItem.set_iconPath item icon;
+  Vscode.TreeItem.set_command item command;
+  item
+;;
+
 let items =
-  [ select_sandbox_item; terminal_item; construct_item; jump_item; type_search_item ]
+  [ select_sandbox_item
+  ; terminal_item
+  ; construct_item
+  ; jump_item
+  ; type_search_item
+  ; navigate_holes_item
+  ]
 ;;
 
 let getTreeItem ~element = `Value element


### PR DESCRIPTION
# Navigating Typed Holes

## Introduction
This PR implements navigation of typed holes.

## UI
Results are displayed in a [QuickPick](https://code.visualstudio.com/api/ux-guidelines/quick-picks) component where upon selection, the cursor is moved to the selected typed hole.

## UX
This command can be triggered from the command pallet "Navigate to different typed holes"

## Notifications
- `Ocamllsp warning`: If `ocamllsp` is not running at the time the command is invoked, this notification is displayed.
- `No support for requests`: If the version of ocamllsp doesn't publish the `ocamllsp/typedHoles` capability then this notification is displayed. 

## Commands
One command is published `ocaml.navigate-typed-holes` which triggers the process.

## Demo

https://github.com/user-attachments/assets/b14aa44e-ea00-494c-9164-83464bee0f05

## References
- QuickPick : [https://code.visualstudio.com/api/ux-guidelines/quick-picks](https://code.visualstudio.com/api/ux-guidelines/quick-picks)

cc @voodoos cc @awilliambauer