### PR TITLE
Remove reliance on external which command in Dune.make

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+- Fix dune detection failing on Windows when `which` is unavailable by
+  running dune directly through `opam exec` instead. (#2131)
+
 ## 2.1.0
 
 - Fix version parsing for nightly and dev builds of dune. This resolves

--- a/src/dune.ml
+++ b/src/dune.ml
@@ -121,7 +121,6 @@ let make root () =
   let dune_version_output bin root =
     command { root; bin } ~args:[ "--version" ] |> Cmd.output ~cwd:root
   in
-  (* Should we do something specific for Windows ? *)
   match root with
   | Some root ->
     let spawn = { Cmd.bin = binary; args = [] } in
@@ -136,24 +135,14 @@ let make root () =
            | _ -> None)
         | Error _err -> None)
      | Error _err ->
-       let* check_if_dune_is_installed_with_opam =
-         command
-           { root; bin = { Cmd.bin = Path.of_string "opam"; args = [] } }
-           ~args:[ "exec"; "--"; "which"; "dune" ]
-         |> Cmd.output ~cwd:root
-       in
-       (match check_if_dune_is_installed_with_opam with
-        | Error _err -> Promise.return None
-        | Ok path when String.is_empty path -> Promise.return None
-        | Ok path ->
-          let bin = { Cmd.bin = Path.of_string path; args = [] } in
-          let* dune_version_output = dune_version_output bin root in
-          (match dune_version_output with
-           | Ok v ->
-             (match Dune_version.from_string v with
-              | Some version when Dune_version.is_valid version ->
-                Promise.return (Some { bin; root })
-              | _ -> Promise.return None)
-           | Error _err -> Promise.return None)))
+       let bin = { Cmd.bin = Path.of_string "opam"; args = [ "exec"; "--"; "dune" ] } in
+       let* dune_version_output = dune_version_output bin root in
+       (match dune_version_output with
+        | Ok v ->
+          (match Dune_version.from_string v with
+           | Some version when Dune_version.is_valid version ->
+             Promise.return (Some { bin; root })
+           | _ -> Promise.return None)
+        | Error _err -> Promise.return None))
   | None -> Promise.return None
 ;;


### PR DESCRIPTION
## Problem

On native Windows, the `which` programme is not available. When `dune` is not found on PATH, `Dune.make` falls back to running `opam exec -- which dune` to locate it within the current opam switch. This fails on Windows with `[ERROR] Command not found 'which'`, preventing the extension from discovering dune installed via opam.

Reported in #2105.

## Solution

Rather than using `which` (or `where.exe` on Windows) to resolve the dune binary path and then invoking it directly, store `opam exec -- dune` as the `Dune.t.bin` spawn command. All command-generating functions (`command`, `exec`, `tools`) use `Cmd.append t.bin args`, so subsequent dune invocations are correctly issued as `opam exec -- dune <args>`.

This approach:
- Eliminates the need for any external path-resolution command (`which`, `where.exe`)
- Ensures the full opam environment is available for all subsequent dune commands
- Simplifies the fallback logic (removes an intermediate `which` step and its result parsing)

## Verification

- `dune build` succeeds
- `dune build @runtest` passes
- `dune build @fmt` passes
- Locally verified that `opam exec -- dune --version` correctly returns the version when run from a directory with a local opam switch

Closes #2105