### PR TITLE
Fix dune-project package version highlighting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- Fix syntax highlighting for the per-package `version` field in the `package`
+  stanza of `dune-project`. (#2182)
 - Use the Node.js entry point for `vscode-languageclient` to avoid loading the
   browser bundle in the extension host.
 - Rewrite the AST explorer webview in TypeScript with React Compiler, Vite and

--- a/syntaxes/dune-project.json
+++ b/syntaxes/dune-project.json
@@ -164,6 +164,17 @@
             },
 
             {
+              "comment": "version",
+              "begin": "\\([[:space:]]*(version)\\b",
+              "end": "\\)",
+              "beginCaptures": {
+                "1": { "name": "keyword.language.dune-project" }
+              },
+              "contentName": "constant.language.dune-project",
+              "patterns": [{ "include": "source.dune#general" }]
+            },
+
+            {
               "comment": "synopsis/description",
               "begin": "\\([[:space:]]*(synopsis|description)\\b",
               "end": "\\)",


### PR DESCRIPTION
## Summary
- add syntax highlighting for per-package `version` fields in `dune-project` package stanzas
- document the change in the changelog

## Tests
- `python3 -m json.tool syntaxes/dune-project.json >/dev/null`
- `bun run lint`
- `opam exec -- make build`
- `opam exec -- make test`