### PR TITLE
Map Alt+D to the correct action kind in package.json

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- Update `destruct` code action command to use `destruct (enumerate cases)` (#1750)
+
 ## 1.28.1
 
 - Fix syntax color for odoc math blocks containing braces (#1741)

--- a/package.json
+++ b/package.json
@@ -764,7 +764,7 @@
         "command": "editor.action.codeAction",
         "key": "Alt+D",
         "args": {
-          "kind": "destruct"
+          "kind": "destruct (enumerate cases)"
         },
         "when": "editorLangId == ocaml || editorLangId == reason"
       },


### PR DESCRIPTION
The extension assigns the key binding Alt+D to the very useful "destruct" code action, but currently the key binding doesn't do anything (also see https://github.com/ocaml/ocaml-lsp/issues/1301).

I did some digging and discovered that the definition of the key binding is passing the `destruct` kind, but ocaml-lsp actually names the kind `destruct (enumerate cases)`.

Now the keybinding is correctly mapped to the destruct action, and I also see the keys suggested in the code actions context menu:
![image](https://github.com/user-attachments/assets/ff10b93c-1979-4813-a1b3-1bfd1f6360fd)
