### PR TITLE
Automatically install or update ocaml-lsp-server 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 # Unreleased
 
+- Add one-click install option for ocaml-lsp-server (#1725)
+
 ## 1.28.0
 
 - Add `.re` file extension support. (#1685)

--- a/package.json
+++ b/package.json
@@ -117,7 +117,7 @@
       {
         "command": "ocaml.install-ocaml-lsp-server",
         "category": "OCaml",
-        "title": "Install OCaml-LSP Server`",
+        "title": "Install OCaml-LSP Server",
         "icon": {
           "light": "assets/plus-light.svg",
           "dark": "assets/plus-dark.svg"

--- a/package.json
+++ b/package.json
@@ -117,7 +117,7 @@
       {
         "command": "ocaml.install-ocaml-lsp-server",
         "category": "OCaml",
-        "title": "Install OCaml-Lsp Server`",
+        "title": "Install OCaml-LSP Server`",
         "icon": {
           "light": "assets/plus-light.svg",
           "dark": "assets/plus-dark.svg"

--- a/package.json
+++ b/package.json
@@ -115,6 +115,15 @@
         }
       },
       {
+        "command": "ocaml.install-ocaml-lsp-server",
+        "category": "OCaml",
+        "title": "Install OCaml-Lsp Server`",
+        "icon": {
+          "light": "assets/plus-light.svg",
+          "dark": "assets/plus-dark.svg"
+        }
+      },
+      {
         "command": "ocaml.upgrade-sandbox",
         "category": "OCaml",
         "title": "Upgrade Packages",

--- a/src/extension_commands.ml
+++ b/src/extension_commands.ml
@@ -59,7 +59,7 @@ let _select_sandbox =
 let _install_ocaml_lsp_server =
   let handler (instance : Extension_instance.t) ~args:_ =
     let open Promise.Syntax in
-    let (_ : unit Promise.t) =
+    let _ =
       let sandbox = Extension_instance.sandbox instance in
       let* ocamllsp_present = Extension_instance.check_ocaml_lsp_available sandbox in
       match ocamllsp_present with
@@ -80,7 +80,7 @@ let _install_ocaml_lsp_server =
 
 let _restart_language_server =
   let handler (instance : Extension_instance.t) ~args:_ =
-    let (_ : unit Promise.t) = Extension_instance.start_language_server instance in
+    let _ = Extension_instance.start_language_server instance in
     ()
   in
   command Extension_consts.Commands.restart_language_server handler

--- a/src/extension_commands.ml
+++ b/src/extension_commands.ml
@@ -70,8 +70,7 @@ let _install_ocaml_lsp_server =
         show_message `Info "Installing the latest release of ocaml-lsp-server...";
         let* () = Extension_instance.install_ocaml_lsp_server sandbox in
         show_message `Info "Installation of ocaml-lsp-server completed successfully.";
-        let+ () = Extension_instance.start_language_server instance in
-        ()
+        Extension_instance.start_language_server instance
     in
     ()
   in

--- a/src/extension_commands.ml
+++ b/src/extension_commands.ml
@@ -67,7 +67,6 @@ let _install_ocaml_lsp_server =
         show_message `Info "ocaml-lsp-server is already installed and up to date."
         |> Promise.return
       | Error _ ->
-        show_message `Info "Installing the latest release of ocaml-lsp-server...";
         let* () = Extension_instance.install_ocaml_lsp_server sandbox in
         show_message `Info "Installation of ocaml-lsp-server completed successfully.";
         Extension_instance.start_language_server instance

--- a/src/extension_commands.ml
+++ b/src/extension_commands.ml
@@ -64,11 +64,11 @@ let _install_ocaml_lsp_server =
       let* ocamllsp_present = Extension_instance.check_ocaml_lsp_available sandbox in
       match ocamllsp_present with
       | Ok () ->
-        show_message `Info "ocaml-lsp-server is already installed and up to date."
+        show_message `Info "OCaml-LSP server is already installed."
         |> Promise.return
       | Error _ ->
         let* () = Extension_instance.install_ocaml_lsp_server sandbox in
-        show_message `Info "Installation of ocaml-lsp-server completed successfully.";
+        show_message `Info "Installation of OCaml-LSP server completed successfully.";
         Extension_instance.start_language_server instance
     in
     ()
@@ -92,7 +92,7 @@ let _upgrade_ocaml_lsp_server =
         let+ _ = Extension_instance.start_language_server instance in
         show_message
           `Info
-          "ocaml-lsp-server upgraded successfully to version %s"
+          "OCaml-LSP server upgraded successfully to version %s"
           latest_version
     in
     ()

--- a/src/extension_commands.ml
+++ b/src/extension_commands.ml
@@ -287,7 +287,9 @@ end = struct
       show_message
         `Warn
         "The installed version of `ocamllsp` does not support typed holes. %s"
-        msg
+        msg;
+      let _ = Extension_instance.suggest_to_upgrade_ocaml_lsp_server () in
+      ()
   ;;
 
   let current_cursor_pos text_editor =
@@ -603,7 +605,9 @@ module Copy_type_under_cursor = struct
       show_message
         `Warn
         "The installed version of `ocamllsp` does not support type enclosings. %s"
-        msg
+        msg;
+      let _ = Extension_instance.suggest_to_upgrade_ocaml_lsp_server () in
+      ()
   ;;
 
   let get_enclosings text_editor client =
@@ -1143,7 +1147,9 @@ module Search_by_type = struct
            when ocaml_lsp_doesnt_support_search_by_type ocaml_lsp ->
            show_message
              `Warn
-             "The installed version of `ocamllsp` does not support type search"
+             "The installed version of `ocamllsp` does not support type search";
+           let _ = Extension_instance.suggest_to_upgrade_ocaml_lsp_server () in
+           ()
          | Some (client, _) -> show_query_input text_editor client)
     in
     command Extension_consts.Commands.search_by_type handler
@@ -1314,7 +1320,9 @@ module Navigate_holes = struct
            ->
            show_message
              `Warn
-             "The installed version of `ocamllsp` does not support typed hole navigation"
+             "The installed version of `ocamllsp` does not support typed hole navigation";
+           let _ = Extension_instance.suggest_to_upgrade_ocaml_lsp_server () in
+           ()
          | Some (client, _) ->
            let _ = handle_hole_navigation text_editor client instance in
            ())

--- a/src/extension_commands.ml
+++ b/src/extension_commands.ml
@@ -287,9 +287,7 @@ end = struct
       show_message
         `Warn
         "The installed version of `ocamllsp` does not support typed holes. %s"
-        msg;
-      let _ = Extension_instance.suggest_to_upgrade_ocaml_lsp_server () in
-      ()
+        msg
   ;;
 
   let current_cursor_pos text_editor =
@@ -605,9 +603,7 @@ module Copy_type_under_cursor = struct
       show_message
         `Warn
         "The installed version of `ocamllsp` does not support type enclosings. %s"
-        msg;
-      let _ = Extension_instance.suggest_to_upgrade_ocaml_lsp_server () in
-      ()
+        msg
   ;;
 
   let get_enclosings text_editor client =
@@ -1148,7 +1144,7 @@ module Search_by_type = struct
            show_message
              `Warn
              "The installed version of `ocamllsp` does not support type search";
-           let _ = Extension_instance.suggest_to_upgrade_ocaml_lsp_server () in
+           let _ = Ocaml_lsp.suggest_to_upgrade_ocaml_lsp_server () in
            ()
          | Some (client, _) -> show_query_input text_editor client)
     in
@@ -1321,7 +1317,7 @@ module Navigate_holes = struct
            show_message
              `Warn
              "The installed version of `ocamllsp` does not support typed hole navigation";
-           let _ = Extension_instance.suggest_to_upgrade_ocaml_lsp_server () in
+           let _ = Ocaml_lsp.suggest_to_upgrade_ocaml_lsp_server () in
            ()
          | Some (client, _) ->
            let _ = handle_hole_navigation text_editor client instance in

--- a/src/extension_commands.ml
+++ b/src/extension_commands.ml
@@ -64,8 +64,7 @@ let _install_ocaml_lsp_server =
       let* ocamllsp_present = Extension_instance.check_ocaml_lsp_available sandbox in
       match ocamllsp_present with
       | Ok () ->
-        show_message `Info "OCaml-LSP server is already installed."
-        |> Promise.return
+        show_message `Info "OCaml-LSP server is already installed." |> Promise.return
       | Error _ ->
         let* () = Extension_instance.install_ocaml_lsp_server sandbox in
         show_message `Info "Installation of OCaml-LSP server completed successfully.";

--- a/src/extension_commands.ml
+++ b/src/extension_commands.ml
@@ -56,6 +56,28 @@ let _select_sandbox =
   command Extension_consts.Commands.select_sandbox handler
 ;;
 
+let _install_ocaml_lsp_server =
+  let handler (instance : Extension_instance.t) ~args:_ =
+    let open Promise.Syntax in
+    let (_ : unit Promise.t) =
+      let sandbox = Extension_instance.sandbox instance in
+      let* ocamllsp_present = Extension_instance.check_ocaml_lsp_available sandbox in
+      match ocamllsp_present with
+      | Ok () ->
+        show_message `Info "ocaml-lsp-server is already installed and up to date."
+        |> Promise.return
+      | Error _ ->
+        show_message `Info "Installing the latest release of ocaml-lsp-server...";
+        let* () = Extension_instance.install_ocaml_lsp_server sandbox in
+        show_message `Info "Installation of ocaml-lsp-server completed successfully.";
+        let+ () = Extension_instance.start_language_server instance in
+        ()
+    in
+    ()
+  in
+  command Extension_consts.Commands.install_ocaml_lsp_server handler
+;;
+
 let _restart_language_server =
   let handler (instance : Extension_instance.t) ~args:_ =
     let (_ : unit Promise.t) = Extension_instance.start_language_server instance in

--- a/src/extension_commands.ml
+++ b/src/extension_commands.ml
@@ -86,13 +86,10 @@ let _upgrade_ocaml_lsp_server =
           (Extension_instance.ocaml_version_exn instance)
       with
       | Ok () -> Promise.return ()
-      | Error (`Msg (_error, latest_version)) ->
-        let* _ = Extension_instance.upgrade_ocaml_lsp_server sandbox latest_version in
+      | Error (`Msg _error) ->
+        let* _ = Extension_instance.upgrade_ocaml_lsp_server sandbox in
         let+ _ = Extension_instance.start_language_server instance in
-        show_message
-          `Info
-          "OCaml-LSP server upgraded successfully to version %s"
-          latest_version
+        show_message `Info "OCaml-LSP server upgraded successfully"
     in
     ()
   in
@@ -286,7 +283,7 @@ end = struct
         (Extension_instance.ocaml_version_exn instance)
     with
     | Ok () -> ()
-    | Error (`Msg (msg, _latest_version)) ->
+    | Error (`Msg msg) ->
       show_message
         `Warn
         "The installed version of `ocamllsp` does not support typed holes. %s"
@@ -602,7 +599,7 @@ module Copy_type_under_cursor = struct
         (Extension_instance.ocaml_version_exn instance)
     with
     | Ok () -> ()
-    | Error (`Msg (msg, _latest_version)) ->
+    | Error (`Msg msg) ->
       show_message
         `Warn
         "The installed version of `ocamllsp` does not support type enclosings. %s"

--- a/src/extension_commands.ml
+++ b/src/extension_commands.ml
@@ -59,7 +59,7 @@ let _select_sandbox =
 let _install_ocaml_lsp_server =
   let handler (instance : Extension_instance.t) ~args:_ =
     let open Promise.Syntax in
-    let _ =
+    let (_ : unit Promise.t) =
       let sandbox = Extension_instance.sandbox instance in
       let* ocamllsp_present = Extension_instance.check_ocaml_lsp_available sandbox in
       match ocamllsp_present with
@@ -101,7 +101,7 @@ let _upgrade_ocaml_lsp_server =
 
 let _restart_language_server =
   let handler (instance : Extension_instance.t) ~args:_ =
-    let _ = Extension_instance.start_language_server instance in
+    let (_ : unit Promise.t) = Extension_instance.start_language_server instance in
     ()
   in
   command Extension_consts.Commands.restart_language_server handler

--- a/src/extension_commands.ml
+++ b/src/extension_commands.ml
@@ -1141,10 +1141,12 @@ module Search_by_type = struct
          | None -> show_message `Warn "ocamllsp is not running"
          | Some (_client, ocaml_lsp)
            when ocaml_lsp_doesnt_support_search_by_type ocaml_lsp ->
-           show_message
-             `Warn
-             "The installed version of `ocamllsp` does not support type search";
-           let _ = Ocaml_lsp.suggest_to_upgrade_ocaml_lsp_server () in
+           let _ =
+             Ocaml_lsp.suggest_to_upgrade_ocaml_lsp_server
+               ~message:
+                 "The installed version of `ocamllsp` does not support type search."
+               ()
+           in
            ()
          | Some (client, _) -> show_query_input text_editor client)
     in
@@ -1314,10 +1316,13 @@ module Navigate_holes = struct
          | None -> show_message `Warn "ocamllsp is not running"
          | Some (_client, ocaml_lsp) when ocaml_lsp_doesnt_support_typed_holes ocaml_lsp
            ->
-           show_message
-             `Warn
-             "The installed version of `ocamllsp` does not support typed hole navigation";
-           let _ = Ocaml_lsp.suggest_to_upgrade_ocaml_lsp_server () in
+           let _ =
+             Ocaml_lsp.suggest_to_upgrade_ocaml_lsp_server
+               ~message:
+                 "The installed version of `ocamllsp` does not support typed hole \
+                  navigation."
+               ()
+           in
            ()
          | Some (client, _) ->
            let _ = handle_hole_navigation text_editor client instance in

--- a/src/extension_consts.ml
+++ b/src/extension_consts.ml
@@ -3,6 +3,7 @@ let ocaml_prefixed key = "ocaml." ^ key
 module Commands = struct
   let select_sandbox = ocaml_prefixed "select-sandbox"
   let install_ocaml_lsp_server = ocaml_prefixed "install-ocaml-lsp-server"
+  let upgrade_ocaml_lsp_server = ocaml_prefixed "update-ocaml-lsp-server"
   let restart_language_server = ocaml_prefixed "server.restart"
   let select_sandbox_and_open_terminal = ocaml_prefixed "open-terminal-select"
   let open_terminal = ocaml_prefixed "open-terminal"

--- a/src/extension_consts.ml
+++ b/src/extension_consts.ml
@@ -2,6 +2,7 @@ let ocaml_prefixed key = "ocaml." ^ key
 
 module Commands = struct
   let select_sandbox = ocaml_prefixed "select-sandbox"
+  let install_ocaml_lsp_server = ocaml_prefixed "install-ocaml-lsp-server"
   let restart_language_server = ocaml_prefixed "server.restart"
   let select_sandbox_and_open_terminal = ocaml_prefixed "open-terminal-select"
   let open_terminal = ocaml_prefixed "open-terminal"

--- a/src/extension_instance.ml
+++ b/src/extension_instance.ml
@@ -203,13 +203,13 @@ end = struct
   let suggest_to_upgrade_ocaml_lsp_server err =
     let open Promise.Syntax in
     let upgrade_lsp_text = "Upgrade OCaml-LSP server" in
-    let select_different_sanbox = "Select a different Sandbox" in
+    let select_different_sandbox = "Select a different Sandbox" in
     let+ selection =
       Window.showInformationMessage
         ~message:("OCaml-LSP server is not up to date: " ^ err)
         ~choices:
           [ upgrade_lsp_text, upgrade_lsp_text
-          ; select_different_sanbox, select_different_sanbox
+          ; select_different_sandbox, select_different_sandbox
           ]
         ()
     in
@@ -221,7 +221,7 @@ end = struct
           ~args:[]
       in
       ()
-    | Some choice when String.equal choice select_different_sanbox ->
+    | Some choice when String.equal choice select_different_sandbox ->
       let (_ : Ojs.t option Promise.t) =
         Vscode.Commands.executeCommand
           ~command:Extension_consts.Commands.select_sandbox

--- a/src/extension_instance.ml
+++ b/src/extension_instance.ml
@@ -217,8 +217,6 @@ end = struct
     match ocamllsp_present with
     | Ok () ->
     let+ res =
-      let open Promise.Result.Syntax in
-      let* () = check_ocaml_lsp_available t.sandbox in
       let client =
         let serverOptions = server_options t.sandbox in
         let clientOptions = client_options () in
@@ -276,6 +274,22 @@ let documentation_server_info () =
   StatusBarItem.set_command status_bar (`Command command);
   StatusBarItem.set_text status_bar "$(radio-tower) OCaml Documentation";
   status_bar
+;;
+
+let install_ocaml_lsp_server sandbox =
+  let open Promise.Syntax in
+  let+ () = Sandbox.install_packages sandbox [ "ocaml-lsp-server" ] in
+  let (_ : Ojs.t option Promise.t) =
+    Vscode.Commands.executeCommand
+      ~command:Extension_consts.Commands.refresh_switches
+      ~args:[]
+  in
+  let (_ : Ojs.t option Promise.t) =
+    Vscode.Commands.executeCommand
+      ~command:Extension_consts.Commands.refresh_sandbox
+      ~args:[]
+  in
+  ()
 ;;
 
 module Sandbox_info : sig

--- a/src/extension_instance.ml
+++ b/src/extension_instance.ml
@@ -125,28 +125,6 @@ let check_ocaml_lsp_available sandbox =
           current sandbox.")
 ;;
 
-let suggest_to_upgrade_ocaml_lsp_server () =
-  let open Promise.Syntax in
-  let upgrade_lsp_text = "Yes" in
-  let no_upgrade = "No" in
-  let* selection =
-    Window.showInformationMessage
-      ~message:"OCaml-LSP server is not up to date. Do you want to upgrade it?"
-      ~choices:[ upgrade_lsp_text, `Update_lsp; no_upgrade, `No_upgrade ]
-      ()
-  in
-  match selection with
-  | Some `Update_lsp ->
-    let+ (_ : Ojs.t option) =
-      Vscode.Commands.executeCommand
-        ~command:Extension_consts.Commands.upgrade_ocaml_lsp_server
-        ~args:[]
-    in
-    ()
-  | Some `No_upgrade -> Promise.return ()
-  | _ -> Promise.return ()
-;;
-
 module Language_server_init : sig
   val start_language_server : t -> unit Promise.t
 end = struct
@@ -255,9 +233,7 @@ end = struct
         t.lsp_client <- Some (client, ocaml_lsp);
         (match Ocaml_lsp.is_version_up_to_date ocaml_lsp (ocaml_version_exn t) with
          | Ok () -> ()
-         | Error (`Msg _) ->
-           let _ = suggest_to_upgrade_ocaml_lsp_server () in
-           ());
+         | Error (`Msg _) -> ());
         send_configuration
           client
           ~codelens:t.codelens

--- a/src/extension_instance.ml
+++ b/src/extension_instance.ml
@@ -253,8 +253,7 @@ end = struct
            "An error occurred starting the language server `ocamllsp`. %s"
            s)
     | Error _ ->
-      let+ () = suggest_to_install_ocaml_lsp_server () in
-      ()
+      suggest_to_install_ocaml_lsp_server ()
   ;;
 end
 

--- a/src/extension_instance.ml
+++ b/src/extension_instance.ml
@@ -290,13 +290,13 @@ let install_ocaml_lsp_server sandbox =
 
 let upgrade_ocaml_lsp_server sandbox =
   let open Promise.Syntax in
-  let+ () = Sandbox.upgrade_packages sandbox ~packages:[ "ocaml-lsp-server" ] in
-  let (_ : Ojs.t option Promise.t) =
+  let* () = Sandbox.upgrade_packages sandbox ~packages:[ "ocaml-lsp-server" ] in
+  let* (_ : Ojs.t option) =
     Vscode.Commands.executeCommand
       ~command:Extension_consts.Commands.refresh_switches
       ~args:[]
   in
-  let (_ : Ojs.t option Promise.t) =
+  let+ (_ : Ojs.t option) =
     Vscode.Commands.executeCommand
       ~command:Extension_consts.Commands.refresh_sandbox
       ~args:[]

--- a/src/extension_instance.ml
+++ b/src/extension_instance.ml
@@ -177,20 +177,18 @@ end = struct
           "Failed to start the language server. `ocaml-lsp-server` is not installed in \
            the current sandbox."
         ~choices:
-          [ install_lsp_text, install_lsp_text
-          ; select_different_sandbox, select_different_sandbox
-          ]
+          [ install_lsp_text, `Install_lsp; select_different_sandbox, `Select_sandbox ]
         ()
     in
     match selection with
-    | Some choice when String.equal choice install_lsp_text ->
+    | Some `Install_lsp ->
       let (_ : Ojs.t option Promise.t) =
         Vscode.Commands.executeCommand
           ~command:Extension_consts.Commands.install_ocaml_lsp_server
           ~args:[]
       in
       ()
-    | Some choice when String.equal choice select_different_sandbox ->
+    | Some `Select_sandbox ->
       let (_ : Ojs.t option Promise.t) =
         Vscode.Commands.executeCommand
           ~command:Extension_consts.Commands.select_sandbox
@@ -207,18 +205,18 @@ end = struct
     let+ selection =
       Window.showInformationMessage
         ~message:"OCaml-LSP server is not up to date. Do you want to upgrade it?"
-        ~choices:[ upgrade_lsp_text, upgrade_lsp_text; no_upgrade, no_upgrade ]
+        ~choices:[ upgrade_lsp_text, `Update_lsp; no_upgrade, `No_upgrade ]
         ()
     in
     match selection with
-    | Some choice when String.equal choice upgrade_lsp_text ->
+    | Some `Update_lsp ->
       let (_ : Ojs.t option Promise.t) =
         Vscode.Commands.executeCommand
           ~command:Extension_consts.Commands.upgrade_ocaml_lsp_server
           ~args:[]
       in
       ()
-    | Some choice when String.equal choice no_upgrade -> ()
+    | Some `No_upgrade -> ()
     | _ -> ()
   ;;
 
@@ -314,9 +312,9 @@ let install_ocaml_lsp_server sandbox =
   ()
 ;;
 
-let upgrade_ocaml_lsp_server sandbox latest_version =
+let upgrade_ocaml_lsp_server sandbox =
   let open Promise.Syntax in
-  let+ () = Sandbox.install_packages sandbox [ "ocaml-lsp-server=" ^ latest_version ] in
+  let+ () = Sandbox.upgrade_packages sandbox ~packages:[ "ocaml-lsp-server" ] in
   let (_ : Ojs.t option Promise.t) =
     Vscode.Commands.executeCommand
       ~command:Extension_consts.Commands.refresh_switches

--- a/src/extension_instance.ml
+++ b/src/extension_instance.ml
@@ -252,8 +252,7 @@ end = struct
            `Error
            "An error occurred starting the language server `ocamllsp`. %s"
            s)
-    | Error _ ->
-      suggest_to_install_ocaml_lsp_server ()
+    | Error _ -> suggest_to_install_ocaml_lsp_server ()
   ;;
 end
 

--- a/src/extension_instance.ml
+++ b/src/extension_instance.ml
@@ -200,17 +200,14 @@ end = struct
     | _ -> ()
   ;;
 
-  let suggest_to_upgrade_ocaml_lsp_server err =
+  let suggest_to_upgrade_ocaml_lsp_server () =
     let open Promise.Syntax in
-    let upgrade_lsp_text = "Upgrade OCaml-LSP server" in
-    let select_different_sandbox = "Select a different Sandbox" in
+    let upgrade_lsp_text = "Yes" in
+    let no_upgrade = "No" in
     let+ selection =
       Window.showInformationMessage
-        ~message:("OCaml-LSP server is not up to date: " ^ err)
-        ~choices:
-          [ upgrade_lsp_text, upgrade_lsp_text
-          ; select_different_sandbox, select_different_sandbox
-          ]
+        ~message:"OCaml-LSP server is not up to date. Do you want to upgrade it?"
+        ~choices:[ upgrade_lsp_text, upgrade_lsp_text; no_upgrade, no_upgrade ]
         ()
     in
     match selection with
@@ -221,13 +218,7 @@ end = struct
           ~args:[]
       in
       ()
-    | Some choice when String.equal choice select_different_sandbox ->
-      let (_ : Ojs.t option Promise.t) =
-        Vscode.Commands.executeCommand
-          ~command:Extension_consts.Commands.select_sandbox
-          ~args:[]
-      in
-      ()
+    | Some choice when String.equal choice no_upgrade -> ()
     | _ -> ()
   ;;
 

--- a/src/extension_instance.ml
+++ b/src/extension_instance.ml
@@ -170,7 +170,7 @@ end = struct
   let suggest_to_install_ocaml_lsp_server () =
     let open Promise.Syntax in
     let install_lsp_text = "Install OCaml-LSP server" in
-    let select_different_sanbox = "Select a different Sandbox" in
+    let select_different_sandbox = "Select a different Sandbox" in
     let+ selection =
       Window.showInformationMessage
         ~message:
@@ -178,7 +178,7 @@ end = struct
            the current sandbox."
         ~choices:
           [ install_lsp_text, install_lsp_text
-          ; select_different_sanbox, select_different_sanbox
+          ; select_different_sandbox, select_different_sandbox
           ]
         ()
     in
@@ -190,7 +190,7 @@ end = struct
           ~args:[]
       in
       ()
-    | Some choice when String.equal choice select_different_sanbox ->
+    | Some choice when String.equal choice select_different_sandbox ->
       let (_ : Ojs.t option Promise.t) =
         Vscode.Commands.executeCommand
           ~command:Extension_consts.Commands.select_sandbox
@@ -257,8 +257,8 @@ end = struct
         t.lsp_client <- Some (client, ocaml_lsp);
         (match Ocaml_lsp.is_version_up_to_date ocaml_lsp (ocaml_version_exn t) with
          | Ok () -> ()
-         | Error (`Msg (error, _latest_version)) ->
-           let _ = suggest_to_upgrade_ocaml_lsp_server error in
+         | Error (`Msg _) ->
+           let _ = suggest_to_upgrade_ocaml_lsp_server () in
            ());
         send_configuration
           client

--- a/src/extension_instance.ml
+++ b/src/extension_instance.ml
@@ -125,6 +125,28 @@ let check_ocaml_lsp_available sandbox =
           current sandbox.")
 ;;
 
+let suggest_to_upgrade_ocaml_lsp_server () =
+  let open Promise.Syntax in
+  let upgrade_lsp_text = "Yes" in
+  let no_upgrade = "No" in
+  let+ selection =
+    Window.showInformationMessage
+      ~message:"OCaml-LSP server is not up to date. Do you want to upgrade it?"
+      ~choices:[ upgrade_lsp_text, `Update_lsp; no_upgrade, `No_upgrade ]
+      ()
+  in
+  match selection with
+  | Some `Update_lsp ->
+    let (_ : Ojs.t option Promise.t) =
+      Vscode.Commands.executeCommand
+        ~command:Extension_consts.Commands.upgrade_ocaml_lsp_server
+        ~args:[]
+    in
+    ()
+  | Some `No_upgrade -> ()
+  | _ -> ()
+;;
+
 module Language_server_init : sig
   val start_language_server : t -> unit Promise.t
 end = struct
@@ -195,28 +217,6 @@ end = struct
           ~args:[]
       in
       ()
-    | _ -> ()
-  ;;
-
-  let suggest_to_upgrade_ocaml_lsp_server () =
-    let open Promise.Syntax in
-    let upgrade_lsp_text = "Yes" in
-    let no_upgrade = "No" in
-    let+ selection =
-      Window.showInformationMessage
-        ~message:"OCaml-LSP server is not up to date. Do you want to upgrade it?"
-        ~choices:[ upgrade_lsp_text, `Update_lsp; no_upgrade, `No_upgrade ]
-        ()
-    in
-    match selection with
-    | Some `Update_lsp ->
-      let (_ : Ojs.t option Promise.t) =
-        Vscode.Commands.executeCommand
-          ~command:Extension_consts.Commands.upgrade_ocaml_lsp_server
-          ~args:[]
-      in
-      ()
-    | Some `No_upgrade -> ()
     | _ -> ()
   ;;
 

--- a/src/extension_instance.ml
+++ b/src/extension_instance.ml
@@ -129,7 +129,7 @@ let suggest_to_upgrade_ocaml_lsp_server () =
   let open Promise.Syntax in
   let upgrade_lsp_text = "Yes" in
   let no_upgrade = "No" in
-  let+ selection =
+  let* selection =
     Window.showInformationMessage
       ~message:"OCaml-LSP server is not up to date. Do you want to upgrade it?"
       ~choices:[ upgrade_lsp_text, `Update_lsp; no_upgrade, `No_upgrade ]
@@ -137,14 +137,14 @@ let suggest_to_upgrade_ocaml_lsp_server () =
   in
   match selection with
   | Some `Update_lsp ->
-    let (_ : Ojs.t option Promise.t) =
+    let+ (_ : Ojs.t option) =
       Vscode.Commands.executeCommand
         ~command:Extension_consts.Commands.upgrade_ocaml_lsp_server
         ~args:[]
     in
     ()
-  | Some `No_upgrade -> ()
-  | _ -> ()
+  | Some `No_upgrade -> Promise.return ()
+  | _ -> Promise.return ()
 ;;
 
 module Language_server_init : sig
@@ -193,7 +193,7 @@ end = struct
     let open Promise.Syntax in
     let install_lsp_text = "Install OCaml-LSP server" in
     let select_different_sandbox = "Select a different Sandbox" in
-    let+ selection =
+    let* selection =
       Window.showInformationMessage
         ~message:
           "Failed to start the language server. `ocaml-lsp-server` is not installed in \
@@ -204,20 +204,20 @@ end = struct
     in
     match selection with
     | Some `Install_lsp ->
-      let (_ : Ojs.t option Promise.t) =
+      let+ (_ : Ojs.t option) =
         Vscode.Commands.executeCommand
           ~command:Extension_consts.Commands.install_ocaml_lsp_server
           ~args:[]
       in
       ()
     | Some `Select_sandbox ->
-      let (_ : Ojs.t option Promise.t) =
+      let+ (_ : Ojs.t option) =
         Vscode.Commands.executeCommand
           ~command:Extension_consts.Commands.select_sandbox
           ~args:[]
       in
       ()
-    | _ -> ()
+    | _ -> Promise.return ()
   ;;
 
   let client_capabilities =
@@ -298,13 +298,13 @@ let documentation_server_info () =
 
 let install_ocaml_lsp_server sandbox =
   let open Promise.Syntax in
-  let+ () = Sandbox.install_packages sandbox [ "ocaml-lsp-server" ] in
-  let (_ : Ojs.t option Promise.t) =
+  let* () = Sandbox.install_packages sandbox [ "ocaml-lsp-server" ] in
+  let* (_ : Ojs.t option) =
     Vscode.Commands.executeCommand
       ~command:Extension_consts.Commands.refresh_switches
       ~args:[]
   in
-  let (_ : Ojs.t option Promise.t) =
+  let+ (_ : Ojs.t option) =
     Vscode.Commands.executeCommand
       ~command:Extension_consts.Commands.refresh_sandbox
       ~args:[]

--- a/src/extension_instance.ml
+++ b/src/extension_instance.ml
@@ -108,6 +108,23 @@ let stop_server t =
     else Promise.return ()
 ;;
 
+let check_ocaml_lsp_available sandbox =
+  let ocaml_lsp_version sandbox =
+    Sandbox.get_command sandbox "ocamllsp" [ "--version" ]
+  in
+  let cwd =
+    match Workspace.workspaceFolders () with
+    | [ cwd ] -> Some (cwd |> WorkspaceFolder.uri |> Uri.fsPath |> Path.of_string)
+    | _ -> None
+  in
+  Cmd.output ?cwd (ocaml_lsp_version sandbox)
+  |> Promise.Result.fold
+       ~ok:(fun (_ : string) -> ())
+       ~error:(fun (_ : string) ->
+         "Sandbox initialization failed: `ocaml-lsp-server` is not installed in the \
+          current sandbox.")
+;;
+
 module Language_server_init : sig
   val start_language_server : t -> unit Promise.t
 end = struct

--- a/src/extension_instance.mli
+++ b/src/extension_instance.mli
@@ -7,6 +7,7 @@ val sandbox : t -> Sandbox.t
 val set_sandbox : t -> Sandbox.t -> unit
 val language_client : t -> LanguageClient.t option
 val ocaml_lsp : t -> Ocaml_lsp.t option
+val check_ocaml_lsp_available : Sandbox.t -> (unit, string) result Promise.t
 
 val start_documentation_server
   :  t

--- a/src/extension_instance.mli
+++ b/src/extension_instance.mli
@@ -18,6 +18,7 @@ val stop_documentation_server : t -> unit
 val lsp_client : t -> (LanguageClient.t * Ocaml_lsp.t) option
 val ocaml_version_exn : t -> Ocaml_version.t
 val start_language_server : t -> unit Promise.t
+val install_ocaml_lsp_server : Sandbox.t -> unit Promise.t
 
 val set_configuration
   :  t

--- a/src/extension_instance.mli
+++ b/src/extension_instance.mli
@@ -19,7 +19,7 @@ val lsp_client : t -> (LanguageClient.t * Ocaml_lsp.t) option
 val ocaml_version_exn : t -> Ocaml_version.t
 val start_language_server : t -> unit Promise.t
 val install_ocaml_lsp_server : Sandbox.t -> unit Promise.t
-val upgrade_ocaml_lsp_server : Sandbox.t -> string -> unit Promise.t
+val upgrade_ocaml_lsp_server : Sandbox.t -> unit Promise.t
 
 val set_configuration
   :  t

--- a/src/extension_instance.mli
+++ b/src/extension_instance.mli
@@ -20,7 +20,6 @@ val ocaml_version_exn : t -> Ocaml_version.t
 val start_language_server : t -> unit Promise.t
 val install_ocaml_lsp_server : Sandbox.t -> unit Promise.t
 val upgrade_ocaml_lsp_server : Sandbox.t -> unit Promise.t
-val suggest_to_upgrade_ocaml_lsp_server : unit -> unit Promise.t
 
 val set_configuration
   :  t

--- a/src/extension_instance.mli
+++ b/src/extension_instance.mli
@@ -20,6 +20,7 @@ val ocaml_version_exn : t -> Ocaml_version.t
 val start_language_server : t -> unit Promise.t
 val install_ocaml_lsp_server : Sandbox.t -> unit Promise.t
 val upgrade_ocaml_lsp_server : Sandbox.t -> unit Promise.t
+val suggest_to_upgrade_ocaml_lsp_server : unit -> unit Promise.t
 
 val set_configuration
   :  t

--- a/src/extension_instance.mli
+++ b/src/extension_instance.mli
@@ -19,6 +19,7 @@ val lsp_client : t -> (LanguageClient.t * Ocaml_lsp.t) option
 val ocaml_version_exn : t -> Ocaml_version.t
 val start_language_server : t -> unit Promise.t
 val install_ocaml_lsp_server : Sandbox.t -> unit Promise.t
+val upgrade_ocaml_lsp_server : Sandbox.t -> string -> unit Promise.t
 
 val set_configuration
   :  t

--- a/src/ocaml_lsp.ml
+++ b/src/ocaml_lsp.ml
@@ -230,12 +230,11 @@ let is_version_up_to_date t ocaml_v =
           | None -> sprintf "to %s" new_
           | Some old -> sprintf "from %s to %s" old new_
         in
-        ( sprintf
-            "There is a newer version of ocaml-lsp-server available. Consider upgrading \
-             %s. Hint: $ opam install ocaml-lsp-server=%s and restart the lsp server"
-            upgrade
-            new_
-        , new_ )
+        sprintf
+          "There is a newer version of ocaml-lsp-server available. Consider upgrading \
+           %s. Hint: $ opam install ocaml-lsp-server=%s and restart the lsp server"
+          upgrade
+          new_
     in
     `Msg msg)
 ;;

--- a/src/ocaml_lsp.ml
+++ b/src/ocaml_lsp.ml
@@ -199,6 +199,28 @@ let available_versions version =
   List.Assoc.find lsp_versions ~equal:Poly.equal prefix
 ;;
 
+let suggest_to_upgrade_ocaml_lsp_server () =
+  let open Promise.Syntax in
+  let upgrade_lsp_text = "Yes" in
+  let no_upgrade = "No" in
+  let* selection =
+    Window.showInformationMessage
+      ~message:"OCaml-LSP server is not up to date. Do you want to upgrade it?"
+      ~choices:[ upgrade_lsp_text, `Update_lsp; no_upgrade, `No_upgrade ]
+      ()
+  in
+  match selection with
+  | Some `Update_lsp ->
+    let+ (_ : Ojs.t option) =
+      Vscode.Commands.executeCommand
+        ~command:Extension_consts.Commands.upgrade_ocaml_lsp_server
+        ~args:[]
+    in
+    ()
+  | Some `No_upgrade -> Promise.return ()
+  | _ -> Promise.return ()
+;;
+
 let is_version_up_to_date t ocaml_v =
   let ocamllsp_version = get_version_from_serverInfo t in
   let res =
@@ -222,6 +244,7 @@ let is_version_up_to_date t ocaml_v =
             else Error (`Newer_available (Some v, available.(last)))))
   in
   Result.map_error res ~f:(fun err ->
+    let _ = suggest_to_upgrade_ocaml_lsp_server () in
     let msg =
       match err with
       | `Newer_available (old, new_) ->

--- a/src/ocaml_lsp.ml
+++ b/src/ocaml_lsp.ml
@@ -244,7 +244,6 @@ let is_version_up_to_date t ocaml_v =
             else Error (`Newer_available (Some v, available.(last)))))
   in
   Result.map_error res ~f:(fun err ->
-    let _ = suggest_to_upgrade_ocaml_lsp_server () in
     let msg =
       match err with
       | `Newer_available (old, new_) ->

--- a/src/ocaml_lsp.ml
+++ b/src/ocaml_lsp.ml
@@ -230,11 +230,12 @@ let is_version_up_to_date t ocaml_v =
           | None -> sprintf "to %s" new_
           | Some old -> sprintf "from %s to %s" old new_
         in
-        sprintf
-          "There is a newer version of ocaml-lsp-server available. Consider upgrading \
-           %s. Hint: $ opam install ocaml-lsp-server=%s and restart the lsp server"
-          upgrade
-          new_
+        ( sprintf
+            "There is a newer version of ocaml-lsp-server available. Consider upgrading \
+             %s. Hint: $ opam install ocaml-lsp-server=%s and restart the lsp server"
+            upgrade
+            new_
+        , new_ )
     in
     `Msg msg)
 ;;

--- a/src/ocaml_lsp.ml
+++ b/src/ocaml_lsp.ml
@@ -199,13 +199,16 @@ let available_versions version =
   List.Assoc.find lsp_versions ~equal:Poly.equal prefix
 ;;
 
-let suggest_to_upgrade_ocaml_lsp_server () =
+let suggest_to_upgrade_ocaml_lsp_server
+      ?(message = "OCaml-LSP server is not up to date.")
+      ()
+  =
   let open Promise.Syntax in
   let upgrade_lsp_text = "Yes" in
   let no_upgrade = "No" in
   let* selection =
     Window.showInformationMessage
-      ~message:"OCaml-LSP server is not up to date. Do you want to upgrade it?"
+      ~message:(message ^ " Do you want to upgrade it?")
       ~choices:[ upgrade_lsp_text, `Update_lsp; no_upgrade, `No_upgrade ]
       ()
   in

--- a/src/ocaml_lsp.mli
+++ b/src/ocaml_lsp.mli
@@ -11,6 +11,7 @@ val can_handle_type_selection : t -> bool
 val can_handle_construct : t -> bool
 val can_handle_merlin_jump : t -> bool
 val can_handle_search_by_type : t -> bool
+val suggest_to_upgrade_ocaml_lsp_server : unit -> unit Promise.t
 
 module OcamllspSettingEnable : sig
   include Ojs.T

--- a/src/ocaml_lsp.mli
+++ b/src/ocaml_lsp.mli
@@ -11,7 +11,7 @@ val can_handle_type_selection : t -> bool
 val can_handle_construct : t -> bool
 val can_handle_merlin_jump : t -> bool
 val can_handle_search_by_type : t -> bool
-val suggest_to_upgrade_ocaml_lsp_server : unit -> unit Promise.t
+val suggest_to_upgrade_ocaml_lsp_server : ?message:string -> unit -> unit Promise.t
 
 module OcamllspSettingEnable : sig
   include Ojs.T

--- a/src/ocaml_lsp.mli
+++ b/src/ocaml_lsp.mli
@@ -3,12 +3,7 @@ open Import
 type t
 
 val of_initialize_result : LanguageClient.InitializeResult.t -> t
-
-val is_version_up_to_date
-  :  t
-  -> Ocaml_version.t
-  -> (unit, [> `Msg of string * string ]) result
-
+val is_version_up_to_date : t -> Ocaml_version.t -> (unit, [ `Msg of string ]) result
 val can_handle_switch_impl_intf : t -> bool
 val can_handle_infer_intf : t -> bool
 val can_handle_typed_holes : t -> bool

--- a/src/ocaml_lsp.mli
+++ b/src/ocaml_lsp.mli
@@ -3,7 +3,12 @@ open Import
 type t
 
 val of_initialize_result : LanguageClient.InitializeResult.t -> t
-val is_version_up_to_date : t -> Ocaml_version.t -> (unit, [ `Msg of string ]) result
+
+val is_version_up_to_date
+  :  t
+  -> Ocaml_version.t
+  -> (unit, [> `Msg of string * string ]) result
+
 val can_handle_switch_impl_intf : t -> bool
 val can_handle_infer_intf : t -> bool
 val can_handle_typed_holes : t -> bool

--- a/src/opam.ml
+++ b/src/opam.ml
@@ -310,7 +310,11 @@ let install t switch ~packages =
 ;;
 
 let update t switch = spawn t [ "update"; switch_arg switch ]
-let upgrade t switch = spawn t [ "upgrade"; switch_arg switch; "-y" ]
+
+let upgrade ?(packages = []) t switch =
+  spawn t ("upgrade" :: switch_arg switch :: "-y" :: packages)
+;;
+
 let remove t switch packages = spawn t ("remove" :: switch_arg switch :: "-y" :: packages)
 
 let switch_compiler t switch =

--- a/src/opam.mli
+++ b/src/opam.mli
@@ -47,7 +47,7 @@ val install : t -> Switch.t -> packages:string list -> Cmd.t
 val update : t -> Switch.t -> Cmd.t
 
 (** Upgrade packages in a switch *)
-val upgrade : t -> Switch.t -> Cmd.t
+val upgrade : ?packages:string list -> t -> Switch.t -> Cmd.t
 
 (* Remove a list of packages from a switch *)
 val remove : t -> Switch.t -> string list -> Cmd.t

--- a/src/sandbox.ml
+++ b/src/sandbox.ml
@@ -602,7 +602,7 @@ let install_packages t packages =
   let options =
     ProgressOptions.create
       ~location:(`ProgressLocation Notification)
-      ~title:"Installing sandbox packages"
+      ~title:("Installing sandbox packages: " ^ String.concat ~sep:"," packages)
       ~cancellable:false
       ()
   in

--- a/src/sandbox.ml
+++ b/src/sandbox.ml
@@ -602,7 +602,7 @@ let install_packages t packages =
   let options =
     ProgressOptions.create
       ~location:(`ProgressLocation Notification)
-      ~title:("Installing sandbox packages: " ^ String.concat ~sep:"," packages)
+      ~title:("Installing sandbox packages: " ^ String.concat ~sep:", " packages)
       ~cancellable:false
       ()
   in

--- a/src/sandbox.ml
+++ b/src/sandbox.ml
@@ -637,7 +637,7 @@ let install_packages t packages =
     ()
 ;;
 
-let upgrade_packages t =
+let upgrade_packages ?(packages = []) t =
   let options =
     ProgressOptions.create
       ~location:(`ProgressLocation Notification)
@@ -662,7 +662,7 @@ let upgrade_packages t =
       let+ result =
         let open Promise.Result.Syntax in
         let* _ = Opam.update opam switch |> Cmd.output in
-        let+ _ = Opam.upgrade opam switch |> Cmd.output in
+        let+ _ = Opam.upgrade ~packages opam switch |> Cmd.output in
         ()
       in
       match result with

--- a/src/sandbox.mli
+++ b/src/sandbox.mli
@@ -73,7 +73,7 @@ val uninstall_packages : t -> Package.t list -> unit Promise.t
 val install_packages : t -> string list -> unit Promise.t
 
 (** Upgrade packages in the sandbox *)
-val upgrade_packages : t -> unit Promise.t
+val upgrade_packages : ?packages:string list -> t -> unit Promise.t
 
 (** [ocaml_version] returns the version of the ocaml compiler installed in given
     sandbox. *)

--- a/src/type_selection.ml
+++ b/src/type_selection.ml
@@ -55,9 +55,7 @@ let ocaml_lsp_doesnt_support_type_selection instance ocaml_lsp =
     show_message
       `Warn
       "The installed version of `ocamllsp` does not support type enclosings. %s"
-      msg;
-    let _ = Extension_instance.suggest_to_upgrade_ocaml_lsp_server () in
-    ()
+      msg
 ;;
 
 type state =

--- a/src/type_selection.ml
+++ b/src/type_selection.ml
@@ -51,7 +51,7 @@ let ocaml_lsp_doesnt_support_type_selection instance ocaml_lsp =
       (Extension_instance.ocaml_version_exn instance)
   with
   | Ok () -> ()
-  | Error (`Msg msg) ->
+  | Error (`Msg (msg, _latest_version)) ->
     show_message
       `Warn
       "The installed version of `ocamllsp` does not support type enclosings. %s"

--- a/src/type_selection.ml
+++ b/src/type_selection.ml
@@ -51,11 +51,13 @@ let ocaml_lsp_doesnt_support_type_selection instance ocaml_lsp =
       (Extension_instance.ocaml_version_exn instance)
   with
   | Ok () -> ()
-  | Error (`Msg (msg, _latest_version)) ->
+  | Error (`Msg msg) ->
     show_message
       `Warn
       "The installed version of `ocamllsp` does not support type enclosings. %s"
-      msg
+      msg;
+    let _ = Extension_instance.suggest_to_upgrade_ocaml_lsp_server () in
+    ()
 ;;
 
 type state =


### PR DESCRIPTION
Currently, when `ocaml-lsp-server` is not found in a sandbox, the language server displays an error and fails to start. 
This PR improves users experience by providing a UI that asks if they will like to install or update `ocaml-lsp-server` or select another sandbox.

If the user wants to select another sandbox, a quickpick will be displayed with various switches. 
If the user decides to install `ocaml-lsp-server`, it will be installed in the background and they can continue with their activities in the editor. 

This PR will streamline the process for complete beginners and also reduce the time to terminal for experienced users who often will have to switch to the terminal to install `ocaml-lsp-server` in their sandbox.

cc @voodoos 
