### PR TITLE
Pin CI OCaml compiler to 5.4

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -22,7 +22,7 @@ jobs:
       - name: Set-up OCaml
         uses: ocaml/setup-ocaml@v3
         with:
-          ocaml-compiler: 5
+          ocaml-compiler: 5.4
 
       - name: Set-up Mise
         uses: jdx/mise-action@v4
@@ -61,7 +61,7 @@ jobs:
       - name: Set-up OCaml
         uses: ocaml/setup-ocaml@v3
         with:
-          ocaml-compiler: 5
+          ocaml-compiler: 5.4
       - uses: ocaml/setup-ocaml/lint-opam@v3
 
   lint-fmt:
@@ -72,7 +72,7 @@ jobs:
       - name: Set-up OCaml
         uses: ocaml/setup-ocaml@v3
         with:
-          ocaml-compiler: 5
+          ocaml-compiler: 5.4
       - uses: ocaml/setup-ocaml/lint-fmt@v3
 
   release:

--- a/.github/workflows/opam-dependency-submission.yml
+++ b/.github/workflows/opam-dependency-submission.yml
@@ -22,5 +22,5 @@ jobs:
       - name: Set-up OCaml
         uses: ocaml/setup-ocaml@v3
         with:
-          ocaml-compiler: 5
+          ocaml-compiler: 5.4
       - uses: ocaml/setup-ocaml/analysis@v3


### PR DESCRIPTION
Pin GitHub Actions to OCaml 5.4 instead of the latest OCaml 5 release so CI does not pick OCaml 5.5, which is currently incompatible with js_of_ocaml 6.3.