### PR TITLE
Fix keybinding when conditions and unsupported language filters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,11 @@
   (`construct`, `next-hole`, `prev-hole`, `search-by-type`,
   `copy-type-under-cursor`) were incorrectly enabled for `.mll` files and
   have been removed. (#1984)
+- Fix keybinding conditions to ensure correct language support. Explicitly add
+  `editorTextFocus` to each language condition to clarify operator precedence.
+  Remove `ocaml.ocamllex` and `ocaml.menhir` from `switch-impl-intf` and
+  `evaluate-selection` commands as these languages are not supported by those
+  features. (#1985)
 
 ## 1.32.3
 

--- a/package.json
+++ b/package.json
@@ -785,7 +785,7 @@
       {
         "command": "ocaml.switch-impl-intf",
         "key": "Alt+O",
-        "when": "editorLangId == ocaml || editorLangId == ocaml.interface || editorLangId == reason || editorLangId == ocaml.ocamllex || editorLangId == ocaml.menhir"
+        "when": "editorTextFocus && editorLangId == ocaml || editorTextFocus && editorLangId == ocaml.interface || editorTextFocus && editorLangId == reason"
       },
       {
         "command": "editor.action.codeAction",
@@ -793,7 +793,7 @@
         "args": {
           "kind": "destruct (enumerate cases)"
         },
-        "when": "editorLangId == ocaml || editorLangId == reason"
+        "when": "editorTextFocus && editorLangId == ocaml || editorTextFocus && editorLangId == reason"
       },
       {
         "command": "ocaml.construct",
@@ -801,7 +801,7 @@
         "args": {
           "kind": "construct"
         },
-        "when": "editorLangId == ocaml || editorLangId == reason"
+        "when": "editorTextFocus && editorLangId == ocaml || editorTextFocus && editorLangId == reason"
       },
       {
         "command": "ocaml.jump",
@@ -809,7 +809,7 @@
         "args": {
           "kind": "jump"
         },
-        "when": "editorLangId == ocaml || editorLangId == ocaml.interface || editorLangId == reason"
+        "when": "editorTextFocus && editorLangId == ocaml || editorTextFocus && editorLangId == ocaml.interface || editorTextFocus && editorLangId == reason"
       },
       {
         "command": "editor.action.codeAction",
@@ -822,17 +822,17 @@
       {
         "command": "ocaml.evaluate-selection",
         "key": "Shift+Enter",
-        "when": "editorTextFocus && editorLangId == ocaml || editorTextFocus && editorLangId == ocaml.interface || editorTextFocus && editorLangId == reason || editorTextFocus && editorLangId == ocaml.ocamllex || editorTextFocus && editorLangId == ocaml.menhir"
+        "when": "editorTextFocus && editorLangId == ocaml || editorTextFocus && editorLangId == ocaml.interface || editorTextFocus && editorLangId == reason"
       },
       {
         "command": "ocaml.next-hole",
         "key": "Alt+Y",
-        "when": "editorLangId == ocaml || editorLangId == ocaml.interface || editorLangId == reason"
+        "when": "editorTextFocus && editorLangId == ocaml || editorTextFocus && editorLangId == ocaml.interface || editorTextFocus && editorLangId == reason"
       },
       {
         "command": "ocaml.prev-hole",
         "key": "Shift+Alt+Y",
-        "when": "editorLangId == ocaml || editorLangId == ocaml.interface || editorLangId == reason"
+        "when": "editorTextFocus && editorLangId == ocaml || editorTextFocus && editorLangId == ocaml.interface || editorTextFocus && editorLangId == reason"
       },
       {
         "command": "ocaml.reveal-ast-node",
@@ -847,7 +847,7 @@
       {
         "command": "ocaml.search-by-type",
         "key": "Alt+F",
-        "when": "editorLangId == ocaml || editorLangId == ocaml.interface || editorLangId == reason"
+        "when": "editorTextFocus && editorLangId == ocaml || editorTextFocus && editorLangId == ocaml.interface || editorTextFocus && editorLangId == reason"
       },
       {
         "command": "ocaml.type-selection",
@@ -1089,7 +1089,7 @@
         {
           "command": "ocaml.evaluate-selection",
           "group": "OCaml",
-          "when": "editorTextFocus && editorLangId == ocaml || editorTextFocus && editorLangId == ocaml.interface || editorTextFocus && editorLangId == reason || editorTextFocus && editorLangId == ocaml.ocamllex || editorTextFocus && editorLangId == ocaml.menhir"
+          "when": "editorTextFocus && editorLangId == ocaml || editorTextFocus && editorLangId == ocaml.interface || editorTextFocus && editorLangId == reason"
         },
         {
           "command": "ocaml.reveal-ast-node",
@@ -1179,7 +1179,7 @@
         {
           "command": "ocaml.switch-impl-intf",
           "key": "Alt+O",
-          "when": "editorLangId == ocaml || editorLangId == ocaml.interface || editorLangId == reason || editorLangId == ocaml.ocamllex || editorLangId == ocaml.menhir",
+          "when": "editorLangId == ocaml || editorLangId == ocaml.interface || editorLangId == reason",
           "group": "navigation"
         }
       ],


### PR DESCRIPTION
Explicitly add editorTextFocus to each language condition in keybindings to ensure correct operator precedence. Previously, conditions like `editorTextFocus && editorLangId == ocaml || editorLangId == reason` were ambiguous and could activate incorrectly.

Remove `ocaml.ocamllex` and `ocaml.menhir` from `switch-impl-intf` command. The implementation only supports `.ml` and `.re` files for switching between implementation and interface.

Remove `ocaml.ocamllex` and `ocaml.menhir` from `evaluate-selection` command. These file types contain specialised syntax not suitable for REPL evaluation.