### PR TITLE
Add links to ocaml tutorials

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,8 @@
 
 ## Unreleased
 
-- Add links to OCaml tutorials and exercises from ocaml.org (#1905)
+- In the plugin's side panel, add links to OCaml tutorials and exercises on
+  ocaml.org. (#1905)
 
 ## 1.31.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- Add links to OCaml tutorials and exercises from ocaml.org (#1905)
+
 ## 1.31.0
 
 - Automatically configure Dune Package Management (#1791)

--- a/src/treeview_help.ml
+++ b/src/treeview_help.ml
@@ -46,6 +46,26 @@ let discuss_item =
   item
 ;;
 
+let tutorials_item =
+  let label =
+    `TreeItemLabel
+      (Vscode.TreeItemLabel.create ~label:"Explore OCaml exercises and tutorials" ())
+  in
+  let icon = `ThemeIcon (Vscode.ThemeIcon.make ~id:"book" ()) in
+  let item = Vscode.TreeItem.make_label ~label () in
+  let command =
+    Vscode.Command.create
+      ~title:"Open"
+      ~command:"vscode.open"
+      ~arguments:
+        [ Vscode.Uri.parse "https://ocaml.org/exercises" () |> Vscode.Uri.t_to_js ]
+      ()
+  in
+  Vscode.TreeItem.set_iconPath item icon;
+  Vscode.TreeItem.set_command item command;
+  item
+;;
+
 let github_item =
   let icon =
     `LightDark
@@ -73,7 +93,7 @@ let github_item =
   item
 ;;
 
-let items = [ discord_item; discuss_item; github_item ]
+let items = [ discord_item; discuss_item; github_item; tutorials_item ]
 let getTreeItem ~element = `Value element
 
 let getChildren ?element () =


### PR DESCRIPTION
This PR adds permanently a link to the tutorials and exercises page of the ocaml.org platform.

cc @pitag-ha 