### PR TITLE
Fix odoc syntax color for math block with braces

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 # Unreleased
 
+- Fix syntax color for odoc math blocks containing braces (#1741)
+
 ## 1.28.0
 
 - Add `.re` file extension support. (#1685)

--- a/syntaxes/ocamldoc.json
+++ b/syntaxes/ocamldoc.json
@@ -127,13 +127,15 @@
           "comment": "odoc inline math",
           "begin": "(?<!\\\\){m[[:space:]]",
           "end": "(?<!\\\\)\\}",
-          "name": "support.class.math.odoc markup.math.inline.odoc meta.math.inline.odoc"
+          "name": "support.class.math.odoc markup.math.inline.odoc meta.math.inline.odoc",
+          "patterns": [{ "include": "#braces" }]
         },
         {
           "comment": "odoc math block",
           "begin": "(?<!\\\\){math[[:space:]]",
           "end": "(?<!\\\\)\\}",
-          "name": "support.class.math.odoc markup.math.block.odoc meta.math.block.odoc"
+          "name": "support.class.math.odoc markup.math.block.odoc meta.math.block.odoc",
+          "patterns": [{ "include": "#braces" }]
         },
         {
           "comment": "ocamldoc simple lists",
@@ -298,6 +300,14 @@
           "comment": "table characters",
           "match": "\\||(\\-\\-\\-+)|(:\\-\\-\\-+:)|(:\\-\\-+)|(\\-\\-+:)",
           "name": "punctuation.definition.list.begin.markdown.tableheader.tablechars.ocamldoc"
+        }
+      ]
+    },
+    "braces": {
+      "patterns": [
+        {
+          "begin": "(?<!\\\\){",
+          "end": "(?<!\\\\)\\}"
         }
       ]
     }


### PR DESCRIPTION
Fix a small bug in odoc syntax coloring. The math mode (`{m ...}` and `{math ... }` blocks) used to terminate at the first closing brace `}`. However, math mode uses LaTeX syntax and thus, can contain a lot of braces (eg. `2^{256}`). This PR fixes that issue.

Here is a small comment that shows the difference:
```ocaml
(**
- Inline math: {m 2^{256}+2^{128}}
- Display math:  {math
2^{256}+2^{128}
}
*)
```