### PR TITLE
Reintroduce quoted string literal highlighting with correct ID handling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Unreleased
 
 - Add support for quoted string literal brackets (`{|`, `|}`) syntax highlighting and auto-closing pairs
+- Revert quoted string literal highlighting removal (#1871)
 
 ## 1.30.1
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## Unreleased
 
 - Add support for quoted string literal brackets (`{|`, `|}`) syntax highlighting and auto-closing pairs
-- Revert quoted string literal highlighting removal (#1871)
+- Reintroduce quoted string literal highlighting with correct ID handling (#1871)
 
 ## 1.30.1
 

--- a/syntaxes/mlx.json
+++ b/syntaxes/mlx.json
@@ -344,8 +344,8 @@
         },
         {
           "comment": "quoted string literal",
-          "begin": "\\{[[:lower:]_]*\\|",
-          "end": "\\|[[:lower:]_]*\\}"
+          "begin": "\\{([[:lower:]_]*)\\|",
+          "end": "\\|\\1\\}"
         }
       ]
     },
@@ -354,8 +354,8 @@
         {
           "comment": "quoted string literal",
           "name": "string.quoted.braced.ocaml",
-          "begin": "\\{(%%?[[:alpha:]_][[:word:]']*(\\.[[:alpha:]_][[:word:]']*)*[[:space:]]*)?[[:lower:]_]*\\|",
-          "end": "\\|[[:lower:]_]*\\}",
+          "begin": "\\{(%%?[[:alpha:]_][[:word:]']*(\\.[[:alpha:]_][[:word:]']*)*[[:space:]]*)?([[:lower:]_]*)\\|",
+          "end": "\\|\\3\\}",
           "beginCaptures": {
             "1": {
               "name": "keyword.other.extension.ocaml"

--- a/syntaxes/mlx.json
+++ b/syntaxes/mlx.json
@@ -341,11 +341,27 @@
               "match": "\\\\\""
             }
           ]
+        },
+        {
+          "comment": "quoted string literal",
+          "begin": "\\{[[:lower:]_]*\\|",
+          "end": "\\|[[:lower:]_]*\\}"
         }
       ]
     },
     "strings": {
       "patterns": [
+        {
+          "comment": "quoted string literal",
+          "name": "string.quoted.braced.ocaml",
+          "begin": "\\{(%%?[[:alpha:]_][[:word:]']*(\\.[[:alpha:]_][[:word:]']*)*[[:space:]]*)?[[:lower:]_]*\\|",
+          "end": "\\|[[:lower:]_]*\\}",
+          "beginCaptures": {
+            "1": {
+              "name": "keyword.other.extension.ocaml"
+            }
+          }
+        },
         {
           "comment": "string literal",
           "name": "string.quoted.double.ocaml",

--- a/syntaxes/ocaml.json
+++ b/syntaxes/ocaml.json
@@ -168,12 +168,26 @@
           "begin": "\"",
           "end": "\"",
           "patterns": [{ "match": "\\\\\\\\" }, { "match": "\\\\\"" }]
+        },
+        {
+          "comment": "quoted string literal",
+          "begin": "\\{[[:lower:]_]*\\|",
+          "end": "\\|[[:lower:]_]*\\}"
         }
       ]
     },
 
     "strings": {
       "patterns": [
+        {
+          "comment": "quoted string literal",
+          "name": "string.quoted.braced.ocaml",
+          "begin": "\\{(%%?[[:alpha:]_][[:word:]']*(\\.[[:alpha:]_][[:word:]']*)*[[:space:]]*)?[[:lower:]_]*\\|",
+          "end": "\\|[[:lower:]_]*\\}",
+          "beginCaptures": {
+            "1": { "name": "keyword.other.extension.ocaml" }
+          }
+        },
         {
           "comment": "string literal",
           "name": "string.quoted.double.ocaml",

--- a/syntaxes/ocaml.json
+++ b/syntaxes/ocaml.json
@@ -171,8 +171,8 @@
         },
         {
           "comment": "quoted string literal",
-          "begin": "\\{[[:lower:]_]*\\|",
-          "end": "\\|[[:lower:]_]*\\}"
+          "begin": "\\{([[:lower:]_]*)\\|",
+          "end": "\\|\\1\\}"
         }
       ]
     },
@@ -182,8 +182,8 @@
         {
           "comment": "quoted string literal",
           "name": "string.quoted.braced.ocaml",
-          "begin": "\\{(%%?[[:alpha:]_][[:word:]']*(\\.[[:alpha:]_][[:word:]']*)*[[:space:]]*)?[[:lower:]_]*\\|",
-          "end": "\\|[[:lower:]_]*\\}",
+          "begin": "\\{(%%?[[:alpha:]_][[:word:]']*(\\.[[:alpha:]_][[:word:]']*)*[[:space:]]*)?([[:lower:]_]*)\\|",
+          "end": "\\|\\3\\}",
           "beginCaptures": {
             "1": { "name": "keyword.other.extension.ocaml" }
           }


### PR DESCRIPTION
Closes #1868

The flawed grammar + semantic highlighting was more reliable than no grammar rules and semantic highlighting.