### PR TITLE
Fix the launch of Utop REPL in context of Dune Package Management

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@
 - Fix the language server not receiving the workspace configuration on startup,
   so settings such as codelens are correctly applied when the extension host
   (re)starts instead of sending an empty configuration. (#2185)
+- Fix the launch of Utop REPL in context of Dune Package Management. (#2198)
 
 ## 2.3.0
 

--- a/src/repl.ml
+++ b/src/repl.ml
@@ -54,7 +54,11 @@ let name = "REPL"
 
 let has_utop (sandbox : Sandbox.t) =
   let open Promise.Syntax in
-  let cmd = Sandbox.get_command sandbox "utop" [ "-version" ] `Tool in
+  let cmd =
+    match sandbox with
+    | Dune dune -> Dune.tools dune ~tool:"utop" `Which
+    | _ -> Sandbox.get_command sandbox "utop" [ "-version" ] `Tool
+  in
   let cwd = Sandbox.workspace_root () in
   let+ result = Cmd.output ?cwd cmd in
   match result with


### PR DESCRIPTION
A small fixes to detect properly if Utop has been installed by Dune.