### PR TITLE
Jump enhance

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 # Unreleased
 
+- MerlinJump: display a message when target list is empty and allow preview of targets. (#1704)
+
 ## 1.26.1
 
 - Construct: display a message when construct list is empty. (#1695)

--- a/src/extension_commands.ml
+++ b/src/extension_commands.ml
@@ -158,6 +158,15 @@ let _open_ocamllsp_output_pane, _open_ocaml_platform_ext_pane, _open_ocaml_comma
       (handler Output.command_output_channel) )
 ;;
 
+let show_selection selection text_editor =
+  TextEditor.set_selection text_editor selection;
+  TextEditor.revealRange
+    text_editor
+    ~range:(Selection.to_range selection)
+    ~revealType:TextEditorRevealType.InCenterIfOutsideViewport
+    ()
+;;
+
 module Holes_commands : sig
   val _jump_to_prev_hole : t
   val _jump_to_next_hole : t


### PR DESCRIPTION
This PR fixes the empty list bug (displays a message rather than an empty quick pick) and also allows the user to preview the different jump targets using the arrow keys without jumping to them.

cc @voodoos 