### PR TITLE
Fix LSP not receiving workspace config on startup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@
 - Fix an infinite loop of error notifications when `dune tools install ocamllsp`
   fails (e.g. with no opam switch installed) by only restarting the language
   server after a successful installation. (#2183)
+- Fix the language server not receiving the workspace configuration on startup,
+  so settings such as codelens are correctly applied when the extension host
+  (re)starts instead of sending an empty configuration. (#2185)
 
 ## 2.3.0
 

--- a/src/extension_instance.ml
+++ b/src/extension_instance.ml
@@ -11,12 +11,7 @@ type t =
   ; documentation_server_info : StatusBarItem.t
   ; sandbox_info : StatusBarItem.t
   ; ast_editor_state : Ast_editor_state.t
-  ; mutable codelens : bool option
-  ; mutable codelens_for_nested_bindings : bool option
-  ; mutable extended_hover : bool option
   ; mutable standard_hover : bool option
-  ; mutable dune_diagnostics : bool option
-  ; mutable syntax_documentation : bool option
   }
 
 let sandbox t = t.sandbox
@@ -25,38 +20,26 @@ let ocaml_lsp t = Option.map ~f:snd t.lsp_client
 let lsp_client t = t.lsp_client
 let ocaml_version_exn t = Option.value_exn t.ocaml_version
 
-let send_configuration
-      ~codelens
-      ~codelens_for_nested_bindings
-      ~extended_hover
-      ~standard_hover
-      ~dune_diagnostics
-      ~syntax_documentation
-      client
-  =
+let send_configuration t client =
+  let enable_setting setting =
+    Option.map (Settings.get setting) ~f:(fun enable ->
+      Ocaml_lsp.OcamllspSettingEnable.create ~enable)
+  in
   let codelens =
-    Option.map codelens ~f:(fun enable ->
+    Option.map (Settings.get Settings.server_codelens_setting) ~f:(fun enable ->
       Ocaml_lsp.OcamllspSettingCodeLens.create
-        ?forNestedBindings:codelens_for_nested_bindings
+        ?forNestedBindings:
+          (Settings.get Settings.server_codelens_for_nested_bindings_setting)
         ~enable
         ())
   in
-  let extendedHover =
-    Option.map extended_hover ~f:(fun enable ->
-      Ocaml_lsp.OcamllspSettingEnable.create ~enable)
-  in
+  let extendedHover = enable_setting Settings.server_extendedHover_setting in
   let standardHover =
-    Option.map standard_hover ~f:(fun enable ->
+    Option.map t.standard_hover ~f:(fun enable ->
       Ocaml_lsp.OcamllspSettingEnable.create ~enable)
   in
-  let duneDiagnostics =
-    Option.map dune_diagnostics ~f:(fun enable ->
-      Ocaml_lsp.OcamllspSettingEnable.create ~enable)
-  in
-  let syntaxDocumentation =
-    Option.map syntax_documentation ~f:(fun enable ->
-      Ocaml_lsp.OcamllspSettingEnable.create ~enable)
-  in
+  let duneDiagnostics = enable_setting Settings.server_duneDiagnostics_setting in
+  let syntaxDocumentation = enable_setting Settings.server_syntaxDocumentation_setting in
   let settings =
     Ocaml_lsp.OcamllspSettings.create
       ~codelens
@@ -76,36 +59,11 @@ let send_configuration
   LanguageClient.sendNotification client "workspace/didChangeConfiguration" payload
 ;;
 
-let set_configuration
-      t
-      ?codelens
-      ?codelens_for_nested_bindings
-      ?extended_hover
-      ?standard_hover
-      ?dune_diagnostics
-      ?syntax_documentation
-      ()
-  =
-  Option.iter codelens ~f:(fun codelens -> t.codelens <- codelens);
-  Option.iter codelens_for_nested_bindings ~f:(fun codelens_for_nested_bindings ->
-    t.codelens_for_nested_bindings <- codelens_for_nested_bindings);
-  Option.iter extended_hover ~f:(fun extended_hover -> t.extended_hover <- extended_hover);
+let set_configuration t ?standard_hover () =
   Option.iter standard_hover ~f:(fun standard_hover -> t.standard_hover <- standard_hover);
-  Option.iter dune_diagnostics ~f:(fun dune_diagnostics ->
-    t.dune_diagnostics <- dune_diagnostics);
-  Option.iter syntax_documentation ~f:(fun syntax_documentation ->
-    t.syntax_documentation <- syntax_documentation);
   match t.lsp_client with
   | None -> ()
-  | Some (client, (_ : Ocaml_lsp.t)) ->
-    send_configuration
-      ~codelens:t.codelens
-      ~codelens_for_nested_bindings:t.codelens_for_nested_bindings
-      ~extended_hover:t.extended_hover
-      ~standard_hover:t.standard_hover
-      ~dune_diagnostics:t.dune_diagnostics
-      ~syntax_documentation:t.syntax_documentation
-      client
+  | Some (client, (_ : Ocaml_lsp.t)) -> send_configuration t client
 ;;
 
 let stop_server t =
@@ -275,14 +233,7 @@ end = struct
         (match Ocaml_lsp.is_version_up_to_date ocaml_lsp (ocaml_version_exn t) with
          | Ok () -> ()
          | Error (`Msg _) -> ());
-        send_configuration
-          client
-          ~codelens:t.codelens
-          ~codelens_for_nested_bindings:t.codelens_for_nested_bindings
-          ~extended_hover:t.extended_hover
-          ~standard_hover:t.standard_hover
-          ~dune_diagnostics:t.dune_diagnostics
-          ~syntax_documentation:t.syntax_documentation;
+        send_configuration t client;
         Ok ()
       in
       (match res with
@@ -370,12 +321,7 @@ let make () =
   ; ocaml_version = None
   ; ast_editor_state
   ; documentation_server = None
-  ; codelens = None
-  ; codelens_for_nested_bindings = None
-  ; extended_hover = None
   ; standard_hover = None
-  ; dune_diagnostics = None
-  ; syntax_documentation = None
   }
 ;;
 

--- a/src/extension_instance.mli
+++ b/src/extension_instance.mli
@@ -21,18 +21,7 @@ val start_language_server : t -> unit Promise.t
 val install_ocaml_lsp_server : Sandbox.t -> unit Promise.t
 val upgrade_ocaml_lsp_server : Sandbox.t -> unit Promise.t
 val suggest_to_run_dune_pkg_lock : unit -> unit
-
-val set_configuration
-  :  t
-  -> ?codelens:bool option
-  -> ?codelens_for_nested_bindings:bool option
-  -> ?extended_hover:bool option
-  -> ?standard_hover:bool option
-  -> ?dune_diagnostics:bool option
-  -> ?syntax_documentation:bool option
-  -> unit
-  -> unit
-
+val set_configuration : t -> ?standard_hover:bool option -> unit -> unit
 val open_terminal : Sandbox.t -> unit
 val disposable : t -> Disposable.t
 val repl : t -> Terminal_sandbox.t option

--- a/src/vscode_ocaml_platform.ml
+++ b/src/vscode_ocaml_platform.ml
@@ -19,22 +19,7 @@ let suggest_to_pick_sandbox () =
 
 let notify_configuration_changes instance =
   Workspace.onDidChangeConfiguration
-    ~listener:(fun _event ->
-      let codelens = Settings.(get server_codelens_setting) in
-      let codelens_for_nested_bindings =
-        Settings.(get server_codelens_for_nested_bindings_setting)
-      in
-      let extended_hover = Settings.(get server_extendedHover_setting) in
-      let dune_diagnostics = Settings.(get server_duneDiagnostics_setting) in
-      let syntax_documentation = Settings.(get server_syntaxDocumentation_setting) in
-      Extension_instance.set_configuration
-        instance
-        ~codelens
-        ~codelens_for_nested_bindings
-        ~extended_hover
-        ~dune_diagnostics
-        ~syntax_documentation
-        ())
+    ~listener:(fun _event -> Extension_instance.set_configuration instance ())
     ()
 ;;
 


### PR DESCRIPTION
## Context

When the extension host is restarted, the language server received `workspace/didChangeConfiguration` with an empty `{}` payload, so user settings such as codelens were not applied. This has been the case since #1321.

## Cause

The extension cached the configuration in mutable fields on the extension instance, which were only populated by the `onDidChangeConfiguration` listener. On startup the listener does not fire, so the fields stayed `None` and `send_configuration` serialised an empty object.

## Fix

`send_configuration` now reads the settings directly from the workspace configuration at send time, so the current configuration is always pushed when the server (re)starts and when settings change. Only `standard_hover`, which has no backing setting and is toggled at runtime by the "Type of selection" feature, is kept in the instance state.

Closes #1345