### PR TITLE
Remove quoted string literal highlighting from grammar

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@
 ## Unreleased
 
 - Add mlx syntax highlight (#1802)
+- Remove broken quoted string literal highlighting from grammar. Quoted strings
+  are already highlighted correctly by the language server. (#1860)
 
 ## 1.29.0
 

--- a/syntaxes/mlx.json
+++ b/syntaxes/mlx.json
@@ -341,27 +341,11 @@
               "match": "\\\\\""
             }
           ]
-        },
-        {
-          "comment": "quoted string literal",
-          "begin": "\\{[[:lower:]_]*\\|",
-          "end": "\\|[[:lower:]_]*\\}"
         }
       ]
     },
     "strings": {
       "patterns": [
-        {
-          "comment": "quoted string literal",
-          "name": "string.quoted.braced.ocaml",
-          "begin": "\\{(%%?[[:alpha:]_][[:word:]']*(\\.[[:alpha:]_][[:word:]']*)*[[:space:]]*)?[[:lower:]_]*\\|",
-          "end": "\\|[[:lower:]_]*\\}",
-          "beginCaptures": {
-            "1": {
-              "name": "keyword.other.extension.ocaml"
-            }
-          }
-        },
         {
           "comment": "string literal",
           "name": "string.quoted.double.ocaml",

--- a/syntaxes/ocaml.json
+++ b/syntaxes/ocaml.json
@@ -168,26 +168,12 @@
           "begin": "\"",
           "end": "\"",
           "patterns": [{ "match": "\\\\\\\\" }, { "match": "\\\\\"" }]
-        },
-        {
-          "comment": "quoted string literal",
-          "begin": "\\{[[:lower:]_]*\\|",
-          "end": "\\|[[:lower:]_]*\\}"
         }
       ]
     },
 
     "strings": {
       "patterns": [
-        {
-          "comment": "quoted string literal",
-          "name": "string.quoted.braced.ocaml",
-          "begin": "\\{(%%?[[:alpha:]_][[:word:]']*(\\.[[:alpha:]_][[:word:]']*)*[[:space:]]*)?[[:lower:]_]*\\|",
-          "end": "\\|[[:lower:]_]*\\}",
-          "beginCaptures": {
-            "1": { "name": "keyword.other.extension.ocaml" }
-          }
-        },
         {
           "comment": "string literal",
           "name": "string.quoted.double.ocaml",


### PR DESCRIPTION
The existing syntax support for quoted string literals was always buggy since it didn't track the IDs. See the first screenshot in #930 for an example.

Since semantic highlighting in the language server highlights these correctly now, I don't see a reason to leave the broken version in the grammar.   