### PR TITLE
Fix dune LSP install failure loop

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+- Fix an infinite loop of error notifications when `dune tools install ocamllsp`
+  fails (e.g. with no opam switch installed) by only restarting the language
+  server after a successful installation. (#2183)
+
 ## 2.3.0
 
 - Fix syntax highlighting for the per-package `version` field in the `package`

--- a/src/extension_commands.ml
+++ b/src/extension_commands.ml
@@ -119,14 +119,17 @@ let _install_dune_lsp_server =
                 |> Cmd.output ~cwd:(Dune.root dune)
               in
               match result with
-              | Ok _ -> Ojs.null
+              | Ok _ -> Ojs.bool_to_js true
               | Error err ->
                 show_message `Error "An error occured while installing ocamllsp : %s" err;
-                Ojs.null
+                Ojs.bool_to_js false
             in
-            let* _ = Vscode.Window.withProgress (module Ojs) ~options ~task in
-            let+ _ = Extension_instance.start_language_server instance in
-            ())
+            let* installed = Vscode.Window.withProgress (module Ojs) ~options ~task in
+            if Ojs.bool_of_js installed
+            then
+              let+ _ = Extension_instance.start_language_server instance in
+              ()
+            else Promise.return ())
         else Extension_instance.suggest_to_run_dune_pkg_lock () |> Promise.return
       | _ ->
         show_message


### PR DESCRIPTION
## Summary

- Fix the Dune Package Management LSP install flow so the language server is only restarted after a successful `dune tools install ocamllsp`
- Prevent repeated error notifications when the Dune install command fails
- Add a changelog entry

## Testing

- `dune build`
- `ocamlformat --check src/extension_commands.ml`
- `dune build @runtest`
- `bun run lint`