### PR TITLE
Use the command `dune pkg enabled` to detect Dune Package Management context

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@
   so settings such as codelens are correctly applied when the extension host
   (re)starts instead of sending an empty configuration. (#2185)
 - Update dune cut-off version to 3.24.0 and nightly build from 11/06/2026 for DPM (#2192)
+- Fix the detection of Dune Package Management to use the recommended `dune pkg enabled` command. Previously, we were checking to see if a `dune.lock` file exists. (#2193)
 
 ## 2.3.0
 

--- a/src/dune.ml
+++ b/src/dune.ml
@@ -78,13 +78,6 @@ type t =
   }
 
 let binary = Path.of_string "dune"
-
-let is_project_locked t =
-  (* Path to the dune.lock dir *)
-  let dune_lock_path = Path.join t.root (Path.of_string "dune.lock") in
-  Fs.exists (Path.to_string dune_lock_path)
-;;
-
 let command t ~args = Cmd.Spawn (Cmd.append t.bin args)
 
 let exec ~target ?(args = []) t =
@@ -92,6 +85,12 @@ let exec ~target ?(args = []) t =
 ;;
 
 let exec_pkg ~cmd ?(args = []) t = Cmd.Spawn (Cmd.append t.bin ([ "pkg"; cmd ] @ args))
+
+let is_dpm_enabled t =
+  let open Promise.Syntax in
+  let+ { exitCode; _ } = Cmd.run (exec_pkg ~cmd:"enabled" t) in
+  Int.equal exitCode 0
+;;
 
 let tools ~tool ?(args = []) t cmd =
   match cmd with

--- a/src/dune.mli
+++ b/src/dune.mli
@@ -6,9 +6,8 @@ type t =
   ; bin : Cmd.spawn
   }
 
-(** Check if a dune project has been locked.
-    If not, user should be advised to run `dune pkg lock` *)
-val is_project_locked : t -> bool Promise.t
+(** Check if dune package management is enable. *)
+val is_dpm_enabled : t -> bool Promise.t
 
 (** Generic function to execute dune commands *)
 val command : t -> args:string list -> Cmd.t

--- a/src/extension_commands.ml
+++ b/src/extension_commands.ml
@@ -97,8 +97,8 @@ let _install_dune_lsp_server =
       let sandbox = Extension_instance.sandbox instance in
       match sandbox with
       | Dune dune ->
-        let* is_dune_locked = Dune.is_project_locked dune in
-        if is_dune_locked
+        let* dpm = Dune.is_dpm_enabled dune in
+        if dpm
         then
           let* dune_lsp_present = Dune.is_ocamllsp_present dune in
           if dune_lsp_present

--- a/src/sandbox.ml
+++ b/src/sandbox.ml
@@ -310,8 +310,7 @@ let detect_dune_pkg ~project_root _dune () =
   Dune.make (Some project_root) ()
   >>= function
   | Some dune ->
-    Dune.is_project_locked dune
-    >>| fun project_locked -> if project_locked then Some (Dune dune) else None
+    Dune.is_dpm_enabled dune >>| fun dpm -> if dpm then Some (Dune dune) else None
   | None -> Promise.return None
 ;;
 


### PR DESCRIPTION
Previously, we detect DPM context by checking for a `dune.lock` lock file in the current workspace. This method is not reliable.