### PR TITLE
update latest dune versions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@
 - Fix the language server not receiving the workspace configuration on startup,
   so settings such as codelens are correctly applied when the extension host
   (re)starts instead of sending an empty configuration. (#2185)
+- Update dune cut-off version to 3.24.0 and nightly build from 11/06/2026 for DPM (#2192)
 
 ## 2.3.0
 

--- a/src/dune.ml
+++ b/src/dune.ml
@@ -61,17 +61,14 @@ module Dune_version = struct
     | None -> parse_release_version str
   ;;
 
-  (* Versions >= 3.20.0 and preview versions with a timestamp on or
-     after 2025-07-30 support everything needed for VSCode to support DPM,
-     e.g. `dune lock`, `dune tools exec`, support of various Dune dev tools etc.
-     The last feature needed was implemented on 2025-07-29 and ensures that
-     other Dune dev tools (in particular ocamlformat) are included in the PATH
-     of the `ocamllsp` process. *)
+  (* Versions >= 3.24.0 and preview versions with a timestamp on or
+     after 2026-06-11 support everything needed for VSCode to support DPM,
+     e.g. `dune lock`, `dune tools exec`, support of various Dune dev tools etc. *)
   let is_valid version =
     match version with
     | Release (major, minor, patch) ->
-      Stdlib.compare (major, minor, patch) (3, 20, 0) >= 0
-    | Preview (y, m, d) -> Stdlib.compare (y, m, d) (2025, 7, 30) >= 0
+      Stdlib.compare (major, minor, patch) (3, 24, 0) >= 0
+    | Preview (y, m, d) -> Stdlib.compare (y, m, d) (2026, 6, 11) >= 0
   ;;
 end
 


### PR DESCRIPTION
For DPM, we need to use the latest version of dune which supports all the features we need to implement.

cc @smorimoto 