### PR TITLE
Standardise UI messages to use quotes instead of Markdown backticks

### DIFF
--- a/src/extension_commands.ml
+++ b/src/extension_commands.ml
@@ -108,7 +108,7 @@ let _install_dune_lsp_server =
             let options =
               ProgressOptions.create
                 ~location:(`ProgressLocation Notification)
-                ~title:"Installing ocaml-lsp server using `dune tools install ocamllsp`"
+            ~title:"Installing ocaml-lsp server using \"dune tools install ocamllsp\""
                 ~cancellable:false
                 ()
             in
@@ -152,7 +152,7 @@ let _run_dune_pkg_lock =
         let options =
           ProgressOptions.create
             ~location:(`ProgressLocation Notification)
-            ~title:"Running `dune pkg lock`"
+            ~title:"Running \"dune pkg lock\""
             ~cancellable:false
             ()
         in
@@ -376,7 +376,7 @@ end = struct
     | Error (`Msg msg) ->
       show_message
         `Warn
-        "The installed version of `ocamllsp` does not support typed holes. %s"
+        "The installed version of \"ocamllsp\" does not support typed holes. %s"
         msg
   ;;
 
@@ -602,7 +602,7 @@ module Copy_type_under_cursor = struct
     | Error (`Msg msg) ->
       show_message
         `Warn
-        "The installed version of `ocamllsp` does not support type enclosings. %s"
+        "The installed version of \"ocamllsp\" does not support type enclosings. %s"
         msg
   ;;
 
@@ -1144,7 +1144,7 @@ module Search_by_type = struct
            let _ =
              Ocaml_lsp.suggest_to_upgrade_ocaml_lsp_server
                ~message:
-                 "The installed version of `ocamllsp` does not support type search."
+                 "The installed version of \"ocamllsp\" does not support type search."
                ()
            in
            ()

--- a/src/extension_instance.ml
+++ b/src/extension_instance.ml
@@ -144,7 +144,7 @@ let check_ocaml_lsp_available (sandbox : Sandbox.t) =
     let+ dune_lsp_present = Dune.is_ocamllsp_present dune in
     if dune_lsp_present
     then Ok ()
-    else Error "`ocaml-lsp-server` is not installed in the current dune sandbox."
+    else Error "\"ocaml-lsp-server\" is not installed in the current dune sandbox."
   | _ ->
     let ocaml_lsp_version sandbox =
       Sandbox.get_command sandbox "ocamllsp" [ "--version" ] `Tool
@@ -154,7 +154,7 @@ let check_ocaml_lsp_available (sandbox : Sandbox.t) =
     |> Promise.Result.fold
          ~ok:(fun (_ : string) -> ())
          ~error:(fun (_ : string) ->
-           "Sandbox initialization failed: `ocaml-lsp-server` is not installed in the \
+           "Sandbox initialization failed: \"ocaml-lsp-server\" is not installed in the \
             current sandbox.")
 ;;
 
@@ -212,7 +212,7 @@ end = struct
       let* selection =
         Window.showInformationMessage
           ~message:
-            "Failed to start the language server. `ocaml-lsp-server` is not installed in \
+            "Failed to start the language server. \"ocaml-lsp-server\" is not installed in \
              the current sandbox."
           ~choices:
             [ install_lsp_text, `Install_lsp; select_different_sandbox, `Select_sandbox ]
@@ -278,7 +278,7 @@ end = struct
        | Error s ->
          show_message
            `Error
-           "An error occurred starting the language server `ocamllsp`. %s"
+           "An error occurred starting the language server \"ocamllsp\". %s"
            s)
     | Error _ -> suggest_or_install_ocaml_lsp_server t
   ;;
@@ -435,7 +435,7 @@ let update_ocaml_info t =
       log_chan
         ~section:"Ocaml.version_semver"
         `Warn
-        "Error running `ocamlc -version`: %s"
+        "Error running \"ocamlc -version\": %s"
         e;
       Error `Ocamlc_missing
   in
@@ -449,7 +449,7 @@ let update_ocaml_info t =
      | `Unable_to_parse_version (`Version v, `Msg msg) ->
        show_message
          `Error
-         "OCaml bytecode compiler `ocamlc` version could not be parsed. Version: %s. \
+         "OCaml bytecode compiler \"ocamlc\" version could not be parsed. Version: %s. \
           Error %s"
          v
          msg
@@ -458,7 +458,7 @@ let update_ocaml_info t =
          let+ maybe_choice =
            Window.showWarningMessage
              ~message:
-               "OCaml bytecode compiler `ocamlc` was not found in the current sandbox. \
+               "OCaml bytecode compiler \"ocamlc\" was not found in the current sandbox. \
                 Do you have OCaml installed in the current sandbox?"
              ~choices:
                [ ( "Pick another sandbox"

--- a/src/type_selection.ml
+++ b/src/type_selection.ml
@@ -54,7 +54,7 @@ let ocaml_lsp_doesnt_support_type_selection instance ocaml_lsp =
   | Error (`Msg msg) ->
     show_message
       `Warn
-      "The installed version of `ocamllsp` does not support type enclosings. %s"
+      "The installed version of \"ocamllsp\" does not support type enclosings. %s"
       msg
 ;;
 


### PR DESCRIPTION
Replace Markdown-style backticks in notifications and message popups with double quotes, since VSCode does not render Markdown in `showInformationMessage`/`showWarningMessage`/`showErrorMessage`.