### PR TITLE
Change wording of dune notifications

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- Reword DPM notification to inform users DPM is available and not selected. (#1930)
+
 ## 1.32.1
 
 - Fix DPM error when invoking `ocamlc --version` without a working directory by

--- a/src/dune.ml
+++ b/src/dune.ml
@@ -117,7 +117,7 @@ let make root () =
            | Some version when Dune_version.is_valid version ->
              show_message
                `Info
-               "Dune Package Management selected with dune from %s, version %s."
+               "Dune Package Management is available with dune from %s, version %s."
                (Path.to_string binary)
                v;
              Some { bin; root }
@@ -142,7 +142,7 @@ let make root () =
               | Some version when Dune_version.is_valid version ->
                 show_message
                   `Info
-                  "Dune Package Management selected with dune from %s, version %s."
+                  "Dune Package Management is available with dune from %s, version %s."
                   path
                   v;
                 Promise.return (Some { bin; root })


### PR DESCRIPTION
When vscode is launched the platform extension tries to find all sandboxes which are available. Since we want users to be more aware of DPM, we have a notification which reads `Dune Package Management selected with dune from [dune|opam], [1.20]`. This is confusing, as it displays regardless of if the user has selected DPM or not. 

We should change the wording to `Dune Package Management is available with dune from [dune|opam], [1.20]`


cc @pitag-ha @smorimoto 