### PR TITLE
Add reason language to ast_editor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 # Unreleased
 
+- Add `.re` file extension support. (#1685)
+
 ## 1.27.0
 
 - Add `ocaml.type-selection` that shows the type of the expression around the


### PR DESCRIPTION
## Description 

This PR adds reasonml to ast_editor to be able to see AST and Pp

## Screenshots

Working with both ocaml and reason

![Captura de Tela 2024-12-11 às 17 45 26](https://github.com/user-attachments/assets/bcca0546-6401-4897-9eb6-49208fbabbd3)
![Captura de Tela 2024-12-11 às 18 24 14](https://github.com/user-attachments/assets/11d9ebb2-8e4f-44f8-8baa-014385ad4fe7)


## How to test

- Follow this steps: https://github.com/ocamllabs/vscode-ocaml-platform/blob/88cbda69761298bde70803d5792c90b497a4256f/CONTRIBUTING.md#L27
- On the debug view, create a `.re` file
- To see the pp you need to build it to have the `.pp.ml` file
