### PR TITLE
Use typed Interop.Js modules instead of Ojs directly

### DIFF
--- a/src-bindings/interop/interop.ml
+++ b/src-bindings/interop/interop.ml
@@ -99,6 +99,10 @@ module Js = struct
     type t = unit [@@js]
   end
 
+  module Bool = struct
+    type t = bool [@@js]
+  end
+
   module Result (Ok : Ojs.T) (Error : Ojs.T) = struct
     type t = (Ok.t, Error.t) result
 

--- a/src-bindings/interop/interop.ml
+++ b/src-bindings/interop/interop.ml
@@ -103,6 +103,10 @@ module Js = struct
     type t = bool [@@js]
   end
 
+  module String = struct
+    type t = string [@@js]
+  end
+
   module Result (Ok : Ojs.T) (Error : Ojs.T) = struct
     type t = (Ok.t, Error.t) result
 

--- a/src-bindings/interop/interop.mli
+++ b/src-bindings/interop/interop.mli
@@ -42,6 +42,7 @@ module Js : sig
 
   module Unit : Ojs.T with type t = unit
   module Bool : Ojs.T with type t = bool
+  module String : Ojs.T with type t = string
   module Result (Ok : Ojs.T) (Error : Ojs.T) : Ojs.T with type t = (Ok.t, Error.t) result
   module Or_undefined (T : Ojs.T) : Ojs.T with type t = T.t or_undefined
   module Dict (T : Ojs.T) : Ojs.T with type t = T.t Dict.t

--- a/src-bindings/interop/interop.mli
+++ b/src-bindings/interop/interop.mli
@@ -41,6 +41,7 @@ module Js : sig
   end
 
   module Unit : Ojs.T with type t = unit
+  module Bool : Ojs.T with type t = bool
   module Result (Ok : Ojs.T) (Error : Ojs.T) : Ojs.T with type t = (Ok.t, Error.t) result
   module Or_undefined (T : Ojs.T) : Ojs.T with type t = T.t or_undefined
   module Dict (T : Ojs.T) : Ojs.T with type t = T.t Dict.t

--- a/src/extension_commands.ml
+++ b/src/extension_commands.ml
@@ -166,12 +166,11 @@ let _run_dune_pkg_lock =
             Dune.exec_pkg ~cmd:"lock" dune |> Cmd.output ~cwd:(Dune.root dune)
           in
           match result with
-          | Ok _ -> Ojs.null
+          | Ok _ -> ()
           | Error err ->
-            show_message `Error "An error occurred while running dune pkg lock: %s" err;
-            Ojs.null
+            show_message `Error "An error occurred while running dune pkg lock: %s" err
         in
-        let+ _ = Vscode.Window.withProgress (module Ojs) ~options ~task in
+        let+ () = Vscode.Window.withProgress (module Interop.Js.Unit) ~options ~task in
         let _ = Extension_instance.start_language_server instance in
         ()
       | _ ->
@@ -309,12 +308,11 @@ let _install_opam =
               ()
           in
           match result with
-          | Ok () -> Ojs.null
+          | Ok () -> ()
           | Error err ->
-            show_message `Error "An error occured while installing opam %s" err;
-            Ojs.null
+            show_message `Error "An error occured while installing opam %s" err
         in
-        let+ _ = Vscode.Window.withProgress (module Ojs) ~options ~task in
+        let+ () = Vscode.Window.withProgress (module Interop.Js.Unit) ~options ~task in
         ()
       | Some opam, _ ->
         let* latest_version =
@@ -396,12 +394,12 @@ let _init_opam =
         ()
       in
       match result with
-      | Ok () -> Ojs.null
-      | Error err ->
-        show_message `Error "An error occured while initializing opam %s" err;
-        Ojs.null
+      | Ok () -> ()
+      | Error err -> show_message `Error "An error occured while initializing opam %s" err
     in
-    let _ = Vscode.Window.withProgress (module Ojs) ~options ~task in
+    let (_ : unit Promise.t) =
+      Vscode.Window.withProgress (module Interop.Js.Unit) ~options ~task
+    in
     ()
   in
   command Command_api.Internal.init_opam callback
@@ -433,12 +431,13 @@ let _install_ocaml_dev =
         ()
       in
       match result with
-      | Ok () -> Ojs.null
+      | Ok () -> ()
       | Error err ->
-        show_message `Error "An error occured while installing packages %s" err;
-        Ojs.null
+        show_message `Error "An error occured while installing packages %s" err
     in
-    let _ = Vscode.Window.withProgress (module Ojs) ~options ~task in
+    let (_ : unit Promise.t) =
+      Vscode.Window.withProgress (module Interop.Js.Unit) ~options ~task
+    in
     ()
   in
   command Command_api.Internal.install_ocaml_dev callback
@@ -468,12 +467,12 @@ let _open_utop =
         ()
       in
       match result with
-      | Ok () -> Ojs.null
-      | Error err ->
-        show_message `Error "An error occured while opening utop %s" err;
-        Ojs.null
+      | Ok () -> ()
+      | Error err -> show_message `Error "An error occured while opening utop %s" err
     in
-    let _ = Vscode.Window.withProgress (module Ojs) ~options ~task in
+    let (_ : unit Promise.t) =
+      Vscode.Window.withProgress (module Interop.Js.Unit) ~options ~task
+    in
     ()
   in
   command Command_api.Internal.open_utop callback

--- a/src/extension_commands.ml
+++ b/src/extension_commands.ml
@@ -119,13 +119,15 @@ let _install_dune_lsp_server =
                 |> Cmd.output ~cwd:(Dune.root dune)
               in
               match result with
-              | Ok _ -> Ojs.bool_to_js true
+              | Ok _ -> true
               | Error err ->
                 show_message `Error "An error occured while installing ocamllsp : %s" err;
-                Ojs.bool_to_js false
+                false
             in
-            let* installed = Vscode.Window.withProgress (module Ojs) ~options ~task in
-            if Ojs.bool_of_js installed
+            let* installed =
+              Vscode.Window.withProgress (module Interop.Js.Bool) ~options ~task
+            in
+            if installed
             then
               let+ _ = Extension_instance.start_language_server instance in
               ()

--- a/src/sandbox.ml
+++ b/src/sandbox.ml
@@ -660,13 +660,12 @@ let uninstall_packages t packages =
         ()
       in
       match result with
-      | Ok () -> Ojs.null
+      | Ok () -> ()
       | Error err ->
-        show_message `Error "An error occured while uninstalling the packages: %s" err;
-        Ojs.null
+        show_message `Error "An error occured while uninstalling the packages: %s" err
     in
     let open Promise.Syntax in
-    let+ _ = Vscode.Window.withProgress (module Ojs) ~options ~task in
+    let+ () = Vscode.Window.withProgress (module Interop.Js.Unit) ~options ~task in
     ()
 ;;
 
@@ -704,13 +703,12 @@ let install_packages t packages =
         ()
       in
       match result with
-      | Ok () -> Ojs.null
+      | Ok () -> ()
       | Error err ->
-        show_message `Error "An error occured while installing the packages: %s" err;
-        Ojs.null
+        show_message `Error "An error occured while installing the packages: %s" err
     in
     let open Promise.Syntax in
-    let+ _ = Vscode.Window.withProgress (module Ojs) ~options ~task in
+    let+ () = Vscode.Window.withProgress (module Interop.Js.Unit) ~options ~task in
     ()
 ;;
 
@@ -746,13 +744,12 @@ let upgrade_packages ?(packages = []) t =
         ()
       in
       match result with
-      | Ok () -> Ojs.null
+      | Ok () -> ()
       | Error err ->
-        show_message `Error "An error occured while upgrading the packages: %s" err;
-        Ojs.null
+        show_message `Error "An error occured while upgrading the packages: %s" err
     in
     let open Promise.Syntax in
-    let+ _ = Vscode.Window.withProgress (module Ojs) ~options ~task in
+    let+ () = Vscode.Window.withProgress (module Interop.Js.Unit) ~options ~task in
     ()
 ;;
 

--- a/src/treeview_sandbox.ml
+++ b/src/treeview_sandbox.ml
@@ -99,7 +99,7 @@ module Command = struct
           let task ~progress:_ ~token:_ = Odig.odoc_exec odig ~sandbox ~package_name in
           let* result =
             Vscode.Window.withProgress
-              (module Interop.Js.Result (Interop.Js.Unit) (Ojs.String))
+              (module Interop.Js.Result (Interop.Js.Unit) (Interop.Js.String))
               ~options
               ~task
           in


### PR DESCRIPTION
## Summary

Removes direct `Ojs` usage from the `Window.withProgress` call sites by introducing typed modules in `Interop.Js` and routing every caller through them.

### Changes

- Add `Interop.Js.Bool` and `Interop.Js.String` alongside the existing `Interop.Js.Unit`, so progress tasks can return plain OCaml values (`bool`, `string`, `unit`) instead of hand-rolling `Ojs.bool_to_js` / `Ojs.bool_of_js` / `Ojs.null` / `Ojs.String`.
- `install_dune_lsp` returns a plain `bool` and is parameterised by `(module Interop.Js.Bool)`.
- The remaining `withProgress` callers in `extension_commands.ml` and `sandbox.ml` return `unit` and use `(module Interop.Js.Unit)`.
- `treeview_sandbox.ml` uses `Interop.Js.String` instead of `Ojs.String`.
- Tighten the handling of `unit`-returning promises for type safety: awaited results that were `let+ _ =` are now `let+ () =`, and fire-and-forget promises are bound with an explicit `let (_ : unit Promise.t) =` annotation.

No behavioural change — this is a pure refactor that confines all low-level `Ojs` conversion to `Interop`.

## Test plan

- `dune build` succeeds
- `dune runtest` passes
- Formatted with ocamlformat 0.28.1