### PR TITLE
New workflow for setting Dune Package Manager as a "sandbox"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@
 - Update dune cut-off version to 3.24.0 and nightly build from 11/06/2026 for DPM (#2192)
 - Fix the detection of Dune Package Management to use the recommended `dune pkg enabled` command. Previously, we were checking to see if a `dune.lock` file exists. (#2193)
 - Fix the launch of Utop REPL in context of Dune Package Management. (#2198)
+- Redesign how Dune Package Manager is handled. Users now use a two step process, first to select DPM as a sandbox and then to select which dune binary they wish to use in the project (#2199)
 
 ## 2.3.0
 

--- a/src-bindings/vscode/vscode.ml
+++ b/src-bindings/vscode/vscode.ml
@@ -1023,6 +1023,13 @@ module QuickInputButton = struct
       val create : iconPath:iconPath -> ?tooltip:string -> unit -> t [@@js.builder]]
 end
 
+module QuickPickItemKind = struct
+  type t =
+    | Separator [@js -1]
+    | Default [@js 0]
+  [@@js.enum] [@@js]
+end
+
 module QuickPickItem = struct
   include Interface.Make ()
 
@@ -1033,6 +1040,7 @@ module QuickPickItem = struct
       val detail : t -> string or_undefined [@@js.get]
       val picked : t -> bool or_undefined [@@js.get]
       val alwaysShow : t -> bool or_undefined [@@js.get]
+      val kind : t -> QuickPickItemKind.t or_undefined [@@js.get]
 
       val create
         :  label:string
@@ -1040,6 +1048,7 @@ module QuickPickItem = struct
         -> ?detail:string
         -> ?picked:bool
         -> ?alwaysShow:bool
+        -> ?kind:QuickPickItemKind.t
         -> unit
         -> t
       [@@js.builder]]

--- a/src-bindings/vscode/vscode.mli
+++ b/src-bindings/vscode/vscode.mli
@@ -756,6 +756,13 @@ module QuickInputButton : sig
   val create : iconPath:iconPath -> ?tooltip:string -> unit -> t
 end
 
+module QuickPickItemKind : sig
+  type t =
+    | Separator [@js -1]
+    | Default [@js 0]
+  [@@js.enum]
+end
+
 module QuickPickItem : sig
   include Ojs.T
 
@@ -764,6 +771,7 @@ module QuickPickItem : sig
   val detail : t -> string option
   val picked : t -> bool option
   val alwaysShow : t -> bool option
+  val kind : t -> QuickPickItemKind.t option
 
   val create
     :  label:string
@@ -771,6 +779,7 @@ module QuickPickItem : sig
     -> ?detail:string
     -> ?picked:bool
     -> ?alwaysShow:bool
+    -> ?kind:QuickPickItemKind.t
     -> unit
     -> t
 end

--- a/src/dune.ml
+++ b/src/dune.ml
@@ -99,11 +99,11 @@ type t =
   ; bin : Cmd.spawn
   }
 
-let make ~root_dir ~dune_path =
+let make ~working_dir ~dune_path =
   let open Promise.Syntax in
   let* spawn = Cmd.check_spawn { Cmd.bin = dune_path; args = [] } in
   match spawn with
-  | Ok bin -> Promise.return (Some { root = root_dir; bin })
+  | Ok bin -> Promise.return (Some { root = working_dir; bin })
   | Error _ ->
     log_chan
       `Info

--- a/src/dune.ml
+++ b/src/dune.ml
@@ -220,9 +220,9 @@ let get_system_dune_path () =
        See: https://github.com/ocaml/dune/issues/11161 *)
     Promise.return None
   | Darwin | Linux | Other ->
-    let bash_script =
-      "if command -v opam >/dev/null 2>&1; then eval $(opam env --revert || true); fi; "
-      ^ "command -v dune && dune --version"
+    let shell_script =
+      "if which opam >/dev/null 2>&1; then eval $(opam env --revert || true); fi; "
+      ^ "which dune && dune --version"
     in
-    run_cmd "bash" [ "-c"; bash_script ]
+    run_cmd "sh" [ "-c"; shell_script ]
 ;;

--- a/src/dune.ml
+++ b/src/dune.ml
@@ -106,7 +106,7 @@ let make ~root_dir ~dune_path =
   | Ok bin -> Promise.return (Some { root = root_dir; bin })
   | Error _ ->
     log_chan
-      `Error
+      `Info
       ~section:"dune package management"
       "Dune not found in the environment.";
     Promise.return None

--- a/src/dune.ml
+++ b/src/dune.ml
@@ -97,8 +97,6 @@ type t =
   ; bin : Cmd.spawn
   }
 
-let binary = Path.of_string "dune"
-
 let make ~root ~path =
   let open Promise.Syntax in
   let* spawn = Cmd.check_spawn { Cmd.bin = path; args = [] } in
@@ -110,12 +108,6 @@ let make ~root ~path =
       ~section:"dune package management"
       "Dune not found in the environment.";
     Promise.return None
-;;
-
-let is_project_locked t =
-  (* Path to the dune.lock dir *)
-  let dune_lock_path = Path.join t.root (Path.of_string "dune.lock") in
-  Fs.exists (Path.to_string dune_lock_path)
 ;;
 
 let command t ~args = Cmd.Spawn (Cmd.append t.bin args)

--- a/src/dune.ml
+++ b/src/dune.ml
@@ -179,7 +179,6 @@ let is_dune_in_switch opam switch =
 ;;
 
 let all_opam_switches_with_dune opam switches =
-  let open Promise.Syntax in
   Promise.List.filter_map (fun switch -> is_dune_in_switch opam switch) switches
 ;;
 

--- a/src/dune.ml
+++ b/src/dune.ml
@@ -87,7 +87,7 @@ module Dune_version = struct
   let is_valid version =
     match version with
     | Release (major, minor, patch) ->
-      Stdlib.compare (major, minor, patch) (3, 20, 0) >= 0
+      Stdlib.compare (major, minor, patch) (3, 24, 0) >= 0
     | Preview (y, m, d) -> Stdlib.compare (y, m, d) (2026, 6, 11) >= 0
   ;;
 end

--- a/src/dune.ml
+++ b/src/dune.ml
@@ -105,10 +105,7 @@ let make ~working_dir ~dune_path =
   match spawn with
   | Ok bin -> Promise.return (Some { root = working_dir; bin })
   | Error _ ->
-    log_chan
-      `Info
-      ~section:"dune package management"
-      "Dune not found in the environment.";
+    log_chan `Info ~section:"dune package management" "Dune not found in the environment.";
     Promise.return None
 ;;
 

--- a/src/dune.ml
+++ b/src/dune.ml
@@ -5,6 +5,24 @@ module Dune_version = struct
     | Release of int * int * int
     | Preview of int * int * int
 
+  let to_string t =
+    match t with
+    | Release (major, minor, patch) -> Printf.sprintf "release-%d.%d.%d" major minor patch
+    | Preview (y, m, d) -> Printf.sprintf "nightly-%d-%d-%d" y m d
+  ;;
+
+  let compare v1 v2 =
+    match v1, v2 with
+    | Release (major1, minor1, patch1), Release (major2, minor2, patch2) ->
+      let open Stdlib in
+      compare (major1, minor1, patch1) (major2, minor2, patch2) |> Ordering.of_int
+    | Preview (y1, m1, d1), Preview (y2, m2, d2) ->
+      let open Stdlib in
+      compare (y1, m1, d1) (y2, m2, d2) |> Ordering.of_int
+    | Release _, Preview _ -> Ordering.of_int 1
+    | Preview _, Release _ -> Ordering.of_int (-1)
+  ;;
+
   let parse_release_version version_str =
     let extract_int s =
       let digits = String.filter s ~f:Char.is_digit in
@@ -72,19 +90,87 @@ module Dune_version = struct
   ;;
 end
 
+type scope =
+  | Global
+  | Switch
+
 type t =
   { root : Path.t
-  ; bin : Cmd.spawn
+  ; bin : [ `Global of Cmd.spawn | `Switch of Opam.t * Opam.Switch.t ]
   }
 
 let binary = Path.of_string "dune"
-let command t ~args = Cmd.Spawn (Cmd.append t.bin args)
 
-let exec ~target ?(args = []) t =
-  Cmd.Spawn (Cmd.append t.bin ([ "exec"; target; "--" ] @ args))
+let scope_of_string = function
+  | "global" -> Some `Global
+  | "switch" -> Some `Switch
+  | _ -> None
 ;;
 
-let exec_pkg ~cmd ?(args = []) t = Cmd.Spawn (Cmd.append t.bin ([ "pkg"; cmd ] @ args))
+let scope_of_json json =
+  let open Jsonoo.Decode in
+  match scope_of_string (string json) with
+  | Some s -> s
+  | None -> raise (Jsonoo.Decode_error "global | switch are the only valid values")
+;;
+
+let make_scope path scope =
+  match scope with
+  | `Global -> `Global { Cmd.bin = Path.of_string path; args = [] }
+  | `Switch ->
+    (match Opam.Switch.of_string path with
+     | None -> `Global { Cmd.bin = Path.of_string path; args = [] }
+     | Some switch -> `Switch (Opam.make (), switch))
+;;
+
+let make ~root ~path scope =
+  let open Promise.Syntax in
+  match scope with
+  | `Global ->
+    let* spawn = Cmd.check_spawn { Cmd.bin = Path.of_string path; args = [] } in
+    (match spawn with
+     | Ok bin -> Promise.return (Some { root; bin = `Global bin })
+     | Error _ ->
+       log_chan
+         `Error
+         ~section:"dune package management"
+         "Dune not found in the environment.";
+       Promise.return None)
+  | `Switch ->
+    (match Opam.Switch.of_string path with
+     | None ->
+       log_chan `Error ~section:"dune package management" "Invalid switch path: %s" path;
+       Promise.return None
+     | Some switch ->
+       let open Promise.Option.Syntax in
+       let* opam = Opam.make () in
+       Promise.return (Some { root; bin = `Switch (opam, switch) }))
+;;
+
+let is_project_locked t =
+  (* Path to the dune.lock dir *)
+  let dune_lock_path = Path.join t.root (Path.of_string "dune.lock") in
+  Fs.exists (Path.to_string dune_lock_path)
+;;
+
+let command t ~args =
+  match t.bin with
+  | `Global bin -> Cmd.Spawn (Cmd.append bin args)
+  | `Switch (opam, switch) -> Opam.exec opam switch ~args:([ "dune" ] @ args)
+;;
+
+let exec ~target ?(args = []) t =
+  match t.bin with
+  | `Global bin -> Cmd.Spawn (Cmd.append bin ([ "exec"; target; "--" ] @ args))
+  | `Switch (opam, switch) ->
+    Opam.exec opam switch ~args:([ "dune"; "exec"; target; "--" ] @ args)
+;;
+
+let exec_pkg ~cmd ?(args = []) t =
+  match t.bin with
+  | `Global bin -> Cmd.Spawn (Cmd.append bin ([ "pkg"; cmd ] @ args))
+  | `Switch (opam, switch) -> Opam.exec opam switch ~args:([ "dune"; "pkg"; cmd ] @ args)
+;;
 
 let is_dpm_enabled t =
   let open Promise.Syntax in
@@ -93,10 +179,18 @@ let is_dpm_enabled t =
 ;;
 
 let tools ~tool ?(args = []) t cmd =
-  match cmd with
-  | `Exec_ -> Cmd.Spawn (Cmd.append t.bin ([ "tools"; "exec"; tool; "--" ] @ args))
-  | `Which -> Cmd.Spawn (Cmd.append t.bin ([ "tools"; "which"; tool ] @ args))
-  | `Install -> Cmd.Spawn (Cmd.append t.bin ([ "tools"; "install"; tool ] @ args))
+  match t.bin with
+  | `Global bin ->
+    (match cmd with
+     | `Exec_ -> Cmd.Spawn (Cmd.append bin ([ "tools"; "exec"; tool; "--" ] @ args))
+     | `Which -> Cmd.Spawn (Cmd.append bin ([ "tools"; "which"; tool ] @ args))
+     | `Install -> Cmd.Spawn (Cmd.append bin ([ "tools"; "install"; tool ] @ args)))
+  | `Switch (opam, switch) ->
+    (match cmd with
+     | `Exec_ -> exec ~target:tool ~args t
+     | `Which -> Opam.exec opam switch ~args:([ "dune"; "tools"; "which"; tool ] @ args)
+     | `Install ->
+       Opam.exec opam switch ~args:([ "dune"; "tools"; "install"; tool ] @ args))
 ;;
 
 let is_ocamllsp_present t =
@@ -109,10 +203,44 @@ let is_ocamllsp_present t =
     false
 ;;
 
-let equal d1 d2 = Path.equal d1.root d2.root
+let equal d1 d2 =
+  let dune_bin =
+    match d1.bin, d2.bin with
+    | `Global bin1, `Global bin2 -> Path.equal bin1.bin bin2.bin
+    | `Switch (opam1, switch1), `Switch (opam2, switch2) ->
+      Opam.Switch.equal switch1 switch2 && Opam.equal opam1 opam2
+    | _ -> false
+  in
+  let root_equal = Path.equal d1.root d2.root in
+  dune_bin && root_equal
+;;
+
 let root t = t.root
 
-let make root () =
+let path_scope t =
+  match t.bin with
+  | `Global bin -> Path.to_string bin.bin, Global
+  | `Switch (_, switch) -> Opam.Switch.name switch, Switch
+;;
+
+let is_dune_in_switch opam switch =
+  let open Promise.Syntax in
+  Opam.exec opam switch ~args:[ "dune"; "--version" ]
+  |> Cmd.output
+  >>| function
+  | Ok v ->
+    (match Dune_version.from_string v with
+     | Some version when Dune_version.is_valid version -> Some (switch, version)
+     | _ -> None)
+  | Error _err -> None
+;;
+
+let all_opam_switches_with_dune opam switches =
+  let open Promise.Syntax in
+  Promise.List.filter_map (fun switch -> is_dune_in_switch opam switch) switches
+;;
+
+let get_dune_binaries root opam () =
   let open Promise.Syntax in
   let dune_version_output bin root =
     command { root; bin } ~args:[ "--version" ] |> Cmd.output ~cwd:root
@@ -121,24 +249,30 @@ let make root () =
   | Some root ->
     let spawn = { Cmd.bin = binary; args = [] } in
     let* spawn = Cmd.check_spawn spawn in
-    (match spawn with
-     | Ok bin ->
-       let+ dune_version_output = dune_version_output bin root in
-       (match dune_version_output with
-        | Ok v ->
-          (match Dune_version.from_string v with
-           | Some version when Dune_version.is_valid version -> Some { bin; root }
-           | _ -> None)
-        | Error _err -> None)
-     | Error _err ->
-       let bin = { Cmd.bin = Path.of_string "opam"; args = [ "exec"; "--"; "dune" ] } in
-       let* dune_version_output = dune_version_output bin root in
-       (match dune_version_output with
-        | Ok v ->
-          (match Dune_version.from_string v with
-           | Some version when Dune_version.is_valid version ->
-             Promise.return (Some { bin; root })
-           | _ -> Promise.return None)
-        | Error _err -> Promise.return None))
-  | None -> Promise.return None
+    let* global_dune =
+      match spawn with
+      | Ok bin ->
+        let+ output = dune_version_output (`Global bin) root in
+        (match output with
+         | Ok v ->
+           (match Dune_version.from_string v with
+            | Some version when Dune_version.is_valid version -> Some (bin, version)
+            | _ -> None)
+         | Error _err -> None)
+      | Error _err -> Promise.return None
+    in
+    let* opam_dunes =
+      match opam with
+      | Some opam ->
+        let* opam_switches = Opam.switch_list opam in
+        all_opam_switches_with_dune opam opam_switches
+      | None -> Promise.return []
+    in
+    let sorted_opam_dunes =
+      List.sort opam_dunes ~compare:(fun (_, v1) (_, v2) ->
+        (* Sort descending: most recent version first *)
+        Dune_version.compare v2 v1)
+    in
+    Promise.return (global_dune, sorted_opam_dunes)
+  | None -> Promise.return (None, [])
 ;;

--- a/src/dune.ml
+++ b/src/dune.ml
@@ -202,17 +202,17 @@ let get_system_dune_path () =
   let open Promise.Syntax in
   let run_cmd bin args =
     let cmd = Cmd.Spawn { bin = Path.of_string bin; args } in
-    let* output = Cmd.output cmd ~cwd:(Path.of_string "") in
+    let+ output = Cmd.output cmd ~cwd:(Path.of_string "") in
     match output with
     | Ok output ->
       (match String.split_lines (String.strip output) with
        | [ path; version_str ] ->
          let version = Dune_version.from_string (String.strip version_str) in
          (match version with
-          | Some v -> Promise.return (Some (String.strip path, v))
-          | None -> Promise.return None)
-       | _ -> Promise.return None)
-    | Error _ -> Promise.return None
+          | Some v -> Some (String.strip path, v)
+          | None -> None)
+       | _ -> None)
+    | Error _ -> None
   in
   match Platform.t with
   | Win32 ->

--- a/src/dune.ml
+++ b/src/dune.ml
@@ -200,8 +200,7 @@ let get_opam_dunes opam =
 
 let get_system_dune_path () =
   let open Promise.Syntax in
-  let run_cmd bin args =
-    let cmd = Cmd.Spawn { bin = Path.of_string bin; args } in
+  let run_cmd cmd =
     let+ output = Cmd.output cmd ~cwd:(Path.of_string "") in
     match output with
     | Ok output ->
@@ -224,5 +223,5 @@ let get_system_dune_path () =
       "if which opam >/dev/null 2>&1; then eval $(opam env --revert || true); fi; "
       ^ "which dune && dune --version"
     in
-    run_cmd "sh" [ "-c"; shell_script ]
+    run_cmd (Cmd.Shell shell_script)
 ;;

--- a/src/dune.ml
+++ b/src/dune.ml
@@ -7,20 +7,22 @@ module Dune_version = struct
 
   let to_string t =
     match t with
-    | Release (major, minor, patch) -> Printf.sprintf "release-%d.%d.%d" major minor patch
-    | Preview (y, m, d) -> Printf.sprintf "nightly-%d-%d-%d" y m d
+    | Release (major, minor, patch) ->
+      Printf.sprintf "(release) %d.%d.%d" major minor patch
+    | Preview (y, m, d) -> Printf.sprintf "(nightly) %d-%d-%d" y m d
   ;;
 
   let compare v1 v2 =
+    let open Stdlib in
     match v1, v2 with
     | Release (major1, minor1, patch1), Release (major2, minor2, patch2) ->
-      let open Stdlib in
       compare (major1, minor1, patch1) (major2, minor2, patch2) |> Ordering.of_int
     | Preview (y1, m1, d1), Preview (y2, m2, d2) ->
-      let open Stdlib in
       compare (y1, m1, d1) (y2, m2, d2) |> Ordering.of_int
-    | Release _, Preview _ -> Ordering.of_int 1
-    | Preview _, Release _ -> Ordering.of_int (-1)
+    | Release _, Preview _ ->
+      Ordering.of_int (-1)
+      (* we assume that users using a preview version are using a more recent version or updating the  nightly previews frequently *)
+    | Preview _, Release _ -> Ordering.of_int 1
   ;;
 
   let parse_release_version version_str =
@@ -158,14 +160,30 @@ let dune_path t = t.bin.bin
 
 let is_dune_in_switch opam switch =
   let open Promise.Syntax in
-  Opam.exec opam switch ~args:[ "dune"; "--version" ]
+  Opam.var opam switch ~args:[ "dune:bin" ]
   |> Cmd.output
-  >>| function
-  | Ok v ->
-    (match Dune_version.from_string v with
-     | Some version when Dune_version.is_valid version -> Some (switch, version)
-     | _ -> None)
-  | Error _err -> None
+  >>= function
+  | Error err ->
+    log_chan
+      `Error
+      ~section:"dune package management"
+      "Dune is not installed in switch %s: %s"
+      (Opam.Switch.name switch)
+      err;
+    Promise.return None
+  | Ok path ->
+    command
+      { root = Path.of_string ""
+      ; bin = { Cmd.bin = Path.(of_string (Stdlib.String.trim path) / "dune"); args = [] }
+      }
+      ~args:[ "--version" ]
+    |> Cmd.output
+    >>| (function
+     | Ok v ->
+       (match Dune_version.from_string v with
+        | Some version when Dune_version.is_valid version -> Some (path, switch, version)
+        | _ -> None)
+     | Error _err -> None)
 ;;
 
 let all_opam_switches_with_dune opam switches =
@@ -173,39 +191,48 @@ let all_opam_switches_with_dune opam switches =
   Promise.List.filter_map (fun switch -> is_dune_in_switch opam switch) switches
 ;;
 
-let get_dune_binaries root opam () =
+let get_opam_dunes opam =
   let open Promise.Syntax in
-  let dune_version_output bin root =
-    command { root; bin } ~args:[ "--version" ] |> Cmd.output ~cwd:root
+  let* opam_dunes =
+    match opam with
+    | Some opam ->
+      let* opam_switches = Opam.switch_list opam in
+      all_opam_switches_with_dune opam opam_switches
+    | None -> Promise.return []
   in
-  match root with
-  | Some root ->
-    let spawn = { Cmd.bin = binary; args = [] } in
-    let* spawn = Cmd.check_spawn spawn in
-    let* global_dune =
-      match spawn with
-      | Ok bin ->
-        let+ output = dune_version_output bin root in
-        (match output with
-         | Ok v ->
-           (match Dune_version.from_string v with
-            | Some version when Dune_version.is_valid version -> Some (bin, version)
-            | _ -> None)
-         | Error _err -> None)
-      | Error _err -> Promise.return None
+  let sorted_opam_dunes =
+    List.sort opam_dunes ~compare:(fun (_, _, v1) (_, _, v2) ->
+      (* Sort descending: most recent version first *)
+      Dune_version.compare v2 v1)
+  in
+  Promise.return sorted_opam_dunes
+;;
+
+let get_system_dune_path () =
+  let open Promise.Syntax in
+  let run_cmd bin args =
+    let cmd = Cmd.Spawn { bin = Path.of_string bin; args } in
+    let* output = Cmd.output cmd ~cwd:(Path.of_string "") in
+    match output with
+    | Ok output ->
+      (match String.split_lines (String.strip output) with
+       | [ path; version_str ] ->
+         let version = Dune_version.from_string (String.strip version_str) in
+         (match version with
+          | Some v -> Promise.return (Some (String.strip path, v))
+          | None -> Promise.return None)
+       | _ -> Promise.return None)
+    | Error _ -> Promise.return None
+  in
+  match Platform.t with
+  | Win32 ->
+    (* Dune package management is not supported on Windows at the moment
+       See: https://github.com/ocaml/dune/issues/11161 *)
+    Promise.return None
+  | Darwin | Linux | Other ->
+    let bash_script =
+      "if command -v opam >/dev/null 2>&1; then eval $(opam env --revert || true); fi; "
+      ^ "command -v dune && dune --version"
     in
-    let* opam_dunes =
-      match opam with
-      | Some opam ->
-        let* opam_switches = Opam.switch_list opam in
-        all_opam_switches_with_dune opam opam_switches
-      | None -> Promise.return []
-    in
-    let sorted_opam_dunes =
-      List.sort opam_dunes ~compare:(fun (_, v1) (_, v2) ->
-        (* Sort descending: most recent version first *)
-        Dune_version.compare v2 v1)
-    in
-    Promise.return (global_dune, sorted_opam_dunes)
-  | None -> Promise.return (None, [])
+    run_cmd "bash" [ "-c"; bash_script ]
 ;;

--- a/src/dune.ml
+++ b/src/dune.ml
@@ -85,66 +85,29 @@ module Dune_version = struct
   let is_valid version =
     match version with
     | Release (major, minor, patch) ->
-      Stdlib.compare (major, minor, patch) (3, 24, 0) >= 0
+      Stdlib.compare (major, minor, patch) (3, 20, 0) >= 0
     | Preview (y, m, d) -> Stdlib.compare (y, m, d) (2026, 6, 11) >= 0
   ;;
 end
 
-type scope =
-  | Global
-  | Switch
-
 type t =
   { root : Path.t
-  ; bin : [ `Global of Cmd.spawn | `Switch of Opam.t * Opam.Switch.t ]
+  ; bin : Cmd.spawn
   }
 
 let binary = Path.of_string "dune"
 
-let scope_of_string = function
-  | "global" -> Some `Global
-  | "switch" -> Some `Switch
-  | _ -> None
-;;
-
-let scope_of_json json =
-  let open Jsonoo.Decode in
-  match scope_of_string (string json) with
-  | Some s -> s
-  | None -> raise (Jsonoo.Decode_error "global | switch are the only valid values")
-;;
-
-let make_scope path scope =
-  match scope with
-  | `Global -> `Global { Cmd.bin = Path.of_string path; args = [] }
-  | `Switch ->
-    (match Opam.Switch.of_string path with
-     | None -> `Global { Cmd.bin = Path.of_string path; args = [] }
-     | Some switch -> `Switch (Opam.make (), switch))
-;;
-
-let make ~root ~path scope =
+let make ~root ~path =
   let open Promise.Syntax in
-  match scope with
-  | `Global ->
-    let* spawn = Cmd.check_spawn { Cmd.bin = Path.of_string path; args = [] } in
-    (match spawn with
-     | Ok bin -> Promise.return (Some { root; bin = `Global bin })
-     | Error _ ->
-       log_chan
-         `Error
-         ~section:"dune package management"
-         "Dune not found in the environment.";
-       Promise.return None)
-  | `Switch ->
-    (match Opam.Switch.of_string path with
-     | None ->
-       log_chan `Error ~section:"dune package management" "Invalid switch path: %s" path;
-       Promise.return None
-     | Some switch ->
-       let open Promise.Option.Syntax in
-       let* opam = Opam.make () in
-       Promise.return (Some { root; bin = `Switch (opam, switch) }))
+  let* spawn = Cmd.check_spawn { Cmd.bin = path; args = [] } in
+  match spawn with
+  | Ok bin -> Promise.return (Some { root; bin })
+  | Error _ ->
+    log_chan
+      `Error
+      ~section:"dune package management"
+      "Dune not found in the environment.";
+    Promise.return None
 ;;
 
 let is_project_locked t =
@@ -153,24 +116,13 @@ let is_project_locked t =
   Fs.exists (Path.to_string dune_lock_path)
 ;;
 
-let command t ~args =
-  match t.bin with
-  | `Global bin -> Cmd.Spawn (Cmd.append bin args)
-  | `Switch (opam, switch) -> Opam.exec opam switch ~args:([ "dune" ] @ args)
-;;
+let command t ~args = Cmd.Spawn (Cmd.append t.bin args)
 
 let exec ~target ?(args = []) t =
-  match t.bin with
-  | `Global bin -> Cmd.Spawn (Cmd.append bin ([ "exec"; target; "--" ] @ args))
-  | `Switch (opam, switch) ->
-    Opam.exec opam switch ~args:([ "dune"; "exec"; target; "--" ] @ args)
+  Cmd.Spawn (Cmd.append t.bin ([ "exec"; target; "--" ] @ args))
 ;;
 
-let exec_pkg ~cmd ?(args = []) t =
-  match t.bin with
-  | `Global bin -> Cmd.Spawn (Cmd.append bin ([ "pkg"; cmd ] @ args))
-  | `Switch (opam, switch) -> Opam.exec opam switch ~args:([ "dune"; "pkg"; cmd ] @ args)
-;;
+let exec_pkg ~cmd ?(args = []) t = Cmd.Spawn (Cmd.append t.bin ([ "pkg"; cmd ] @ args))
 
 let is_dpm_enabled t =
   let open Promise.Syntax in
@@ -179,18 +131,10 @@ let is_dpm_enabled t =
 ;;
 
 let tools ~tool ?(args = []) t cmd =
-  match t.bin with
-  | `Global bin ->
-    (match cmd with
-     | `Exec_ -> Cmd.Spawn (Cmd.append bin ([ "tools"; "exec"; tool; "--" ] @ args))
-     | `Which -> Cmd.Spawn (Cmd.append bin ([ "tools"; "which"; tool ] @ args))
-     | `Install -> Cmd.Spawn (Cmd.append bin ([ "tools"; "install"; tool ] @ args)))
-  | `Switch (opam, switch) ->
-    (match cmd with
-     | `Exec_ -> exec ~target:tool ~args t
-     | `Which -> Opam.exec opam switch ~args:([ "dune"; "tools"; "which"; tool ] @ args)
-     | `Install ->
-       Opam.exec opam switch ~args:([ "dune"; "tools"; "install"; tool ] @ args))
+  match cmd with
+  | `Exec_ -> Cmd.Spawn (Cmd.append t.bin ([ "tools"; "exec"; tool; "--" ] @ args))
+  | `Which -> Cmd.Spawn (Cmd.append t.bin ([ "tools"; "which"; tool ] @ args))
+  | `Install -> Cmd.Spawn (Cmd.append t.bin ([ "tools"; "install"; tool ] @ args))
 ;;
 
 let is_ocamllsp_present t =
@@ -204,24 +148,13 @@ let is_ocamllsp_present t =
 ;;
 
 let equal d1 d2 =
-  let dune_bin =
-    match d1.bin, d2.bin with
-    | `Global bin1, `Global bin2 -> Path.equal bin1.bin bin2.bin
-    | `Switch (opam1, switch1), `Switch (opam2, switch2) ->
-      Opam.Switch.equal switch1 switch2 && Opam.equal opam1 opam2
-    | _ -> false
-  in
+  let dune_bin = Path.equal d1.bin.bin d2.bin.bin in
   let root_equal = Path.equal d1.root d2.root in
   dune_bin && root_equal
 ;;
 
 let root t = t.root
-
-let path_scope t =
-  match t.bin with
-  | `Global bin -> Path.to_string bin.bin, Global
-  | `Switch (_, switch) -> Opam.Switch.name switch, Switch
-;;
+let dune_path t = t.bin.bin
 
 let is_dune_in_switch opam switch =
   let open Promise.Syntax in
@@ -252,7 +185,7 @@ let get_dune_binaries root opam () =
     let* global_dune =
       match spawn with
       | Ok bin ->
-        let+ output = dune_version_output (`Global bin) root in
+        let+ output = dune_version_output bin root in
         (match output with
          | Ok v ->
            (match Dune_version.from_string v with

--- a/src/dune.ml
+++ b/src/dune.ml
@@ -92,16 +92,18 @@ module Dune_version = struct
   ;;
 end
 
+let construct_dune_path path = Path.(of_string (String.strip path) / "dune")
+
 type t =
   { root : Path.t
   ; bin : Cmd.spawn
   }
 
-let make ~root ~path =
+let make ~root_dir ~dune_path =
   let open Promise.Syntax in
-  let* spawn = Cmd.check_spawn { Cmd.bin = path; args = [] } in
+  let* spawn = Cmd.check_spawn { Cmd.bin = dune_path; args = [] } in
   match spawn with
-  | Ok bin -> Promise.return (Some { root; bin })
+  | Ok bin -> Promise.return (Some { root = root_dir; bin })
   | Error _ ->
     log_chan
       `Error
@@ -157,7 +159,7 @@ let is_dune_in_switch opam switch =
   >>= function
   | Error err ->
     log_chan
-      `Error
+      `Info
       ~section:"dune package management"
       "Dune is not installed in switch %s: %s"
       (Opam.Switch.name switch)
@@ -166,7 +168,7 @@ let is_dune_in_switch opam switch =
   | Ok path ->
     command
       { root = Path.of_string ""
-      ; bin = { Cmd.bin = Path.(of_string (Stdlib.String.trim path) / "dune"); args = [] }
+      ; bin = { Cmd.bin = construct_dune_path path; args = [] }
       }
       ~args:[ "--version" ]
     |> Cmd.output

--- a/src/dune.mli
+++ b/src/dune.mli
@@ -42,7 +42,7 @@ val is_ocamllsp_present : t -> bool Promise.t
 (** Check if amy two instances of dune pkg management projects are equal *)
 val equal : t -> t -> bool
 
-val make : root_dir:Path.t -> dune_path:Path.t -> t option Promise.t
+val make : working_dir:Path.t -> dune_path:Path.t -> t option Promise.t
 
 val get_opam_dunes
   :  Opam.t option

--- a/src/dune.mli
+++ b/src/dune.mli
@@ -9,6 +9,8 @@ module Dune_version : sig
   val is_valid : t -> bool
 end
 
+val construct_dune_path : string -> Path.t
+
 type t =
   { root : Path.t
   ; bin : Cmd.spawn
@@ -40,7 +42,7 @@ val is_ocamllsp_present : t -> bool Promise.t
 (** Check if amy two instances of dune pkg management projects are equal *)
 val equal : t -> t -> bool
 
-val make : root:Path.t -> path:Path.t -> t option Promise.t
+val make : root_dir:Path.t -> dune_path:Path.t -> t option Promise.t
 
 val get_opam_dunes
   :  Opam.t option

--- a/src/dune.mli
+++ b/src/dune.mli
@@ -5,6 +5,8 @@ module Dune_version : sig
   type t
 
   val to_string : t -> string
+  val from_string : string -> t option
+  val is_valid : t -> bool
 end
 
 type t =
@@ -21,7 +23,7 @@ val command : t -> args:string list -> Cmd.t
 (** Generic function to execute dune exec commands *)
 val exec : target:string -> ?args:string list -> t -> Cmd.t
 
-(** Run specific `dune pkg <foo> commands*)
+(** Run specific `dune pkg <foo> commands` *)
 val exec_pkg : cmd:string -> ?args:string list -> t -> Cmd.t
 
 (** Run `dune tools <exec/which>` *)
@@ -40,12 +42,11 @@ val equal : t -> t -> bool
 
 val make : root:Path.t -> path:Path.t -> t option Promise.t
 
-val get_dune_binaries
-  :  Path.t option
-  -> Opam.t option
-  -> unit
-  -> ((Cmd.spawn * Dune_version.t) option * (Opam.Switch.t * Dune_version.t) list)
-       Promise.t
+val get_opam_dunes
+  :  Opam.t option
+  -> (string * Opam.Switch.t * Dune_version.t) list Promise.t
+
+val get_system_dune_path : unit -> (string * Dune_version.t) option Promise.t
 
 (** Get the path of the project root directory *)
 val root : t -> Path.t

--- a/src/dune.mli
+++ b/src/dune.mli
@@ -7,16 +7,10 @@ module Dune_version : sig
   val to_string : t -> string
 end
 
-type scope =
-  | Global
-  | Switch
-
 type t =
   { root : Path.t
-  ; bin : [ `Global of Cmd.spawn | `Switch of Opam.t * Opam.Switch.t ]
+  ; bin : Cmd.spawn
   }
-
-val scope_of_json : Jsonoo.t -> [> `Global | `Switch ]
 
 (** Check if dune package management is enable. *)
 val is_dpm_enabled : t -> bool Promise.t
@@ -44,7 +38,7 @@ val is_ocamllsp_present : t -> bool Promise.t
 (** Check if amy two instances of dune pkg management projects are equal *)
 val equal : t -> t -> bool
 
-val make : root:Path.t -> path:string -> [< `Global | `Switch ] -> t option Promise.t
+val make : root:Path.t -> path:Path.t -> t option Promise.t
 
 val get_dune_binaries
   :  Path.t option
@@ -56,4 +50,4 @@ val get_dune_binaries
 (** Get the path of the project root directory *)
 val root : t -> Path.t
 
-val path_scope : t -> string * scope
+val dune_path : t -> Path.t

--- a/src/dune.mli
+++ b/src/dune.mli
@@ -1,10 +1,22 @@
 (** Provide an interface to Dune pkg management.*)
 open Import
 
+module Dune_version : sig
+  type t
+
+  val to_string : t -> string
+end
+
+type scope =
+  | Global
+  | Switch
+
 type t =
   { root : Path.t
-  ; bin : Cmd.spawn
+  ; bin : [ `Global of Cmd.spawn | `Switch of Opam.t * Opam.Switch.t ]
   }
+
+val scope_of_json : Jsonoo.t -> [> `Global | `Switch ]
 
 (** Check if dune package management is enable. *)
 val is_dpm_enabled : t -> bool Promise.t
@@ -32,7 +44,16 @@ val is_ocamllsp_present : t -> bool Promise.t
 (** Check if amy two instances of dune pkg management projects are equal *)
 val equal : t -> t -> bool
 
-val make : Path.t option -> unit -> t option Promise.t
+val make : root:Path.t -> path:string -> [< `Global | `Switch ] -> t option Promise.t
+
+val get_dune_binaries
+  :  Path.t option
+  -> Opam.t option
+  -> unit
+  -> ((Cmd.spawn * Dune_version.t) option * (Opam.Switch.t * Dune_version.t) list)
+       Promise.t
 
 (** Get the path of the project root directory *)
 val root : t -> Path.t
+
+val path_scope : t -> string * scope

--- a/src/opam.ml
+++ b/src/opam.ml
@@ -260,6 +260,7 @@ let exec t switch ~args =
   spawn t ("exec" :: switch_arg switch :: "--set-switch" :: "--" :: args)
 ;;
 
+let var t switch ~args = spawn t ("var" :: switch_arg switch :: args)
 let init t = spawn t [ "init"; "-y" ]
 
 let parse_switch_list out =

--- a/src/opam.mli
+++ b/src/opam.mli
@@ -97,5 +97,8 @@ val package_remove : t -> Switch.t -> Package.t list -> Cmd.t
 (** Execute an opam sub-command with in the given switch. *)
 val exec : t -> Switch.t -> args:string list -> Cmd.t
 
+(** Execute opam var command. *)
+val var : t -> Switch.t -> args:string list -> Cmd.t
+
 (** Check that two instances of [Opam] are equal. *)
 val equal : t -> t -> bool

--- a/src/sandbox.ml
+++ b/src/sandbox.ml
@@ -90,10 +90,8 @@ let to_string = function
   | Opam (_, switch) -> Printf.sprintf "opam(%s)" (Opam.Switch.name switch)
   | Global -> "global"
   | Custom _ -> "custom"
-  | Dune dune ->
-    (match dune.bin with
-     | `Global bin -> Printf.sprintf "dune(%s)" (Path.basename bin.bin)
-     | `Switch (_, switch) -> Printf.sprintf "dune(%s)" (Opam.Switch.name switch))
+  (* TODO: it should be dune(<version>) *)
+  | Dune dune -> "dune"
 ;;
 
 let to_pretty_string t =
@@ -154,7 +152,7 @@ module Setting = struct
     | Esy of Esy.Manifest.t
     | Global
     | Custom of string
-    | Dune of Dune.scope * string * Path.t
+    | Dune of Path.t (* path to dune *)
 
   let kind : t -> Kind.t = function
     | Opam _ -> Opam
@@ -186,12 +184,8 @@ module Setting = struct
       let template = Jsonoo.Decode.field "template" decode_vars json in
       Custom template
     | Dune ->
-      let root = Jsonoo.Decode.field "root" decode_vars json |> Path.of_string in
       let path = Jsonoo.Decode.field "path" decode_vars json in
-      let scope = Jsonoo.Decode.field "scope" Dune.scope_of_json json in
-      (match scope with
-       | `Global -> Dune (Dune.Global, path, root)
-       | `Switch -> Dune (Dune.Switch, path, root))
+      Dune (Path.of_string path)
   ;;
 
   let to_json (t : t) =
@@ -205,18 +199,7 @@ module Setting = struct
         [ kind; "root", encode_vars @@ (manifest |> Esy.Manifest.path |> Path.to_string) ]
     | Opam switch -> object_ [ kind; "switch", encode_vars @@ Opam.Switch.name switch ]
     | Custom template -> object_ [ kind; "template", string template ]
-    | Dune (scope, path, root) ->
-      let scope_json =
-        match scope with
-        | Global -> "global"
-        | Switch -> "switch"
-      in
-      object_
-        [ kind
-        ; "scope", string scope_json
-        ; "path", string path
-        ; "root", string (Path.to_string root)
-        ]
+    | Dune path -> object_ [ kind; "path", string (Path.to_string path) ]
   ;;
 
   let t = Settings.create_setting ~scope:Workspace ~key:"sandbox" ~of_json ~to_json
@@ -275,14 +258,10 @@ let of_settings () : t option Promise.t =
          None))
   | Some Global -> Promise.return (Some Global)
   | Some (Custom template) -> Promise.return (Some (Custom template))
-  | Some (Dune (scope, path, root)) ->
+  | Some (Dune path) ->
     let open Promise.Option.Syntax in
-    let scope =
-      match scope with
-      | Global -> `Global
-      | Switch -> `Switch
-    in
-    let* dune = Dune.make ~root ~path scope in
+    let* root = workspace_root () |> Promise.return in
+    let* dune = Dune.make ~root ~path in
     Promise.return (Some (Dune dune))
 ;;
 
@@ -325,7 +304,7 @@ let detect_opam_sandbox ~project_root opam () =
 
 let detect_dune_pkg ~project_root () =
   let open Promise.Syntax in
-  Dune.make ~root:project_root ~path:(Path.to_string project_root) `Global
+  Dune.make ~root:project_root ~path:project_root
   >>= function
   | Some dune ->
     Dune.is_dpm_enabled dune >>| fun dpm -> if dpm then Some (Dune dune) else None
@@ -360,9 +339,8 @@ let save_to_settings sandbox =
     | Global -> Setting.Global
     | Custom template -> Setting.Custom template
     | Dune dune ->
-      let root = Dune.root dune in
-      let path, scope = Dune.path_scope dune in
-      Setting.Dune (scope, path, root)
+      let path = Dune.dune_path dune in
+      Setting.Dune path
   in
   Settings.set ~section:"ocaml" Setting.t (to_setting sandbox)
 ;;
@@ -440,7 +418,7 @@ let select_dune_binary () =
                    (Dune.Dune_version.to_string version))
               ~detail:(Path.to_string binary.bin)
               ()
-          , Dune.make ~root ~path:(Path.to_string binary.bin) `Global )
+          , Dune.make ~root ~path:binary.bin )
         ]
       | None -> []
     in
@@ -454,7 +432,7 @@ let select_dune_binary () =
                    (Dune.Dune_version.to_string version))
               ~detail:(Printf.sprintf "Switch: %s" (Opam.Switch.name switch))
               ()
-          , Dune.make ~root ~path:(Opam.Switch.name switch) `Switch ))
+          , Dune.make ~root ~path:(Path.of_string (Opam.Switch.name switch)) ))
         opam_dunes
     in
     let options =
@@ -546,7 +524,8 @@ let sandbox_candidates ~workspace_folders =
        custom commands in [select] *)
   in
   let dune =
-    let+ dummy_dune = Dune.make ~root:(Path.of_string "") ~path:"" `Global in
+    let dummy_path = Path.of_string "" in
+    let+ dummy_dune = Dune.make ~root:dummy_path ~path:dummy_path in
     match dummy_dune with
     | Some dummy_dune -> { Candidate.sandbox = Dune dummy_dune; status = Ok () }
     | None -> Candidate.ok Global

--- a/src/sandbox.ml
+++ b/src/sandbox.ml
@@ -91,7 +91,7 @@ let to_string = function
   | Global -> "global"
   | Custom _ -> "custom"
   (* TODO: it should be dune(<version>) *)
-  | Dune dune -> "dune"
+  | Dune _ -> "dune"
 ;;
 
 let to_pretty_string t =
@@ -577,7 +577,7 @@ let select_dune_binary () =
              Dune.make ~root ~path:(Path.of_string (String.strip path_str)))))
 ;;
 
-let select_sandbox (choices : Candidate.t list) t =
+let select_sandbox (choices : Candidate.t list) _t =
   let placeHolder = "Which package manager would you like to manage the sandbox?" in
   let open Promise.Syntax in
   let* current_switch =

--- a/src/sandbox.ml
+++ b/src/sandbox.ml
@@ -407,42 +407,174 @@ let select_dune_binary () =
   | Some root ->
     let* opam = Opam.make () in
     let create = QuickPickItem.create in
-    let* global_dune, opam_dunes = Dune.get_dune_binaries (Some root) opam () in
-    let global_dune_item =
-      match global_dune with
-      | Some (binary, version) ->
-        [ ( create
-              ~label:
-                (Printf.sprintf
-                   "Dune, %s, available"
-                   (Dune.Dune_version.to_string version))
-              ~detail:(Path.to_string binary.bin)
-              ()
-          , Dune.make ~root ~path:binary.bin )
-        ]
-      | None -> []
-    in
-    let opam_dune_items =
-      List.map
-        ~f:(fun (switch, version) ->
-          ( create
-              ~label:
-                (Printf.sprintf
-                   "Dune, %s, available via opam switch"
-                   (Dune.Dune_version.to_string version))
-              ~detail:(Printf.sprintf "Switch: %s" (Opam.Switch.name switch))
-              ()
-          , Dune.make ~root ~path:(Path.of_string (Opam.Switch.name switch)) ))
-        opam_dunes
-    in
+    let data = ref None in
     let options =
-      QuickPickOptions.create
-        ~canPickMany:false
-        ~placeHolder:"Which dune binary do you want to use for Dune Package Management?"
+      ProgressOptions.create
+        ~location:(`ProgressLocation Notification)
+        ~title:"Discovering Dune binaries..."
+        ~cancellable:false
         ()
     in
-    let choices = global_dune_item @ opam_dune_items in
-    Window.showQuickPickItems ~choices ~options ()
+    let task ~progress:_ ~token:_ =
+      let* opam_dunes = Dune.get_opam_dunes opam in
+      let* current_switch =
+        let open Promise.Option.Syntax in
+        let* opam = Promise.return opam in
+        Opam.switch_show ~cwd:root opam
+      in
+      let* system_dune = Dune.get_system_dune_path () in
+      data := Some (opam_dunes, current_switch, system_dune);
+      Promise.return ()
+    in
+    let* () = Window.withProgress (module Interop.Js.Unit) ~options ~task in
+    (match !data with
+     | None -> Promise.return None
+     | Some (opam_dunes, current_switch, system_dune) ->
+       let active_switch_item =
+         match current_switch with
+         | None -> None
+         | Some active ->
+           List.find_map opam_dunes ~f:(fun (path, switch, version) ->
+             if Opam.Switch.equal switch active
+             then (
+               let switch_kind_s =
+                 match switch with
+                 | Opam.Switch.Local _ -> "Local switch"
+                 | Opam.Switch.Named _ -> "Global switch"
+               in
+               let switch_name =
+                 match switch with
+                 | Opam.Switch.Local p -> Path.basename p
+                 | Opam.Switch.Named n -> n
+               in
+               let label =
+                 Printf.sprintf
+                   "Dune %s, via opam switch %s"
+                   (Dune.Dune_version.to_string version)
+                   switch_name
+               in
+               let description =
+                 switch_kind_s ^ " | Currently active switch in project root"
+               in
+               Some
+                 ( create
+                     ~label
+                     ~description
+                     ~detail:(Printf.sprintf "%s" (Stdlib.String.trim path ^ "/dune"))
+                     ()
+                 , `Opam_dune Path.(of_string (Stdlib.String.trim path) / "dune") ))
+             else None)
+       in
+       let global_dune_items, other_local_dune_items =
+         let inactive_dunes =
+           List.filter opam_dunes ~f:(fun (_path, switch, _version) ->
+             match current_switch with
+             | Some active -> not (Opam.Switch.equal switch active)
+             | None -> true)
+         in
+         let global_dunes, local_dunes =
+           List.partition_tf inactive_dunes ~f:(fun (_, switch, _) ->
+             match switch with
+             | Opam.Switch.Named _ -> true
+             | Opam.Switch.Local _ -> false)
+         in
+         let to_item (path, switch, version) =
+           let switch_name =
+             match switch with
+             | Opam.Switch.Local p -> Path.basename p
+             | Opam.Switch.Named n -> n
+           in
+           ( create
+               ~label:
+                 (Printf.sprintf
+                    "Dune %s, via opam switch %s"
+                    (Dune.Dune_version.to_string version)
+                    switch_name)
+               ~detail:(Printf.sprintf "%s" (Stdlib.String.trim path ^ "/dune"))
+               ()
+           , `Opam_dune Path.(of_string (Stdlib.String.trim path) / "dune") )
+         in
+         List.map ~f:to_item global_dunes, List.map ~f:to_item local_dunes
+       in
+       let system_dune_item =
+         match system_dune with
+         | Some (path, version) ->
+           let label =
+             Printf.sprintf
+               "Dune %s, via system PATH"
+               (Dune.Dune_version.to_string version)
+           in
+           Some
+             ( create ~label ~description:"System Dune" ~detail:path ()
+             , `Opam_dune (Path.of_string path) )
+         | None -> None
+       in
+       let custom_dune_item =
+         ( create
+             ~label:"Custom path to dune"
+             ~detail:"Provide a custom path to a dune executable"
+             ()
+         , `Custom_dune )
+       in
+       let separator =
+         create ~label:"Other dunes" ~kind:QuickPickItemKind.Separator (), `Separator
+       in
+       let other_dune_items = global_dune_items @ other_local_dune_items in
+       let choices =
+         Option.to_list active_switch_item
+         @ Option.to_list system_dune_item
+         @ [ custom_dune_item ]
+         @ if List.is_empty other_dune_items then [] else separator :: other_dune_items
+       in
+       let options =
+         QuickPickOptions.create
+           ~canPickMany:false
+           ~placeHolder:
+             "Which dune binary do you want to use for Dune Package Management?"
+           ()
+       in
+       let* choice = Window.showQuickPickItems ~choices ~options () in
+       (match choice with
+        | None | Some `Separator -> Promise.return None
+        | Some (`Opam_dune path) -> Dune.make ~root ~path
+        | Some `Custom_dune ->
+          let validateInput ~value =
+            let open Promise.Syntax in
+            let path = Path.of_string value in
+            let* exists = Fs.exists (Path.to_string path) in
+            if not exists
+            then Promise.return (Some "Provided path does not exist")
+            else (
+              let cmd = Cmd.Spawn { bin = path; args = [ "--version" ] } in
+              let* output = Cmd.output cmd ~cwd:(Path.of_string "") in
+              match output with
+              | Error _ ->
+                Promise.return (Some "Provided path is not a valid dune executable")
+              | Ok v ->
+                (match Dune.Dune_version.from_string v with
+                 | None -> Promise.return (Some "Unable to parse dune version")
+                 | Some version when Dune.Dune_version.is_valid version ->
+                   Promise.return None
+                 | Some version ->
+                   let msg =
+                     Printf.sprintf
+                       "Dune version %s is not supported. Please use a more recent \
+                        version."
+                       (Dune.Dune_version.to_string version)
+                   in
+                   Promise.return (Some msg)))
+          in
+          let options =
+            InputBoxOptions.create
+              ~prompt:"Input the path to the dune executable"
+              ~validateInput
+              ()
+          in
+          let* input = Window.showInputBox ~options () in
+          (match input with
+           | None -> Promise.return None
+           | Some path_str ->
+             Dune.make ~root ~path:(Path.of_string (String.strip path_str)))))
 ;;
 
 let select_sandbox (choices : Candidate.t list) t =
@@ -524,14 +656,17 @@ let sandbox_candidates ~workspace_folders =
        custom commands in [select] *)
   in
   let dune =
-    let dummy_path = Path.of_string "" in
-    let+ dummy_dune = Dune.make ~root:dummy_path ~path:dummy_path in
-    match dummy_dune with
-    | Some dummy_dune -> { Candidate.sandbox = Dune dummy_dune; status = Ok () }
-    | None -> Candidate.ok Global
+    match Platform.t with
+    | Win32 -> Promise.return None
+    | Darwin | Linux | Other ->
+      let dummy_path = Path.of_string "" in
+      let+ dummy_dune = Dune.make ~root:dummy_path ~path:dummy_path in
+      (match dummy_dune with
+       | Some dummy_dune -> Some { Candidate.sandbox = Dune dummy_dune; status = Ok () }
+       | None -> None)
   in
   let+ esy, (opam, current_switch), dune = Promise.all3 (esy, opam, dune) in
-  let cs = (global :: custom :: dune :: esy) @ opam in
+  let cs = global :: custom :: (Option.to_list dune @ esy @ opam) in
   Option.value_map current_switch ~default:cs ~f:(fun current_switch ->
     current_switch :: cs)
 ;;
@@ -562,8 +697,7 @@ let select_sandbox t =
     let template = String.strip input in
     Promise.Option.return @@ Custom template
   | { status = Ok (); sandbox = Dune _ } ->
-    let* dune = select_dune_binary () in
-    let+ dune = dune in
+    let+ dune = select_dune_binary () in
     Dune dune
   | { status; sandbox } ->
     (match status with

--- a/src/sandbox.ml
+++ b/src/sandbox.ml
@@ -90,7 +90,6 @@ let to_string = function
   | Opam (_, switch) -> Printf.sprintf "opam(%s)" (Opam.Switch.name switch)
   | Global -> "global"
   | Custom _ -> "custom"
-  (* TODO: it should be dune(<version>) *)
   | Dune _ -> "dune"
 ;;
 
@@ -261,7 +260,7 @@ let of_settings () : t option Promise.t =
   | Some (Dune path) ->
     let open Promise.Option.Syntax in
     let* root = workspace_root () |> Promise.return in
-    let* dune = Dune.make ~root ~path in
+    let* dune = Dune.make ~root_dir:root ~dune_path:path in
     Promise.return (Some (Dune dune))
 ;;
 
@@ -304,7 +303,7 @@ let detect_opam_sandbox ~project_root opam () =
 
 let detect_dune_pkg ~project_root () =
   let open Promise.Syntax in
-  Dune.make ~root:project_root ~path:project_root
+  Dune.make ~root_dir:project_root ~dune_path:project_root
   >>= function
   | Some dune ->
     Dune.is_dpm_enabled dune >>| fun dpm -> if dpm then Some (Dune dune) else None
@@ -400,6 +399,121 @@ module Candidate = struct
   let ok sandbox = { sandbox; status = Ok () }
 end
 
+let find_all_dune_binaries root opam () =
+  let open Promise.Syntax in
+  let* opam_dunes = Dune.get_opam_dunes opam in
+  let* current_switch =
+    let open Promise.Option.Syntax in
+    let* opam = Promise.return opam in
+    Opam.switch_show ~cwd:root opam
+  in
+  let+ system_dune = Dune.get_system_dune_path () in
+  opam_dunes, current_switch, system_dune
+;;
+
+let custom_dune_input_validation root =
+  let open Promise.Syntax in
+  let validateInput ~value =
+    let path = Path.of_string value in
+    let* exists = Fs.exists (Path.to_string path) in
+    if not exists
+    then Promise.return (Some "Provided path does not exist")
+    else (
+      let cmd = Cmd.Spawn { bin = path; args = [ "--version" ] } in
+      let+ output = Cmd.output cmd ~cwd:(Path.of_string "") in
+      match output with
+      | Error _ -> Some "Provided path is not a valid dune executable"
+      | Ok v ->
+        (match Dune.Dune_version.from_string v with
+         | None -> Some "Unable to parse dune version"
+         | Some version when Dune.Dune_version.is_valid version -> None
+         | Some version ->
+           let msg =
+             Printf.sprintf
+               "Dune version %s is not supported. Please use a more recent version."
+               (Dune.Dune_version.to_string version)
+           in
+           Some msg))
+  in
+  let options =
+    InputBoxOptions.create
+      ~prompt:"Input the path to the dune executable"
+      ~validateInput
+      ()
+  in
+  let* input = Window.showInputBox ~options () in
+  match input with
+  | None -> Promise.return None
+  | Some path_str ->
+    Dune.make ~root_dir:root ~dune_path:(Path.of_string (String.strip path_str))
+;;
+
+let get_active_switch_for_dpm opam_dunes = function
+  | None -> None
+  | Some active ->
+    List.find_map opam_dunes ~f:(fun (path, switch, version) ->
+      if Opam.Switch.equal switch active
+      then (
+        let switch_kind_s =
+          match switch with
+          | Opam.Switch.Local _ -> "Local switch"
+          | Opam.Switch.Named _ -> "Global switch"
+        in
+        let switch_name =
+          match switch with
+          | Opam.Switch.Local p -> Path.basename p
+          | Opam.Switch.Named n -> n
+        in
+        let label =
+          Printf.sprintf
+            "Dune %s, via opam switch %s"
+            (Dune.Dune_version.to_string version)
+            switch_name
+        in
+        let description = switch_kind_s ^ " | Currently active switch in project root" in
+        Some
+          ( QuickPickItem.create
+              ~label
+              ~description
+              ~detail:
+                (Printf.sprintf "%s" (Path.to_string (Dune.construct_dune_path path)))
+              ()
+          , `Opam_dune (Dune.construct_dune_path path) ))
+      else None)
+;;
+
+let get_non_active_opam_dunes opam_dunes current_switch =
+  let inactive_dunes =
+    List.filter opam_dunes ~f:(fun (_path, switch, _version) ->
+      match current_switch with
+      | Some active -> not (Opam.Switch.equal switch active)
+      | None -> true)
+  in
+  let global_dunes, local_dunes =
+    List.partition_tf inactive_dunes ~f:(fun (_, switch, _) ->
+      match switch with
+      | Opam.Switch.Named _ -> true
+      | Opam.Switch.Local _ -> false)
+  in
+  let to_item (path, switch, version) =
+    let switch_name =
+      match switch with
+      | Opam.Switch.Local p -> Path.basename p
+      | Opam.Switch.Named n -> n
+    in
+    ( QuickPickItem.create
+        ~label:
+          (Printf.sprintf
+             "Dune %s, via opam switch %s"
+             (Dune.Dune_version.to_string version)
+             switch_name)
+        ~detail:(Printf.sprintf "%s" (Path.to_string (Dune.construct_dune_path path)))
+        ()
+    , `Opam_dune (Dune.construct_dune_path path) )
+  in
+  List.map ~f:to_item global_dunes, List.map ~f:to_item local_dunes
+;;
+
 let select_dune_binary () =
   let open Promise.Syntax in
   match workspace_root () with
@@ -416,85 +530,18 @@ let select_dune_binary () =
         ()
     in
     let task ~progress:_ ~token:_ =
-      let* opam_dunes = Dune.get_opam_dunes opam in
-      let* current_switch =
-        let open Promise.Option.Syntax in
-        let* opam = Promise.return opam in
-        Opam.switch_show ~cwd:root opam
+      let+ opam_dunes, current_switch, system_dune =
+        find_all_dune_binaries root opam ()
       in
-      let* system_dune = Dune.get_system_dune_path () in
-      data := Some (opam_dunes, current_switch, system_dune);
-      Promise.return ()
+      data := Some (opam_dunes, current_switch, system_dune)
     in
     let* () = Window.withProgress (module Interop.Js.Unit) ~options ~task in
     (match !data with
      | None -> Promise.return None
      | Some (opam_dunes, current_switch, system_dune) ->
-       let active_switch_item =
-         match current_switch with
-         | None -> None
-         | Some active ->
-           List.find_map opam_dunes ~f:(fun (path, switch, version) ->
-             if Opam.Switch.equal switch active
-             then (
-               let switch_kind_s =
-                 match switch with
-                 | Opam.Switch.Local _ -> "Local switch"
-                 | Opam.Switch.Named _ -> "Global switch"
-               in
-               let switch_name =
-                 match switch with
-                 | Opam.Switch.Local p -> Path.basename p
-                 | Opam.Switch.Named n -> n
-               in
-               let label =
-                 Printf.sprintf
-                   "Dune %s, via opam switch %s"
-                   (Dune.Dune_version.to_string version)
-                   switch_name
-               in
-               let description =
-                 switch_kind_s ^ " | Currently active switch in project root"
-               in
-               Some
-                 ( create
-                     ~label
-                     ~description
-                     ~detail:(Printf.sprintf "%s" (Stdlib.String.trim path ^ "/dune"))
-                     ()
-                 , `Opam_dune Path.(of_string (Stdlib.String.trim path) / "dune") ))
-             else None)
-       in
+       let active_switch_item = get_active_switch_for_dpm opam_dunes current_switch in
        let global_dune_items, other_local_dune_items =
-         let inactive_dunes =
-           List.filter opam_dunes ~f:(fun (_path, switch, _version) ->
-             match current_switch with
-             | Some active -> not (Opam.Switch.equal switch active)
-             | None -> true)
-         in
-         let global_dunes, local_dunes =
-           List.partition_tf inactive_dunes ~f:(fun (_, switch, _) ->
-             match switch with
-             | Opam.Switch.Named _ -> true
-             | Opam.Switch.Local _ -> false)
-         in
-         let to_item (path, switch, version) =
-           let switch_name =
-             match switch with
-             | Opam.Switch.Local p -> Path.basename p
-             | Opam.Switch.Named n -> n
-           in
-           ( create
-               ~label:
-                 (Printf.sprintf
-                    "Dune %s, via opam switch %s"
-                    (Dune.Dune_version.to_string version)
-                    switch_name)
-               ~detail:(Printf.sprintf "%s" (Stdlib.String.trim path ^ "/dune"))
-               ()
-           , `Opam_dune Path.(of_string (Stdlib.String.trim path) / "dune") )
-         in
-         List.map ~f:to_item global_dunes, List.map ~f:to_item local_dunes
+         get_non_active_opam_dunes opam_dunes current_switch
        in
        let system_dune_item =
          match system_dune with
@@ -536,45 +583,8 @@ let select_dune_binary () =
        let* choice = Window.showQuickPickItems ~choices ~options () in
        (match choice with
         | None | Some `Separator -> Promise.return None
-        | Some (`Opam_dune path) -> Dune.make ~root ~path
-        | Some `Custom_dune ->
-          let validateInput ~value =
-            let open Promise.Syntax in
-            let path = Path.of_string value in
-            let* exists = Fs.exists (Path.to_string path) in
-            if not exists
-            then Promise.return (Some "Provided path does not exist")
-            else (
-              let cmd = Cmd.Spawn { bin = path; args = [ "--version" ] } in
-              let* output = Cmd.output cmd ~cwd:(Path.of_string "") in
-              match output with
-              | Error _ ->
-                Promise.return (Some "Provided path is not a valid dune executable")
-              | Ok v ->
-                (match Dune.Dune_version.from_string v with
-                 | None -> Promise.return (Some "Unable to parse dune version")
-                 | Some version when Dune.Dune_version.is_valid version ->
-                   Promise.return None
-                 | Some version ->
-                   let msg =
-                     Printf.sprintf
-                       "Dune version %s is not supported. Please use a more recent \
-                        version."
-                       (Dune.Dune_version.to_string version)
-                   in
-                   Promise.return (Some msg)))
-          in
-          let options =
-            InputBoxOptions.create
-              ~prompt:"Input the path to the dune executable"
-              ~validateInput
-              ()
-          in
-          let* input = Window.showInputBox ~options () in
-          (match input with
-           | None -> Promise.return None
-           | Some path_str ->
-             Dune.make ~root ~path:(Path.of_string (String.strip path_str)))))
+        | Some (`Opam_dune path) -> Dune.make ~root_dir:root ~dune_path:path
+        | Some `Custom_dune -> custom_dune_input_validation root))
 ;;
 
 let select_sandbox (choices : Candidate.t list) _t =
@@ -659,11 +669,24 @@ let sandbox_candidates ~workspace_folders =
     match Platform.t with
     | Win32 -> Promise.return None
     | Darwin | Linux | Other ->
-      let dummy_path = Path.of_string "" in
-      let+ dummy_dune = Dune.make ~root:dummy_path ~path:dummy_path in
-      (match dummy_dune with
-       | Some dummy_dune -> Some { Candidate.sandbox = Dune dummy_dune; status = Ok () }
-       | None -> None)
+      let* opam = available.opam in
+      (match workspace_root () with
+       | None -> Promise.return None
+       | Some root ->
+         let* dune_binary = find_all_dune_binaries root opam () in
+         let dune_path =
+           match dune_binary with
+           | _, _, Some (path, _) -> Some path
+           | (path, _, _) :: _, _, _ -> Some path
+           | _ -> None
+         in
+         (match dune_path with
+          | None -> Promise.return None
+          | Some dune_path ->
+            let+ dune = Dune.make ~root_dir:root ~dune_path:(Path.of_string dune_path) in
+            (match dune with
+             | Some dune -> Some { Candidate.sandbox = Dune dune; status = Ok () }
+             | None -> None)))
   in
   let+ esy, (opam, current_switch), dune = Promise.all3 (esy, opam, dune) in
   let cs = global :: custom :: (Option.to_list dune @ esy @ opam) in

--- a/src/sandbox.ml
+++ b/src/sandbox.ml
@@ -259,7 +259,7 @@ let of_settings () : t option Promise.t =
   | Some (Custom template) -> Promise.return (Some (Custom template))
   | Some (Dune path) ->
     let open Promise.Option.Syntax in
-    let* root = workspace_root () |> Promise.return in
+    let* root = Promise.return (workspace_root ()) in
     let* dune = Dune.make ~working_dir:root ~dune_path:path in
     Promise.return (Some (Dune dune))
 ;;
@@ -683,7 +683,9 @@ let sandbox_candidates ~workspace_folders =
          (match dune_path with
           | None -> Promise.return None
           | Some dune_path ->
-            let+ dune = Dune.make ~working_dir:root ~dune_path:(Path.of_string dune_path) in
+            let+ dune =
+              Dune.make ~working_dir:root ~dune_path:(Path.of_string dune_path)
+            in
             (match dune with
              | Some dune -> Some { Candidate.sandbox = Dune dune; status = Ok () }
              | None -> None)))

--- a/src/sandbox.ml
+++ b/src/sandbox.ml
@@ -90,7 +90,10 @@ let to_string = function
   | Opam (_, switch) -> Printf.sprintf "opam(%s)" (Opam.Switch.name switch)
   | Global -> "global"
   | Custom _ -> "custom"
-  | Dune _ -> "dune"
+  | Dune dune ->
+    (match dune.bin with
+     | `Global bin -> Printf.sprintf "dune(%s)" (Path.basename bin.bin)
+     | `Switch (_, switch) -> Printf.sprintf "dune(%s)" (Opam.Switch.name switch))
 ;;
 
 let to_pretty_string t =
@@ -151,7 +154,7 @@ module Setting = struct
     | Esy of Esy.Manifest.t
     | Global
     | Custom of string
-    | Dune of Path.t
+    | Dune of Dune.scope * string * Path.t
 
   let kind : t -> Kind.t = function
     | Opam _ -> Opam
@@ -184,7 +187,11 @@ module Setting = struct
       Custom template
     | Dune ->
       let root = Jsonoo.Decode.field "root" decode_vars json |> Path.of_string in
-      Dune root
+      let path = Jsonoo.Decode.field "path" decode_vars json in
+      let scope = Jsonoo.Decode.field "scope" Dune.scope_of_json json in
+      (match scope with
+       | `Global -> Dune (Dune.Global, path, root)
+       | `Switch -> Dune (Dune.Switch, path, root))
   ;;
 
   let to_json (t : t) =
@@ -198,7 +205,18 @@ module Setting = struct
         [ kind; "root", encode_vars @@ (manifest |> Esy.Manifest.path |> Path.to_string) ]
     | Opam switch -> object_ [ kind; "switch", encode_vars @@ Opam.Switch.name switch ]
     | Custom template -> object_ [ kind; "template", string template ]
-    | Dune dune -> object_ [ kind; "root", encode_vars @@ Path.to_string dune ]
+    | Dune (scope, path, root) ->
+      let scope_json =
+        match scope with
+        | Global -> "global"
+        | Switch -> "switch"
+      in
+      object_
+        [ kind
+        ; "scope", string scope_json
+        ; "path", string path
+        ; "root", string (Path.to_string root)
+        ]
   ;;
 
   let t = Settings.create_setting ~scope:Workspace ~key:"sandbox" ~of_json ~to_json
@@ -207,11 +225,10 @@ end
 type available_sandboxes =
   { opam : Opam.t option Promise.t
   ; esy : Esy.t option Promise.t
-  ; dune : Dune.t option Promise.t
   }
 
 let available_sandboxes () : available_sandboxes =
-  { dune = Dune.make (workspace_root ()) (); opam = Opam.make (); esy = Esy.make () }
+  { opam = Opam.make (); esy = Esy.make () }
 ;;
 
 let of_settings () : t option Promise.t =
@@ -258,14 +275,15 @@ let of_settings () : t option Promise.t =
          None))
   | Some Global -> Promise.return (Some Global)
   | Some (Custom template) -> Promise.return (Some (Custom template))
-  | Some (Dune _dune) ->
-    let open Promise.Syntax in
-    let* dune = available.dune in
-    (match dune with
-     | None ->
-       not_available `Dune;
-       Promise.return None
-     | Some dune -> Promise.return (Some (Dune dune)))
+  | Some (Dune (scope, path, root)) ->
+    let open Promise.Option.Syntax in
+    let scope =
+      match scope with
+      | Global -> `Global
+      | Switch -> `Switch
+    in
+    let* dune = Dune.make ~root ~path scope in
+    Promise.return (Some (Dune dune))
 ;;
 
 let detect_esy_sandbox ~project_root esy () =
@@ -305,9 +323,9 @@ let detect_opam_sandbox ~project_root opam () =
   Opam (opam, switch)
 ;;
 
-let detect_dune_pkg ~project_root _dune () =
+let detect_dune_pkg ~project_root () =
   let open Promise.Syntax in
-  Dune.make (Some project_root) ()
+  Dune.make ~root:project_root ~path:(Path.to_string project_root) `Global
   >>= function
   | Some dune ->
     Dune.is_dpm_enabled dune >>| fun dpm -> if dpm then Some (Dune dune) else None
@@ -320,10 +338,10 @@ let detect () =
   let available = available_sandboxes () in
   Promise.List.find_map
     (fun f -> f ())
-    [ detect_opam_local_switch ~project_root available.opam
+    [ detect_dune_pkg ~project_root
+    ; detect_opam_local_switch ~project_root available.opam
     ; detect_esy_sandbox ~project_root available.esy
     ; detect_opam_sandbox ~project_root available.opam
-    ; detect_dune_pkg ~project_root available.dune
     ]
 ;;
 
@@ -341,7 +359,10 @@ let save_to_settings sandbox =
     | Opam (_, switch) -> Setting.Opam switch
     | Global -> Setting.Global
     | Custom template -> Setting.Custom template
-    | Dune dune -> Setting.Dune (Dune.root dune)
+    | Dune dune ->
+      let root = Dune.root dune in
+      let path, scope = Dune.path_scope dune in
+      Setting.Dune (scope, path, root)
   in
   Settings.set ~section:"ocaml" Setting.t (to_setting sandbox)
 ;;
@@ -369,7 +390,8 @@ module Candidate = struct
            then Some (switch_kind_s ^ " | Currently active switch in project root")
            else Some switch_kind_s
          | Esy (_, _) -> Some "Esy"
-         | Global | Custom _ | Dune _ -> None)
+         | Dune _ -> Some "Use Dune Package Management in this project"
+         | Global | Custom _ -> None)
     in
     match sandbox with
     | Opam (_, Named name) -> create ~label:name ?description ()
@@ -394,25 +416,65 @@ module Candidate = struct
         ~label:"Custom"
         ~detail:"Custom sandbox using a command template"
         ()
-    | Dune dune ->
-      let project_path = Path.to_string (Dune.root dune) in
-      create ?description ~label:"Dune Package Manager" ~detail:project_path ()
+    | Dune _ -> create ~label:"Dune Package Manager" ()
   ;;
 
   let ok sandbox = { sandbox; status = Ok () }
 end
 
+let select_dune_binary () =
+  let open Promise.Syntax in
+  match workspace_root () with
+  | None -> Promise.return None
+  | Some root ->
+    let* opam = Opam.make () in
+    let create = QuickPickItem.create in
+    let* global_dune, opam_dunes = Dune.get_dune_binaries (Some root) opam () in
+    let global_dune_item =
+      match global_dune with
+      | Some (binary, version) ->
+        [ ( create
+              ~label:
+                (Printf.sprintf
+                   "Dune, %s, available"
+                   (Dune.Dune_version.to_string version))
+              ~detail:(Path.to_string binary.bin)
+              ()
+          , Dune.make ~root ~path:(Path.to_string binary.bin) `Global )
+        ]
+      | None -> []
+    in
+    let opam_dune_items =
+      List.map
+        ~f:(fun (switch, version) ->
+          ( create
+              ~label:
+                (Printf.sprintf
+                   "Dune, %s, available via opam switch"
+                   (Dune.Dune_version.to_string version))
+              ~detail:(Printf.sprintf "Switch: %s" (Opam.Switch.name switch))
+              ()
+          , Dune.make ~root ~path:(Opam.Switch.name switch) `Switch ))
+        opam_dunes
+    in
+    let options =
+      QuickPickOptions.create
+        ~canPickMany:false
+        ~placeHolder:"Which dune binary do you want to use for Dune Package Management?"
+        ()
+    in
+    let choices = global_dune_item @ opam_dune_items in
+    Window.showQuickPickItems ~choices ~options ()
+;;
+
 let select_sandbox (choices : Candidate.t list) t =
   let placeHolder = "Which package manager would you like to manage the sandbox?" in
   let open Promise.Syntax in
   let* current_switch =
-    match t with
-    | Dune _ -> Promise.return None
-    | _ ->
-      let open Promise.Option.Syntax in
-      let* opam = Opam.make () in
-      let* cwd = workspace_root () |> Promise.return in
-      Opam.switch_show ~cwd opam
+    let open Promise.Option.Syntax in
+    let* opam = Opam.make () in
+    let* cwd = workspace_root () |> Promise.return in
+    Opam.switch_show ~cwd opam
   in
   let choices =
     List.map
@@ -484,21 +546,13 @@ let sandbox_candidates ~workspace_folders =
        custom commands in [select] *)
   in
   let dune =
-    let+ dune_projects =
-      workspace_folders
-      |> List.map ~f:(fun (folder : WorkspaceFolder.t) ->
-        let root = folder |> WorkspaceFolder.uri |> Uri.fsPath |> Path.of_string in
-        let+ dune = Dune.make (Some root) () in
-        match dune with
-        | Some dune -> [ dune ]
-        | None -> [])
-      |> Promise.all_list
-    in
-    List.concat dune_projects
-    |> List.map ~f:(fun dune -> { Candidate.sandbox = Dune dune; status = Ok () })
+    let+ dummy_dune = Dune.make ~root:(Path.of_string "") ~path:"" `Global in
+    match dummy_dune with
+    | Some dummy_dune -> { Candidate.sandbox = Dune dummy_dune; status = Ok () }
+    | None -> Candidate.ok Global
   in
   let+ esy, (opam, current_switch), dune = Promise.all3 (esy, opam, dune) in
-  let cs = (global :: custom :: dune) @ esy @ opam in
+  let cs = (global :: custom :: dune :: esy) @ opam in
   Option.value_map current_switch ~default:cs ~f:(fun current_switch ->
     current_switch :: cs)
 ;;
@@ -528,6 +582,10 @@ let select_sandbox t =
     let* input = Window.showInputBox ~options () in
     let template = String.strip input in
     Promise.Option.return @@ Custom template
+  | { status = Ok (); sandbox = Dune _ } ->
+    let* dune = select_dune_binary () in
+    let+ dune = dune in
+    Dune dune
   | { status; sandbox } ->
     (match status with
      | Error s ->

--- a/src/sandbox.ml
+++ b/src/sandbox.ml
@@ -260,7 +260,7 @@ let of_settings () : t option Promise.t =
   | Some (Dune path) ->
     let open Promise.Option.Syntax in
     let* root = workspace_root () |> Promise.return in
-    let* dune = Dune.make ~root_dir:root ~dune_path:path in
+    let* dune = Dune.make ~working_dir:root ~dune_path:path in
     Promise.return (Some (Dune dune))
 ;;
 
@@ -303,7 +303,7 @@ let detect_opam_sandbox ~project_root opam () =
 
 let detect_dune_pkg ~project_root () =
   let open Promise.Syntax in
-  Dune.make ~root_dir:project_root ~dune_path:project_root
+  Dune.make ~working_dir:project_root ~dune_path:project_root
   >>= function
   | Some dune ->
     Dune.is_dpm_enabled dune >>| fun dpm -> if dpm then Some (Dune dune) else None
@@ -445,7 +445,7 @@ let custom_dune_input_validation root =
   match input with
   | None -> Promise.return None
   | Some path_str ->
-    Dune.make ~root_dir:root ~dune_path:(Path.of_string (String.strip path_str))
+    Dune.make ~working_dir:root ~dune_path:(Path.of_string (String.strip path_str))
 ;;
 
 let get_active_switch_for_dpm opam_dunes = function
@@ -583,7 +583,7 @@ let select_dune_binary () =
        let* choice = Window.showQuickPickItems ~choices ~options () in
        (match choice with
         | None | Some `Separator -> Promise.return None
-        | Some (`Opam_dune path) -> Dune.make ~root_dir:root ~dune_path:path
+        | Some (`Opam_dune path) -> Dune.make ~working_dir:root ~dune_path:path
         | Some `Custom_dune -> custom_dune_input_validation root))
 ;;
 
@@ -683,7 +683,7 @@ let sandbox_candidates ~workspace_folders =
          (match dune_path with
           | None -> Promise.return None
           | Some dune_path ->
-            let+ dune = Dune.make ~root_dir:root ~dune_path:(Path.of_string dune_path) in
+            let+ dune = Dune.make ~working_dir:root ~dune_path:(Path.of_string dune_path) in
             (match dune with
              | Some dune -> Some { Candidate.sandbox = Dune dune; status = Ok () }
              | None -> None)))


### PR DESCRIPTION
In this PR: 
## summary
we define two scopes for dune:
- global: by running `eval $(opam env --revert) dune --version` and
- switch: checking which opam switches have dune installed
    - ordering them by global (by version)
    - then by local (by version)

This is then compiled in a list and displayed to the user in the order:

- dune in currently active switch
- dune in system path
- custom path to dune
- dunes in global switches
- dunes in local switches

## usage
Activating DPM now happens in two steps:

1) Selecting Dune Package Manager as the sandbox
<img width="1336" height="906" alt="image" src="https://github.com/user-attachments/assets/908d747b-8fb4-4d8e-a381-e5adbea7e9c6" />

2) After selecting DPM, a list of all dune versions available is listed. The one the user selects is then registered as the dune binary to be used in the project.
<img width="1348" height="822" alt="image" src="https://github.com/user-attachments/assets/cd03733c-7359-4240-90d1-f2583e0c86ad" />


This PR is only concerned with setting DPM as the current "sandbox" and updating the `.vscode` config. Proper usage of the dune binary after that is not handled in this PR. Subsequent PR's will be done to evaluate and make any corrections if needed.
