### PR TITLE
Check if ocamllsp is present the dune way

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,6 @@
   installed using the installation script for the Dune binary distribution. (#1903)
 - In the plugin's side panel, add links to OCaml tutorials and exercises on
   ocaml.org. (#1905)
-- Use `dune tools which ocamllsp` to check for the presence of ocamllsp in DPM (#1907)
 
 ## 1.31.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
   installed using the installation script for the Dune binary distribution. (#1903)
 - In the plugin's side panel, add links to OCaml tutorials and exercises on
   ocaml.org. (#1905)
+- Use `dune tools which ocamllsp` to check for the presence of ocamllsp in DPM (#1907)
 
 ## 1.31.0
 

--- a/src/dune.ml
+++ b/src/dune.ml
@@ -78,7 +78,7 @@ let exec ~target ?(args = []) t =
 
 let exec_pkg ~cmd ?(args = []) t = Cmd.Spawn (Cmd.append t.bin ([ "pkg"; cmd ] @ args))
 
-let exec_tool ~tool ?(args = []) t cmd =
+let tools ~tool ?(args = []) t cmd =
   match cmd with
   | `Exec_ -> Cmd.Spawn (Cmd.append t.bin ([ "tools"; "exec"; tool; "--" ] @ args))
   | `Which -> Cmd.Spawn (Cmd.append t.bin ([ "tools"; "which"; tool ] @ args))

--- a/src/dune.ml
+++ b/src/dune.ml
@@ -82,6 +82,7 @@ let tools ~tool ?(args = []) t cmd =
   match cmd with
   | `Exec_ -> Cmd.Spawn (Cmd.append t.bin ([ "tools"; "exec"; tool; "--" ] @ args))
   | `Which -> Cmd.Spawn (Cmd.append t.bin ([ "tools"; "which"; tool ] @ args))
+  | `Install -> Cmd.Spawn (Cmd.append t.bin ([ "tools"; "install"; tool ] @ args))
 ;;
 
 let is_ocamllsp_present t =

--- a/src/dune.ml
+++ b/src/dune.ml
@@ -91,7 +91,7 @@ let is_ocamllsp_present t =
   match ocamllsp_path with
   | Ok _path -> true
   | Error err ->
-    log_chan `Error ~section:"dune" "Ocamllsp not found: %s" err;
+    log_chan `Info ~section:"dune" "Ocamllsp not found" err;
     false
 ;;
 

--- a/src/dune.ml
+++ b/src/dune.ml
@@ -85,13 +85,12 @@ let tools ~tool ?(args = []) t cmd =
 ;;
 
 let is_ocamllsp_present t =
-  (* use dune tools which ocamllsp *)
   let open Promise.Syntax in
-  let+ ocamllsp_path = exec_tool ~tool:"ocamllsp" t `Which |> Cmd.output ~cwd:t.root in
+  let+ ocamllsp_path = tools ~tool:"ocamllsp" t `Which |> Cmd.output ~cwd:t.root in
   match ocamllsp_path with
   | Ok _path -> true
   | Error err ->
-    log_chan `Info ~section:"dune" "Ocamllsp not found" err;
+    log_chan `Info ~section:"dune" "Ocamllsp not found with error %s" err;
     false
 ;;
 

--- a/src/dune.mli
+++ b/src/dune.mli
@@ -22,8 +22,8 @@ val exec : target:string -> ?args:string list -> t -> Cmd.t
 (** Run specific `dune pkg <foo> commands*)
 val exec_pkg : cmd:string -> ?args:string list -> t -> Cmd.t
 
-(** Execute any `dune tools exec | which` command*)
-val exec_tool : tool:string -> ?args:string list -> t -> [< `Exec_ | `Which ] -> Cmd.t
+(** Run `dune tools <exec/which>` *)
+val tools : tool:string -> ?args:string list -> t -> [< `Exec_ | `Which ] -> Cmd.t
 
 (** Check if amy two instances of dune pkg management projects are equal *)
 val equal : t -> t -> bool

--- a/src/dune.mli
+++ b/src/dune.mli
@@ -23,7 +23,12 @@ val exec : target:string -> ?args:string list -> t -> Cmd.t
 val exec_pkg : cmd:string -> ?args:string list -> t -> Cmd.t
 
 (** Run `dune tools <exec/which>` *)
-val tools : tool:string -> ?args:string list -> t -> [< `Exec_ | `Which ] -> Cmd.t
+val tools
+  :  tool:string
+  -> ?args:string list
+  -> t
+  -> [< `Exec_ | `Which | `Install ]
+  -> Cmd.t
 
 (** Check if amy two instances of dune pkg management projects are equal *)
 val equal : t -> t -> bool

--- a/src/dune.mli
+++ b/src/dune.mli
@@ -10,9 +10,6 @@ type t =
     If not, user should be advised to run `dune pkg lock` *)
 val is_project_locked : t -> bool Promise.t
 
-(** Check if the dune project has ocamllsp server as a dev-tool. *)
-val is_ocamllsp_present : t -> bool Promise.t
-
 (** Generic function to execute dune commands *)
 val command : t -> args:string list -> Cmd.t
 
@@ -29,6 +26,9 @@ val tools
   -> t
   -> [< `Exec_ | `Which | `Install ]
   -> Cmd.t
+
+(** Check if the dune project has ocamllsp server as a dev-tool. *)
+val is_ocamllsp_present : t -> bool Promise.t
 
 (** Check if amy two instances of dune pkg management projects are equal *)
 val equal : t -> t -> bool

--- a/src/dune.mli
+++ b/src/dune.mli
@@ -22,8 +22,8 @@ val exec : target:string -> ?args:string list -> t -> Cmd.t
 (** Run specific `dune pkg <foo> commands*)
 val exec_pkg : cmd:string -> ?args:string list -> t -> Cmd.t
 
-(** Execute any `dune tools exec` command*)
-val exec_tool : tool:string -> ?args:string list -> t -> Cmd.t
+(** Execute any `dune tools exec | which` command*)
+val exec_tool : tool:string -> ?args:string list -> t -> [< `Exec_ | `Which ] -> Cmd.t
 
 (** Check if amy two instances of dune pkg management projects are equal *)
 val equal : t -> t -> bool

--- a/src/extension_commands.ml
+++ b/src/extension_commands.ml
@@ -114,14 +114,14 @@ let _install_dune_lsp_server =
             let options =
               ProgressOptions.create
                 ~location:(`ProgressLocation Notification)
-                ~title:"Installing ocaml-lsp server using `dune tools exec ocamllsp`"
+                ~title:"Installing ocaml-lsp server using `dune tools install ocamllsp`"
                 ~cancellable:false
                 ()
             in
             let task ~progress:_ ~token:_ =
               let+ result =
                 (* We first check the version so that the process can exit, otherwise the progress indicator runs forever.*)
-                Sandbox.get_command sandbox "ocamllsp" [ "--version" ] `Tool
+                Sandbox.get_command sandbox "ocamllsp" [] `Install
                 |> Cmd.output ~cwd:(Dune.root dune)
               in
               match result with

--- a/src/sandbox.ml
+++ b/src/sandbox.ml
@@ -545,12 +545,19 @@ let select_sandbox_and_save t =
   Some sandbox
 ;;
 
-let get_command sandbox bin args (dune_cmd_type : [> `Tool | `Command | `Exec ]) : Cmd.t =
+let get_command
+      sandbox
+      bin
+      args
+      (dune_cmd_type : [> `Tool | `Command | `Exec | `Install ])
+  : Cmd.t
+  =
   match sandbox with
   | Opam (opam, switch) -> Opam.exec opam switch ~args:(bin :: args)
   | Esy (esy, manifest) -> Esy.exec esy manifest ~args:(bin :: args)
   | Dune dune ->
     (match dune_cmd_type with
+     | `Install -> Dune.tools ~tool:bin ~args dune `Install
      | `Tool -> Dune.tools ~tool:bin ~args dune `Exec_
      | `Command -> Dune.command dune ~args
      | `Exec -> Dune.exec ~target:bin ~args dune)

--- a/src/sandbox.ml
+++ b/src/sandbox.ml
@@ -551,7 +551,7 @@ let get_command sandbox bin args (dune_cmd_type : [> `Tool | `Command | `Exec ])
   | Esy (esy, manifest) -> Esy.exec esy manifest ~args:(bin :: args)
   | Dune dune ->
     (match dune_cmd_type with
-     | `Tool -> Dune.exec_tool ~tool:bin ~args dune
+     | `Tool -> Dune.exec_tool ~tool:bin ~args dune `Exec_
      | `Command -> Dune.command dune ~args
      | `Exec -> Dune.exec ~target:bin ~args dune)
   | Global -> Spawn { bin = Path.of_string bin; args }

--- a/src/sandbox.ml
+++ b/src/sandbox.ml
@@ -551,7 +551,7 @@ let get_command sandbox bin args (dune_cmd_type : [> `Tool | `Command | `Exec ])
   | Esy (esy, manifest) -> Esy.exec esy manifest ~args:(bin :: args)
   | Dune dune ->
     (match dune_cmd_type with
-     | `Tool -> Dune.exec_tool ~tool:bin ~args dune `Exec_
+     | `Tool -> Dune.tools ~tool:bin ~args dune `Exec_
      | `Command -> Dune.command dune ~args
      | `Exec -> Dune.exec ~target:bin ~args dune)
   | Global -> Spawn { bin = Path.of_string bin; args }

--- a/src/sandbox.mli
+++ b/src/sandbox.mli
@@ -54,7 +54,12 @@ val select_sandbox : t -> t option Promise.t
 (* Helper utils *)
 
 (** Extract command to run with the sandbox *)
-val get_command : t -> string -> string list -> [ `Command | `Exec | `Tool ] -> Cmd.t
+val get_command
+  :  t
+  -> string
+  -> string list
+  -> [ `Command | `Exec | `Tool | `Install ]
+  -> Cmd.t
 
 (** Command to install dependencies in the sandbox *)
 val get_install_command : t -> string list -> Cmd.t option


### PR DESCRIPTION
Previously, wrt Dune package management we check if ocamllsp is present by checking if its found in the `dev-tools.lock` directory. 
This PR https://github.com/ocaml/dune/pull/11922 allows us to be able to check for the presence of ocamllsp in a much cleaner way `dune tools which ocamllsp`.

cc @pitag-ha 