### PR TITLE
Complete syntax highlighting for the library stanza and parameterised libraries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,13 @@
   `library_parameter` stanza, the `parameters` and `implements` library fields,
   and the `(instantiate ...)` dependency form together with its `:as` keyword.
   (#2187)
+- Complete syntax highlighting for the remaining `library` stanza fields: the
+  `(kind parameter)`/`(kind virtual)` and bare `(modes byte native best melange)`
+  values, `virtual_modules`, `default_implementation`, `public_headers`,
+  `allow_unused_libraries`, `empty_module_interface_if_absent`, `instrumentation`,
+  `lint`, `extra_objects`, `stdlib`, `special_builtin_support`, `wasm_of_ocaml`,
+  and the `melange.libraries`, `melange.modules`, `melange.ppx_runtime_libraries`,
+  `melange.preprocess` and `melange.preprocessor_deps` fields. (#2187)
 - Fix an infinite loop of error notifications when `dune tools install ocamllsp`
   fails (e.g. with no opam switch installed) by only restarting the language
   server after a successful installation. (#2183)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+- Add syntax highlighting for Dune's parameterised library keywords: the
+  `library_parameter` stanza, the `parameters` and `implements` library fields,
+  and the `(instantiate ...)` dependency form together with its `:as` keyword.
+  (#2187)
 - Fix an infinite loop of error notifications when `dune tools install ocamllsp`
   fails (e.g. with no opam switch installed) by only restarting the language
   server after a successful installation. (#2183)

--- a/syntaxes/dune.json
+++ b/syntaxes/dune.json
@@ -48,6 +48,24 @@
           ]
         },
         {
+          "comment": "library_parameter",
+          "begin": "\\([[:space:]]*(library_parameter)\\b",
+          "end": "\\)",
+          "beginCaptures": {
+            "1": {
+              "name": "keyword.language.dune"
+            }
+          },
+          "patterns": [
+            {
+              "include": "#library"
+            },
+            {
+              "include": "#general"
+            }
+          ]
+        },
+        {
           "comment": "foreign_library",
           "begin": "\\([[:space:]]*(foreign_library)\\b",
           "end": "\\)",
@@ -2273,10 +2291,40 @@
           },
           "patterns": [
             {
-              "include": "#general"
+              "include": "#library_dependencies"
             },
             {
-              "include": "#library_dependencies"
+              "include": "#general"
+            }
+          ]
+        },
+        {
+          "comment": "parameters",
+          "begin": "\\([[:space:]]*(parameters)\\b",
+          "end": "\\)",
+          "beginCaptures": {
+            "1": {
+              "name": "keyword.language.dune"
+            }
+          },
+          "patterns": [
+            {
+              "include": "#general"
+            }
+          ]
+        },
+        {
+          "comment": "implements",
+          "begin": "\\([[:space:]]*(implements)\\b",
+          "end": "\\)",
+          "beginCaptures": {
+            "1": {
+              "name": "keyword.language.dune"
+            }
+          },
+          "patterns": [
+            {
+              "include": "#general"
             }
           ]
         },
@@ -2922,6 +2970,26 @@
     },
     "library_dependencies": {
       "patterns": [
+        {
+          "comment": "instantiated_dependencies",
+          "begin": "\\([[:space:]]*(instantiate)\\b",
+          "end": "\\)",
+          "beginCaptures": {
+            "1": {
+              "name": "keyword.language.dune"
+            }
+          },
+          "patterns": [
+            {
+              "comment": "instantiate/:as",
+              "match": ":as\\b",
+              "name": "keyword.language.dune"
+            },
+            {
+              "include": "#general"
+            }
+          ]
+        },
         {
           "comment": "alternative_dependencies",
           "patterns": [

--- a/syntaxes/dune.json
+++ b/syntaxes/dune.json
@@ -2329,6 +2329,36 @@
           ]
         },
         {
+          "comment": "default_implementation",
+          "begin": "\\([[:space:]]*(default_implementation)\\b",
+          "end": "\\)",
+          "beginCaptures": {
+            "1": {
+              "name": "keyword.language.dune"
+            }
+          },
+          "patterns": [
+            {
+              "include": "#general"
+            }
+          ]
+        },
+        {
+          "comment": "virtual_modules",
+          "begin": "\\([[:space:]]*(virtual_modules)\\b",
+          "end": "\\)",
+          "beginCaptures": {
+            "1": {
+              "name": "keyword.language.dune"
+            }
+          },
+          "patterns": [
+            {
+              "include": "#general"
+            }
+          ]
+        },
+        {
           "comment": "self_build_stubs_archive",
           "begin": "\\([[:space:]]*(self_build_stubs_archive)\\b",
           "end": "\\)",
@@ -2464,6 +2494,120 @@
           ]
         },
         {
+          "comment": "melange.libraries",
+          "begin": "\\([[:space:]]*(melange)(\\.)((libraries))\\b",
+          "end": "\\)",
+          "beginCaptures": {
+            "1": {
+              "name": "keyword.language.dune"
+            },
+            "2": {
+              "name": "keyword.operator.dune"
+            },
+            "3": {
+              "name": "keyword.language.dune"
+            }
+          },
+          "patterns": [
+            {
+              "include": "#library_dependencies"
+            },
+            {
+              "include": "#general"
+            }
+          ]
+        },
+        {
+          "comment": "melange.modules",
+          "begin": "\\([[:space:]]*(melange)(\\.)((modules))\\b",
+          "end": "\\)",
+          "beginCaptures": {
+            "1": {
+              "name": "keyword.language.dune"
+            },
+            "2": {
+              "name": "keyword.operator.dune"
+            },
+            "3": {
+              "name": "keyword.language.dune"
+            }
+          },
+          "patterns": [
+            {
+              "include": "#general"
+            }
+          ]
+        },
+        {
+          "comment": "melange.ppx_runtime_libraries",
+          "begin": "\\([[:space:]]*(melange)(\\.)((ppx_runtime_libraries))\\b",
+          "end": "\\)",
+          "beginCaptures": {
+            "1": {
+              "name": "keyword.language.dune"
+            },
+            "2": {
+              "name": "keyword.operator.dune"
+            },
+            "3": {
+              "name": "keyword.language.dune"
+            }
+          },
+          "patterns": [
+            {
+              "include": "#general"
+            }
+          ]
+        },
+        {
+          "comment": "melange.preprocessor_deps",
+          "begin": "\\([[:space:]]*(melange)(\\.)((preprocessor_deps))\\b",
+          "end": "\\)",
+          "beginCaptures": {
+            "1": {
+              "name": "keyword.language.dune"
+            },
+            "2": {
+              "name": "keyword.operator.dune"
+            },
+            "3": {
+              "name": "keyword.language.dune"
+            }
+          },
+          "patterns": [
+            {
+              "include": "#dependencies"
+            },
+            {
+              "include": "#general"
+            }
+          ]
+        },
+        {
+          "comment": "melange.preprocess",
+          "begin": "\\([[:space:]]*(melange)(\\.)((preprocess))\\b",
+          "end": "\\)",
+          "beginCaptures": {
+            "1": {
+              "name": "keyword.language.dune"
+            },
+            "2": {
+              "name": "keyword.operator.dune"
+            },
+            "3": {
+              "name": "keyword.language.dune"
+            }
+          },
+          "patterns": [
+            {
+              "include": "#preprocessing_specs"
+            },
+            {
+              "include": "#general"
+            }
+          ]
+        },
+        {
           "comment": "optional",
           "begin": "\\([[:space:]]*(optional)\\b",
           "end": "\\)",
@@ -2472,6 +2616,222 @@
               "name": "keyword.language.dune"
             }
           }
+        },
+        {
+          "comment": "empty_module_interface_if_absent",
+          "begin": "\\([[:space:]]*(empty_module_interface_if_absent)\\b",
+          "end": "\\)",
+          "beginCaptures": {
+            "1": {
+              "name": "keyword.language.dune"
+            }
+          }
+        },
+        {
+          "comment": "public_headers",
+          "begin": "\\([[:space:]]*(public_headers)\\b",
+          "end": "\\)",
+          "beginCaptures": {
+            "1": {
+              "name": "keyword.language.dune"
+            }
+          },
+          "patterns": [
+            {
+              "include": "#general"
+            }
+          ]
+        },
+        {
+          "comment": "allow_unused_libraries",
+          "begin": "\\([[:space:]]*(allow_unused_libraries)\\b",
+          "end": "\\)",
+          "beginCaptures": {
+            "1": {
+              "name": "keyword.language.dune"
+            }
+          },
+          "patterns": [
+            {
+              "include": "#general"
+            }
+          ]
+        },
+        {
+          "comment": "lint",
+          "begin": "\\([[:space:]]*(lint)\\b",
+          "end": "\\)",
+          "beginCaptures": {
+            "1": {
+              "name": "keyword.language.dune"
+            }
+          },
+          "patterns": [
+            {
+              "include": "#preprocessing_specs"
+            },
+            {
+              "include": "#general"
+            }
+          ]
+        },
+        {
+          "comment": "instrumentation",
+          "begin": "\\([[:space:]]*(instrumentation)\\b",
+          "end": "\\)",
+          "beginCaptures": {
+            "1": {
+              "name": "keyword.language.dune"
+            }
+          },
+          "patterns": [
+            {
+              "comment": "backend",
+              "begin": "\\([[:space:]]*(backend)\\b",
+              "end": "\\)",
+              "beginCaptures": {
+                "1": {
+                  "name": "keyword.language.dune"
+                }
+              },
+              "patterns": [
+                {
+                  "include": "#general"
+                }
+              ]
+            },
+            {
+              "comment": "flags/deps",
+              "begin": "\\([[:space:]]*(flags|deps)\\b",
+              "end": "\\)",
+              "beginCaptures": {
+                "1": {
+                  "name": "keyword.language.dune"
+                }
+              },
+              "patterns": [
+                {
+                  "include": "#dependencies"
+                },
+                {
+                  "include": "#general"
+                }
+              ]
+            },
+            {
+              "include": "#general"
+            }
+          ]
+        },
+        {
+          "comment": "extra_objects",
+          "begin": "\\([[:space:]]*(extra_objects)\\b",
+          "end": "\\)",
+          "beginCaptures": {
+            "1": {
+              "name": "keyword.language.dune"
+            }
+          },
+          "patterns": [
+            {
+              "comment": "files/archives",
+              "begin": "\\([[:space:]]*(files|archives)\\b",
+              "end": "\\)",
+              "beginCaptures": {
+                "1": {
+                  "name": "keyword.language.dune"
+                }
+              },
+              "patterns": [
+                {
+                  "include": "#general"
+                }
+              ]
+            },
+            {
+              "include": "#general"
+            }
+          ]
+        },
+        {
+          "comment": "stdlib",
+          "begin": "\\([[:space:]]*(stdlib)\\b",
+          "end": "\\)",
+          "beginCaptures": {
+            "1": {
+              "name": "keyword.language.dune"
+            }
+          },
+          "patterns": [
+            {
+              "comment": "modules_before_stdlib/exit_module/internal_modules/experimental_building_ocaml_compiler_with_dune",
+              "begin": "\\([[:space:]]*(modules_before_stdlib|exit_module|internal_modules|experimental_building_ocaml_compiler_with_dune)\\b",
+              "end": "\\)",
+              "beginCaptures": {
+                "1": {
+                  "name": "keyword.language.dune"
+                }
+              },
+              "patterns": [
+                {
+                  "include": "#general"
+                }
+              ]
+            },
+            {
+              "include": "#general"
+            }
+          ]
+        },
+        {
+          "comment": "special_builtin_support",
+          "begin": "\\([[:space:]]*(special_builtin_support)\\b",
+          "end": "\\)",
+          "beginCaptures": {
+            "1": {
+              "name": "keyword.language.dune"
+            }
+          },
+          "patterns": [
+            {
+              "comment": "findlib_dynload",
+              "match": "\\b(findlib_dynload)\\b",
+              "name": "variable.other.declaration.dune"
+            },
+            {
+              "comment": "build_info/configurator/dune_site",
+              "begin": "\\([[:space:]]*(build_info|configurator|dune_site)\\b",
+              "end": "\\)",
+              "beginCaptures": {
+                "1": {
+                  "name": "keyword.language.dune"
+                }
+              },
+              "patterns": [
+                {
+                  "comment": "data_module/api_version/plugins",
+                  "begin": "\\([[:space:]]*(data_module|api_version|plugins)\\b",
+                  "end": "\\)",
+                  "beginCaptures": {
+                    "1": {
+                      "name": "keyword.language.dune"
+                    }
+                  },
+                  "patterns": [
+                    {
+                      "include": "#general"
+                    }
+                  ]
+                },
+                {
+                  "include": "#general"
+                }
+              ]
+            },
+            {
+              "include": "#general"
+            }
+          ]
         },
         {
           "comment": "foreign_archives",
@@ -2633,6 +2993,11 @@
           },
           "patterns": [
             {
+              "comment": "byte/native/best/melange atoms",
+              "match": "\\b(byte|native|best|melange)\\b",
+              "name": "variable.other.declaration.dune"
+            },
+            {
               "comment": "byte/native/best",
               "begin": "\\([[:space:]]*(byte|native|best)\\b",
               "end": "\\)",
@@ -2677,6 +3042,11 @@
             }
           },
           "patterns": [
+            {
+              "comment": "normal/parameter/virtual/ppx_rewriter/ppx_deriver",
+              "match": "\\b(normal|parameter|virtual|ppx_rewriter|ppx_deriver)\\b",
+              "name": "variable.other.declaration.dune"
+            },
             {
               "comment": "normal/ppx_rewriter/ppx_deriver/cookies",
               "begin": "\\([[:space:]]*(normal|ppx_rewriter|ppx_deriver|cookies)\\b",
@@ -2790,6 +3160,10 @@
         {
           "comment": "js_of_ocaml",
           "include": "#js_of_ocaml"
+        },
+        {
+          "comment": "wasm_of_ocaml",
+          "include": "#wasm_of_ocaml"
         },
         {
           "comment": "inline_tests",
@@ -3431,8 +3805,38 @@
       },
       "patterns": [
         {
-          "comment": "javascript_files/flags/build_runtime_flags/link_flags",
-          "begin": "\\([[:space:]]*(javascript_files|flags|build_runtime_flags|link_flags)\\b",
+          "comment": "javascript_files/wasm_files/flags/build_runtime_flags/link_flags/enabled_if/compilation_mode/sourcemap",
+          "begin": "\\([[:space:]]*(javascript_files|wasm_files|flags|build_runtime_flags|link_flags|enabled_if|compilation_mode|sourcemap)\\b",
+          "end": "\\)",
+          "beginCaptures": {
+            "1": {
+              "name": "keyword.language.dune"
+            }
+          },
+          "patterns": [
+            {
+              "include": "#general"
+            }
+          ]
+        },
+        {
+          "include": "#general"
+        }
+      ]
+    },
+    "wasm_of_ocaml": {
+      "comment": "wasm_of_ocaml",
+      "begin": "\\([[:space:]]*(wasm_of_ocaml)\\b",
+      "end": "\\)",
+      "beginCaptures": {
+        "1": {
+          "name": "keyword.language.dune"
+        }
+      },
+      "patterns": [
+        {
+          "comment": "javascript_files/wasm_files/flags/build_runtime_flags/link_flags/enabled_if/compilation_mode/sourcemap",
+          "begin": "\\([[:space:]]*(javascript_files|wasm_files|flags|build_runtime_flags|link_flags|enabled_if|compilation_mode|sourcemap)\\b",
           "end": "\\)",
           "beginCaptures": {
             "1": {


### PR DESCRIPTION
## Summary

Completes `dune` file syntax highlighting for the `library` stanza family. It started from Dune's new parameterised library keywords (#1972) and now also fills in every other field of the `library` stanza that the grammar was still missing.

### Parameterised libraries (the original #1972 scope)

| Keyword | Kind | Example |
| --- | --- | --- |
| `library_parameter` | top-level stanza | `(library_parameter (name param))` |
| `parameters` | `library` field | `(library (parameters param))` |
| `implements` | `library` field | `(library (implements param))` |
| `instantiate` + `:as` | dependency form inside `(libraries ...)` | `(instantiate lib impl :as Lib1)` |

### Remaining `library` fields

- Bare-atom values for `(kind ...)` (`normal`, `parameter`, `virtual`, `ppx_rewriter`, `ppx_deriver`) and `(modes ...)` (`byte`, `native`, `best`, `melange`), which were previously only matched in their parenthesised forms.
- The virtual library fields `virtual_modules` and `default_implementation`.
- `public_headers`, `allow_unused_libraries`, `empty_module_interface_if_absent`, `instrumentation`, `lint`, `extra_objects`, `stdlib` and `special_builtin_support`, with their nested sub-fields.
- The Melange variants `melange.libraries`, `melange.modules`, `melange.ppx_runtime_libraries`, `melange.preprocess` and `melange.preprocessor_deps`.
- A `wasm_of_ocaml` block mirroring `js_of_ocaml`, plus the `js_of_ocaml` fields that were missing (`wasm_files`, `enabled_if`, `compilation_mode`, `sourcemap`).

The deprecated `no_keep_locs` field is intentionally omitted, as it has been an error since dune lang 2.0.

## Implementation notes

Field names and value sets were taken from the dune source of truth (`library.ml`, `buildable.ml`, `lib_kind.ml`, `mode_conf.ml`, `preprocess.ml`, `lib_info.ml`, `ocaml_stdlib.ml`, `js_of_ocaml.ml`). The `(kind ...)` and `(modes ...)` fixes add a bare-atom `match` rule alongside the existing parenthesised begin-rule, so both forms now highlight without disturbing the other.

## Verification

Tokenised with `vscode-textmate` + `vscode-oniguruma` (the engine VS Code itself uses):

- Every new keyword and nested sub-keyword highlights, including against the upstream parameterised-library tutorial files.
- The bare-atom `kind`/`modes` rules are scoped to their own stanzas and do not over-match elsewhere (e.g. a library named `parameter`, or `byte_complete`).
- Regression-checked against a 300-file corpus of real `dune` files from `ocaml/dune`: every token-level difference is an intended improvement, with no existing highlight changed.
- JSON validates and `oxfmt --check` passes.

Closes #1972