### PR TITLE
Use Uri.fsPath instead of Uri.path to use with Node.js filesystem APIs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+- Fix Windows LSP server startup failure by using `Uri.fsPath` instead of
+  `Uri.path` for filesystem API calls. (#1929)
+
 ## 1.32.1
 
 - Fix DPM error when invoking `ocamlc --version` without a working directory by

--- a/src/sandbox.ml
+++ b/src/sandbox.ml
@@ -62,7 +62,7 @@ let workspace_root () =
   match Workspace.workspaceFolders () with
   | [] -> None
   | [ workspace_folder ] ->
-    Some (workspace_folder |> WorkspaceFolder.uri |> Uri.path |> Path.of_string)
+    Some (workspace_folder |> WorkspaceFolder.uri |> Uri.fsPath |> Path.of_string)
   | _ ->
     (* We don't support multiple workspace roots at the moment *)
     None


### PR DESCRIPTION
This PR fixes a bug on Windows that appeared in version 1.32.1.
The command for starting the LSP server was failing with exit code `-4058` (ENOENT: file or directory not found).

The bug was introduced by commit aab1308d15d0ef442f3114c391a9ad1e247e11d9 of #1925, which replaced the following code:

```ocaml
let cwd =
  match Workspace.workspaceFolders () with
  | [ cwd ] -> Some (cwd |> WorkspaceFolder.uri |> Uri.fsPath |> Path.of_string)
  | _ -> None
in
```

with a call to `Sandbox.workspace_root ()`, defined as:

```ocaml
let workspace_root () =
  match Workspace.workspaceFolders () with
  | [] -> None
  | [ workspace_folder ] ->
    Some (workspace_folder |> WorkspaceFolder.uri |> Uri.path |> Path.of_string)
  | _ ->
    (* We don't support multiple workspace roots at the moment *)
    None
```

The problem is that `workspace_root` uses `Uri.path` instead of `Uri.fsPath`, which is more appropriate for paths passed to the filesystem API. This PR updates this definition to use `Uri.fsPath`, which should hopefully fix other usage sites as well.

**Note:** On Unix systems, `Uri.path` and `Uri.fsPath` are identical, so this bug went unnoticed.
