### PR TITLE
Enforce users to enable dune package management if not enabled in a DPM sandbox

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@
 - Fix the detection of Dune Package Management to use the recommended `dune pkg enabled` command. Previously, we were checking to see if a `dune.lock` file exists. (#2193)
 - Fix the launch of Utop REPL in context of Dune Package Management. (#2198)
 - Redesign how Dune Package Manager is handled. Users now use a two step process, first to select DPM as a sandbox and then to select which dune binary they wish to use in the project (#2199)
+- Enforce that users either enable dune package management by generating a lockfile (as recommended by the dune team) or select a different sandbox. Pressing the escape key will display the select sandbox ui. (2208)
 
 ## 2.3.0
 

--- a/src-bindings/vscode/vscode.ml
+++ b/src-bindings/vscode/vscode.ml
@@ -3032,7 +3032,7 @@ module Window = struct
         -> TextEditorDecorationType.t
       [@@js.global "@vscode.window.createTextEditorDecorationType"]
 
-      val showInformationMessage
+      val informationMessage
         :  message:string
         -> ?options:MessageOptions.t
         -> items:(MessageItem.t list[@js.variadic])
@@ -3048,7 +3048,7 @@ module Window = struct
         -> MessageItem.t or_undefined Promise.t
       [@@js.global "@vscode.window.showWarningMessage"]
 
-      val errorMessage
+      val showErrorMessage
         :  message:string
         -> ?options:MessageOptions.t
         -> items:(MessageItem.t list[@js.variadic])
@@ -3193,9 +3193,7 @@ module Window = struct
   let showInformationMessage ~message ?options ?(choices = []) () =
     let choices = getChoices choices in
     let open Promise.Option.Syntax in
-    let+ item =
-      showInformationMessage ~message ?options ~items:(List.map fst choices) ()
-    in
+    let+ item = informationMessage ~message ?options ~items:(List.map fst choices) () in
     List.assoc item choices
   ;;
 
@@ -3209,7 +3207,7 @@ module Window = struct
   let showErrorMessage ~message ?options ?(choices = []) () =
     let choices = getChoices choices in
     let open Promise.Option.Syntax in
-    let+ item = errorMessage ~message ?options ~items:(List.map fst choices) () in
+    let+ item = showErrorMessage ~message ?options ~items:(List.map fst choices) () in
     List.assoc item choices
   ;;
 

--- a/src-bindings/vscode/vscode.ml
+++ b/src-bindings/vscode/vscode.ml
@@ -3048,7 +3048,7 @@ module Window = struct
         -> MessageItem.t or_undefined Promise.t
       [@@js.global "@vscode.window.showWarningMessage"]
 
-      val showErrorMessage
+      val errorMessage
         :  message:string
         -> ?options:MessageOptions.t
         -> items:(MessageItem.t list[@js.variadic])
@@ -3209,7 +3209,7 @@ module Window = struct
   let showErrorMessage ~message ?options ?(choices = []) () =
     let choices = getChoices choices in
     let open Promise.Option.Syntax in
-    let+ item = showErrorMessage ~message ?options ~items:(List.map fst choices) () in
+    let+ item = errorMessage ~message ?options ~items:(List.map fst choices) () in
     List.assoc item choices
   ;;
 

--- a/src-bindings/vscode/vscode.mli
+++ b/src-bindings/vscode/vscode.mli
@@ -2188,7 +2188,7 @@ module Window : sig
     :  options:DecorationRenderOptions.t
     -> TextEditorDecorationType.t
 
-  val errorMessage
+  val informationMessage
     :  message:string
     -> ?options:MessageOptions.t
     -> items:MessageItem.t maybe_list

--- a/src-bindings/vscode/vscode.mli
+++ b/src-bindings/vscode/vscode.mli
@@ -2188,6 +2188,13 @@ module Window : sig
     :  options:DecorationRenderOptions.t
     -> TextEditorDecorationType.t
 
+  val errorMessage
+    :  message:string
+    -> ?options:MessageOptions.t
+    -> items:MessageItem.t maybe_list
+    -> unit
+    -> MessageItem.t or_undefined Promise.t
+
   val showInformationMessage
     :  message:string
     -> ?options:MessageOptions.t

--- a/src/dune.ml
+++ b/src/dune.ml
@@ -119,7 +119,7 @@ let exec_pkg ~cmd ?(args = []) t = Cmd.Spawn (Cmd.append t.bin ([ "pkg"; cmd ] @
 
 let is_dpm_enabled t =
   let open Promise.Syntax in
-  let+ { exitCode; _ } = Cmd.run (exec_pkg ~cmd:"enabled" t) in
+  let+ { exitCode; _ } = Cmd.run ~cwd:t.root (exec_pkg ~cmd:"enabled" t) in
   Int.equal exitCode 0
 ;;
 

--- a/src/extension_commands.ml
+++ b/src/extension_commands.ml
@@ -132,7 +132,7 @@ let _install_dune_lsp_server =
               let+ _ = Extension_instance.start_language_server instance in
               ()
             else Promise.return ())
-        else Extension_instance.suggest_to_run_dune_pkg_lock () |> Promise.return
+        else Sandbox.suggest_to_run_dune_pkg_lock () |> Promise.return
       | _ ->
         show_message
           `Warn

--- a/src/extension_instance.ml
+++ b/src/extension_instance.ml
@@ -76,35 +76,6 @@ let stop_server t =
     else Promise.return ()
 ;;
 
-let suggest_to_run_dune_pkg_lock () =
-  let open Promise.Syntax in
-  let (_ : unit Promise.t) =
-    let+ maybe_choice =
-      Window.showWarningMessage
-        ~message:
-          "Dune Package Manager is selected as the active sandbox, but no lock file is \
-           present. Do you want to run dune pkg lock?"
-        ~choices:
-          [ ( "Generate lockfile"
-            , fun () ->
-                let (_ : unit Promise.t) =
-                  Command_api.(execute Internal.run_dune_pkg_lock) ()
-                in
-                () )
-          ; ( "Pick another sandbox"
-            , fun () ->
-                let (_ : unit Promise.t) =
-                  Command_api.(execute Internal.select_sandbox) ()
-                in
-                () )
-          ]
-        ()
-    in
-    Option.iter maybe_choice ~f:(fun f -> f ())
-  in
-  ()
-;;
-
 let check_ocaml_lsp_available (sandbox : Sandbox.t) =
   match sandbox with
   | Dune dune ->

--- a/src/extension_instance.mli
+++ b/src/extension_instance.mli
@@ -20,7 +20,6 @@ val ocaml_version_exn : t -> Ocaml_version.t
 val start_language_server : t -> unit Promise.t
 val install_ocaml_lsp_server : Sandbox.t -> unit Promise.t
 val upgrade_ocaml_lsp_server : Sandbox.t -> unit Promise.t
-val suggest_to_run_dune_pkg_lock : unit -> unit
 val set_configuration : t -> ?standard_hover:bool option -> unit -> unit
 val open_terminal : Sandbox.t -> unit
 val disposable : t -> Disposable.t

--- a/src/sandbox.ml
+++ b/src/sandbox.ml
@@ -331,17 +331,54 @@ let of_settings_or_detect () =
   | None -> detect ()
 ;;
 
-let save_to_settings sandbox =
-  let to_setting = function
-    | Esy (_, root) -> Setting.Esy root
-    | Opam (_, switch) -> Setting.Opam switch
-    | Global -> Setting.Global
-    | Custom template -> Setting.Custom template
-    | Dune dune ->
-      let path = Dune.dune_path dune in
-      Setting.Dune path
+let suggest_to_run_dune_pkg_lock () =
+  let open Promise.Syntax in
+  let (_ : unit Promise.t) =
+    let* maybe_choice =
+      Window.errorMessage
+        ~options:(MessageOptions.create ~modal:true ())
+        ~message:
+          "Dune Package Manager is selected as the active sandbox, but dune package \
+           management is not enabled in your workspace. One way of enabling it is \
+           generate a lock file. Do you want to run dune pkg lock?"
+        ~items:
+          [ MessageItem.create ~title:"Generate lockfile" ()
+          ; MessageItem.create
+              ~isCloseAffordance:true
+              ~title:"Select a different sandbox"
+              ()
+          ]
+        ()
+    in
+    match maybe_choice with
+    | Some item when Option.value ~default:false (MessageItem.isCloseAffordance item) ->
+      Command_api.(execute Internal.select_sandbox) ()
+    | None | Some _ -> Command_api.(execute Internal.run_dune_pkg_lock) ()
   in
-  Settings.set ~section:"ocaml" Setting.t (to_setting sandbox)
+  ()
+;;
+
+let save_to_settings sandbox =
+  let open Promise.Syntax in
+  let save_setting =
+    let to_setting = function
+      | Esy (_, root) -> Setting.Esy root
+      | Opam (_, switch) -> Setting.Opam switch
+      | Global -> Setting.Global
+      | Custom template -> Setting.Custom template
+      | Dune dune ->
+        let path = Dune.dune_path dune in
+        Setting.Dune path
+    in
+    Settings.set ~section:"ocaml" Setting.t (to_setting sandbox)
+  in
+  match sandbox with
+  | Dune dune ->
+    Dune.is_dpm_enabled dune
+    >>= (function
+     | true -> save_setting
+     | false -> Promise.return (suggest_to_run_dune_pkg_lock ()))
+  | _ -> save_setting
 ;;
 
 module Candidate = struct

--- a/src/sandbox.ml
+++ b/src/sandbox.ml
@@ -335,7 +335,7 @@ let suggest_to_run_dune_pkg_lock () =
   let open Promise.Syntax in
   let (_ : unit Promise.t) =
     let* maybe_choice =
-      Window.errorMessage
+      Window.informationMessage
         ~options:(MessageOptions.create ~modal:true ())
         ~message:
           "Dune Package Manager is selected as the active sandbox, but dune package \

--- a/src/sandbox.ml
+++ b/src/sandbox.ml
@@ -360,7 +360,7 @@ let suggest_to_run_dune_pkg_lock () =
 
 let save_to_settings sandbox =
   let open Promise.Syntax in
-  let save_setting =
+  let save_setting () =
     let to_setting = function
       | Esy (_, root) -> Setting.Esy root
       | Opam (_, switch) -> Setting.Opam switch
@@ -376,9 +376,9 @@ let save_to_settings sandbox =
   | Dune dune ->
     Dune.is_dpm_enabled dune
     >>= (function
-     | true -> save_setting
+     | true -> save_setting ()
      | false -> Promise.return (suggest_to_run_dune_pkg_lock ()))
-  | _ -> save_setting
+  | _ -> save_setting ()
 ;;
 
 module Candidate = struct

--- a/src/sandbox.mli
+++ b/src/sandbox.mli
@@ -39,6 +39,7 @@ val to_pretty_string : t -> string
 val of_settings : unit -> t option Promise.t
 val detect : unit -> t option Promise.t
 val of_settings_or_detect : unit -> t option Promise.t
+val suggest_to_run_dune_pkg_lock : unit -> unit
 val save_to_settings : t -> unit Promise.t
 
 (** [select_sandbox_and_save] requires the process environment the plugin is


### PR DESCRIPTION
This PR is checked from https://github.com/ocamllabs/vscode-ocaml-platform/pull/2199

when DPM is selected as the sanbox and a dune binary chosen, if DPM is not enabled in the workspace, then it will display a modal for the user to either: 
- generate a lockfile (the recommended way by the dune team) to enable DPM
- select a different sandbox

pressing escape will display the select_Sandbox quickpick ui 

<img width="1017" height="334" alt="image" src="https://github.com/user-attachments/assets/13f35dad-9533-45bb-a26f-e510700f8280" />
