### PR TITLE
Display message instead of empty list

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 # Unreleased
 
+- Construct: display a message when construct list is empty. (#1695)
+
 ## 1.26.0
 
 - Add `ocaml.navigate-typed-holes` to navigate between typed holes. (#1666)


### PR DESCRIPTION
When construct is empty, display an error message instead of an empty quickPick. 

cc @voodoos 