### PR TITLE
Support for autoClose and brackets for quoted string literals `{|`

### DIFF
--- a/languages/ocaml.json
+++ b/languages/ocaml.json
@@ -5,9 +5,10 @@
     { "open": "(", "close": ")" },
     { "open": "\"", "close": "\"", "notIn": ["string"] },
     { "open": "(*", "close": "*", "notIn": ["string"] },
-    { "open": "[|", "close": "|", "notIn": ["string"] }
+    { "open": "[|", "close": "|", "notIn": ["string"] },
+    { "open": "{|", "close": "|", "notIn": ["string"] }
   ],
-  "brackets": [["{", "}"], ["[", "]"], ["(", ")"], ["[|", "|]"]],
+  "brackets": [["{", "}"], ["[", "]"], ["(", ")"], ["[|", "|]"], ["{|", "|}"]],
   "comments": {
     "blockComment": ["(*", "*)"]
   },


### PR DESCRIPTION
Adding support for autoClosing quoted string literals opened with `{|` and also brackets support for it.

Previous behavior:
![quotstrlit_before](https://github.com/user-attachments/assets/99193a74-016e-4033-bdd0-9f27c0dc3c79)

New behavior:
![quotstrlit_after](https://github.com/user-attachments/assets/55e87fcb-15d2-4921-9c5c-b739b0c8c0fc)

Does this count as a "User-visible change" that needs a changelog entry?