### PR TITLE
Improve quick peek with highlighting in both the jump and holes commands

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@
   can be used to shrink the selection and increase the verbosity of the
   displayed type. (#1675)
 
+- Jump and holes commands: display message when target list is empty and allow
+  preview of available targets (#1705)
+
 ## 1.26.1
 
 - Construct: display a message when construct list is empty. (#1695)

--- a/src/extension_commands.ml
+++ b/src/extension_commands.ml
@@ -804,9 +804,6 @@ module MerlinJump = struct
                 (TextDocument.getWordRangeAtPosition
                    text_document
                    ~position:(Range.start range)
-                   ~regex:
-                     (Js_of_ocaml.Regexp.regexp
-                        "\\(?\\b(let|fun|match|module|module\\s*type|\\w+)(?=\\s*(?:->|\\s|\\)|$))")
                    ())
                 ~default:range
             in

--- a/src/extension_commands.ml
+++ b/src/extension_commands.ml
@@ -779,7 +779,7 @@ module MerlinJump = struct
       QuickPick.onDidChangeActive
         quickPick
         ~listener:(function
-          | { position; target } :: _ ->
+          | { position; target; _ } :: _ ->
             let range =
               Range.makePositions
                 ~start:position

--- a/src/extension_commands.ml
+++ b/src/extension_commands.ml
@@ -779,7 +779,7 @@ module MerlinJump = struct
       QuickPick.onDidChangeActive
         quickPick
         ~listener:(function
-          | { position; item; target } :: _ ->
+          | { position; target } :: _ ->
             let range =
               Range.makePositions
                 ~start:position

--- a/src/extension_commands.ml
+++ b/src/extension_commands.ml
@@ -736,40 +736,37 @@ module MerlinJump = struct
     show_selection (Selection.makePositions ~anchor:position ~active:position) text_editor
   ;;
 
-  module QuickPickItemWithPosition = struct
+  module JumpQuickPickItem = struct
     type t =
       { item : QuickPickItem.t
       ; position : Position.t
-      ; target : string
       }
 
     let t_of_js js =
       let position = Ojs.get_prop_ascii js "position" |> Position.t_of_js in
       let item = QuickPickItem.t_of_js js in
-      let target = Ojs.get_prop_ascii js "target" |> Ojs.string_of_js in
-      { item; position; target }
+      { item; position }
     ;;
 
     let t_to_js t =
       let item = QuickPickItem.t_to_js t.item in
       Ojs.set_prop_ascii item "position" (Position.t_to_js t.position);
-      Ojs.set_prop_ascii item "target" (Ojs.string_to_js t.target);
       item
     ;;
   end
 
-  module QuickPick = Vscode.QuickPick.Make (QuickPickItemWithPosition)
+  module QuickPick = Vscode.QuickPick.Make (JumpQuickPickItem)
 
   let display_results (results : Custom_requests.Merlin_jump.response) text_editor =
     let selected_item = ref false in
     let quickPickItems =
       List.map results ~f:(fun (target, position) ->
         let item = (QuickPickItem.create ~label:("Jump to nearest " ^ target)) () in
-        { QuickPickItemWithPosition.item; position; target })
+        { JumpQuickPickItem.item; position })
     in
     let quickPick =
       QuickPick.set
-        (Window.createQuickPick (module QuickPickItemWithPosition) ())
+        (Window.createQuickPick (module JumpQuickPickItem) ())
         ~title:"Available Jump Targets"
         ~activeItems:[]
         ~busy:false

--- a/src/extension_commands.ml
+++ b/src/extension_commands.ml
@@ -158,6 +158,15 @@ let _open_ocamllsp_output_pane, _open_ocaml_platform_ext_pane, _open_ocaml_comma
       (handler Output.command_output_channel) )
 ;;
 
+let show_selection selection text_editor =
+  TextEditor.set_selection text_editor selection;
+  TextEditor.revealRange
+    text_editor
+    ~range:(Selection.to_range selection)
+    ~revealType:TextEditorRevealType.InCenterIfOutsideViewport
+    ()
+;;
+
 module Holes_commands : sig
   val _jump_to_prev_hole : t
   val _jump_to_next_hole : t

--- a/src/extension_commands.ml
+++ b/src/extension_commands.ml
@@ -778,7 +778,7 @@ module MerlinJump = struct
       QuickPick.onDidChangeActive
         quickPick
         ~listener:(function
-          | { position; target; _ } :: _ ->
+          | { position; _ } :: _ ->
             let range =
               Range.makePositions
                 ~start:position

--- a/src/extension_commands.ml
+++ b/src/extension_commands.ml
@@ -753,7 +753,6 @@ module MerlinJump = struct
   module QuickPick = Vscode.QuickPick.Make (QuickPickItemWithPosition)
 
   let display_results (results : Custom_requests.Merlin_jump.response) text_editor =
-    let open Promise.Syntax in
     let selected_item = ref false in
     let quickPickItems =
       List.map results ~f:(fun (target, position) ->
@@ -785,7 +784,7 @@ module MerlinJump = struct
                 ~start:position
                 ~end_:
                   (Position.make
-                     ~character:(Position.character position + String.length target)
+                     ~character:(Position.character position + 1)
                      ~line:(Position.line position))
             in
             show_selection
@@ -802,8 +801,8 @@ module MerlinJump = struct
           match QuickPick.selectedItems quickPick with
           | Some (item :: _) ->
             ignore
-              (let position = item.position in
-               let* () = jump_to_position text_editor position in
+              (let open Promise.Syntax in
+               let* () = jump_to_position text_editor item.position in
                selected_item := true;
                Promise.return ())
           | _ -> ())

--- a/src/extension_commands.ml
+++ b/src/extension_commands.ml
@@ -863,8 +863,8 @@ module MerlinJump = struct
           if not(!event_fired || !selected_item)
           then show_selection initial_selection text_editor;
           Decorations.remove_all_highlights text_editor;
-          Disposable.dispose selection_listener_disposable);
-          QuickPick.dispose quickPick
+          Disposable.dispose selection_listener_disposable;
+          QuickPick.dispose quickPick)
         ()
     in
     QuickPick.show quickPick

--- a/src/extension_commands.ml
+++ b/src/extension_commands.ml
@@ -218,7 +218,7 @@ end
 (**  If the user hits the ESC key, this should go back to the initial_selection,
      otherwise the current position of the click is used *)
 let move_cursor_after_selection_change event_fired () =
-  let onDidChangeTextEditorSelection_listener event = event_fired := true in
+  let onDidChangeTextEditorSelection_listener _event = event_fired := true in
   let listener = onDidChangeTextEditorSelection_listener in
   Window.onDidChangeTextEditorSelection () ~listener ()
 ;;
@@ -860,7 +860,7 @@ module MerlinJump = struct
       QuickPick.onDidHide
         quickPick
         ~listener:(fun () ->
-          if not(!event_fired || !selected_item)
+          if not (!event_fired || !selected_item)
           then show_selection initial_selection text_editor;
           Decorations.remove_all_highlights text_editor;
           Disposable.dispose selection_listener_disposable;

--- a/src/extension_commands.ml
+++ b/src/extension_commands.ml
@@ -860,9 +860,8 @@ module MerlinJump = struct
       QuickPick.onDidHide
         quickPick
         ~listener:(fun () ->
-          if !event_fired || !selected_item
-          then ()
-          else show_selection initial_selection text_editor;
+          if not(!event_fired || !selected_item)
+          then show_selection initial_selection text_editor;
           Decorations.remove_all_highlights text_editor;
           Disposable.dispose selection_listener_disposable);
           QuickPick.dispose quickPick

--- a/src/extension_commands.ml
+++ b/src/extension_commands.ml
@@ -206,17 +206,14 @@ let show_selection selection text_editor =
 ;;
 
 (**  If the user hits the ESC key, this should go back to the initial_selection,
-     otherwise the current position of the click *)
-let move_cursor_after_quickpick_close event_fired () =
+     otherwise the current position of the click is used *)
+let move_cursor_after_selection_change event_fired () =
   let onDidChangeTextEditorSelection_listener event =
     event_fired := true;
     let selections = TextEditorSelectionChangeEvent.selections event in
-    match TextEditorSelectionChangeEvent.kind event with
-    | TextEditorSelectionChangeKind.Keyboard | TextEditorSelectionChangeKind.Mouse ->
-      (match selections with
-       | [ selection ] ->
-         show_selection selection (TextEditorSelectionChangeEvent.textEditor event)
-       | _ -> ())
+    match selections with
+    | [ selection ] ->
+      show_selection selection (TextEditorSelectionChangeEvent.textEditor event)
     | _ -> ()
   in
   let listener = onDidChangeTextEditorSelection_listener in
@@ -859,7 +856,7 @@ module MerlinJump = struct
       let event_fired = ref false in
       let initial_selection = TextEditor.selection text_editor in
       let selection_listener_disposable =
-        move_cursor_after_quickpick_close event_fired ()
+        move_cursor_after_selection_change event_fired ()
       in
       QuickPick.onDidHide
         quickPick

--- a/src/extension_commands.ml
+++ b/src/extension_commands.ml
@@ -208,14 +208,7 @@ let show_selection selection text_editor =
 (**  If the user hits the ESC key, this should go back to the initial_selection,
      otherwise the current position of the click is used *)
 let move_cursor_after_selection_change event_fired () =
-  let onDidChangeTextEditorSelection_listener event =
-    event_fired := true;
-    let selections = TextEditorSelectionChangeEvent.selections event in
-    match selections with
-    | [ selection ] ->
-      show_selection selection (TextEditorSelectionChangeEvent.textEditor event)
-    | _ -> ()
-  in
+  let onDidChangeTextEditorSelection_listener event = event_fired := true in
   let listener = onDidChangeTextEditorSelection_listener in
   Window.onDidChangeTextEditorSelection () ~listener ()
 ;;

--- a/src/extension_commands.ml
+++ b/src/extension_commands.ml
@@ -864,8 +864,8 @@ module MerlinJump = struct
           then ()
           else show_selection initial_selection text_editor;
           Decorations.remove_all_highlights text_editor;
-          QuickPick.dispose quickPick;
-          Disposable.dispose selection_listener_disposable)
+          Disposable.dispose selection_listener_disposable);
+          QuickPick.dispose quickPick
         ()
     in
     QuickPick.show quickPick


### PR DESCRIPTION
This PR 
- fixes the empty list bug (displays a message rather than an empty quick pick) 
- allows the user to preview the different jump targets using the arrow keys without jumping to them.

Match first word from position of interest

https://github.com/user-attachments/assets/cda4a8af-82e5-437b-80b6-377acf9c7085


cc @voodoos @awilliambauer