### PR TITLE
Start the ocamllsp server as a dev tool

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- Start ocamllsp server for DPM using dune tools exec ocamllsp (#1903)
+
 ## 1.31.0
 
 - Automatically configure Dune Package Management (#1791)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,9 @@
 
 ## Unreleased
 
-- Start ocamllsp server for DPM using dune tools exec ocamllsp (#1903)
+- Fix DPM (Dune Package Management) support for users with Dune installed via
+  Opam, Nix or similar. Previously, DPM support worked only when Dune was
+  installed using the installation script for the Dune binary distribution. (#1903)
 
 ## 1.31.0
 

--- a/src/extension_commands.ml
+++ b/src/extension_commands.ml
@@ -131,11 +131,7 @@ let _install_dune_lsp_server =
                 Ojs.null
             in
             let* _ = Vscode.Window.withProgress (module Ojs) ~options ~task in
-            (* We now just use the shim [script](https://github.com/ocaml-dune/binary-distribution/blob/4456a8f870bac910e9591fe9c4b1d1438538d484/tool-wrappers/ocamllsp) to start the server *)
-            let* _ =
-              Sandbox.get_command sandbox "ocamllsp" [ "--version" ] `Ocamllsp
-              |> Cmd.output
-            in
+            let* _ = Sandbox.get_command sandbox "ocamllsp" [] `Tool |> Cmd.output in
             let+ _ = Extension_instance.start_language_server instance in
             ())
         else Extension_instance.suggest_to_run_dune_pkg_lock () |> Promise.return

--- a/src/extension_commands.ml
+++ b/src/extension_commands.ml
@@ -131,7 +131,6 @@ let _install_dune_lsp_server =
                 Ojs.null
             in
             let* _ = Vscode.Window.withProgress (module Ojs) ~options ~task in
-            let* _ = Sandbox.get_command sandbox "ocamllsp" [] `Tool |> Cmd.output in
             let+ _ = Extension_instance.start_language_server instance in
             ())
         else Extension_instance.suggest_to_run_dune_pkg_lock () |> Promise.return

--- a/src/extension_instance.ml
+++ b/src/extension_instance.ml
@@ -151,7 +151,7 @@ let check_ocaml_lsp_available (sandbox : Sandbox.t) =
     else Error "`ocaml-lsp-server` is not installed in the current dune sandbox."
   | _ ->
     let ocaml_lsp_version sandbox =
-      Sandbox.get_command sandbox "ocamllsp" [ "--version" ] `Ocamllsp
+      Sandbox.get_command sandbox "ocamllsp" [ "--version" ] `Tool
     in
     let cwd =
       match Workspace.workspaceFolders () with
@@ -190,7 +190,7 @@ end = struct
 
   let server_options t =
     let args = Settings.(get server_args_setting) |> Option.value ~default:[] in
-    let command = Sandbox.get_command t.sandbox "ocamllsp" args `Ocamllsp in
+    let command = Sandbox.get_command t.sandbox "ocamllsp" args `Tool in
     Cmd.log command;
     let env =
       let extra_env_vars =

--- a/src/sandbox.ml
+++ b/src/sandbox.ml
@@ -545,20 +545,12 @@ let select_sandbox_and_save t =
   Some sandbox
 ;;
 
-let get_command
-      sandbox
-      bin
-      args
-      (dune_cmd_type : [> `Tool | `Command | `Exec | `Ocamllsp ])
-  : Cmd.t
-  =
+let get_command sandbox bin args (dune_cmd_type : [> `Tool | `Command | `Exec ]) : Cmd.t =
   match sandbox with
   | Opam (opam, switch) -> Opam.exec opam switch ~args:(bin :: args)
   | Esy (esy, manifest) -> Esy.exec esy manifest ~args:(bin :: args)
   | Dune dune ->
     (match dune_cmd_type with
-     | `Ocamllsp ->
-       Cmd.Spawn (Cmd.append { Cmd.bin = Path.of_string "ocamllsp"; args } [])
      | `Tool -> Dune.exec_tool ~tool:bin ~args dune
      | `Command -> Dune.command dune ~args
      | `Exec -> Dune.exec ~target:bin ~args dune)

--- a/src/sandbox.mli
+++ b/src/sandbox.mli
@@ -54,12 +54,7 @@ val select_sandbox : t -> t option Promise.t
 (* Helper utils *)
 
 (** Extract command to run with the sandbox *)
-val get_command
-  :  t
-  -> string
-  -> string list
-  -> [ `Command | `Exec | `Tool | `Ocamllsp ]
-  -> Cmd.t
+val get_command : t -> string -> string list -> [ `Command | `Exec | `Tool ] -> Cmd.t
 
 (** Command to install dependencies in the sandbox *)
 val get_install_command : t -> string list -> Cmd.t option


### PR DESCRIPTION
This Pr no longer relies on the shim script to start ocamllsp server and rather starts it as a dune dev tool.

cc @pitag-ha 