### PR TITLE
fix: outputChannel.error is not a function

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+- Fix `outputChannel.error is not a function` error by creating the language
+  server output channel as a log output channel. (#2174)
+
 ## 2.2.0
 
 - Stop mutating `globalThis` in generated JS bindings by switching to `gen_js_api`

--- a/src-bindings/vscode/vscode.ml
+++ b/src-bindings/vscode/vscode.ml
@@ -1647,6 +1647,15 @@ module OutputChannel = struct
   let disposable this = Disposable.make ~dispose:(fun () -> dispose this)
 end
 
+module OutputChannelOptions = struct
+  include Interface.Make ()
+
+  include
+    [%js:
+      val log : t -> bool [@@js.get]
+      val create : log:bool -> t [@@js.builder]]
+end
+
 module Memento = struct
   include Interface.Make ()
 
@@ -3064,6 +3073,12 @@ module Window = struct
         :  name:string
         -> ?languageId:string
         -> unit
+        -> OutputChannel.t
+      [@@js.global "@vscode.window.createOutputChannel"]
+
+      val createOutputChannelWithOptions
+        :  name:string
+        -> options:OutputChannelOptions.t
         -> OutputChannel.t
       [@@js.global "@vscode.window.createOutputChannel"]
 

--- a/src-bindings/vscode/vscode.mli
+++ b/src-bindings/vscode/vscode.mli
@@ -1199,6 +1199,13 @@ module OutputChannel : sig
   val disposable : t -> Disposable.t
 end
 
+module OutputChannelOptions : sig
+  include Ojs.T
+
+  val log : t -> bool
+  val create : log:bool -> t
+end
+
 module Memento : sig
   include Ojs.T
 
@@ -2212,6 +2219,11 @@ module Window : sig
   val createInputBox : unit -> InputBox.t
   val showOpenDialog : ?options:OpenDialogOptions.t -> unit -> Uri.t list option Promise.t
   val createOutputChannel : name:string -> ?languageId:string -> unit -> OutputChannel.t
+
+  val createOutputChannelWithOptions
+    :  name:string
+    -> options:OutputChannelOptions.t
+    -> OutputChannel.t
 
   val setStatusBarMessage
     :  text:string

--- a/src/output.ml
+++ b/src/output.ml
@@ -1,5 +1,10 @@
+let language_server_output_channel_options = Vscode.OutputChannelOptions.create ~log:true
+
 let language_server_output_channel =
-  lazy (Vscode.Window.createOutputChannel ~name:"OCaml Language Server" ())
+  lazy
+    (Vscode.Window.createOutputChannelWithOptions
+       ~name:"OCaml Language Server"
+       ~options:language_server_output_channel_options)
 ;;
 
 let extension_output_channel =


### PR DESCRIPTION
Many colleagues complain about a runtime error in the vscode extension. No logs on Output, neither the OCaml Language Extension tab.

The terminal said:

<img width="1252" height="169" alt="image" src="https://github.com/user-attachments/assets/3e634b95-d41f-49a0-bf21-cb649af33aae" />

Might be related to this: https://github.com/ocamllabs/vscode-ocaml-platform/issues/2173

[OCaml Platform 2.2.0](https://github.com/ocamllabs/vscode-ocaml-platform/releases/tag/2.2.0) upgraded vscode-languageclient from 9.0.1 to 10.0.0 in this PR https://github.com/ocamllabs/vscode-ocaml-platform/pull/2163 while still passing a plain VS Code OutputChannel into the language client. Maybe we can have a e2e test to ensure CI could catch this in the future? @smorimoto.

Anyway, this PR passes the object (`{log: true}`) on `vscode.window.createOutputChannel` call, only the one that sends it into vscode-languageclient. The rest of createOutputChannels are untouched.