### PR TITLE
Provide hints to the user depending of the sandbox type.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@
 - Redesign how Dune Package Manager is handled. Users now use a two step process, first to select DPM as a sandbox and then to select which dune binary they wish to use in the project (#2199)
 - Enforce that users either enable dune package management by generating a lockfile (as recommended by the dune team) or select a different sandbox. Pressing the escape key will display the select sandbox ui. (2208)
 - Rely on `dune tools env` to retrieve the local OCaml LSP path in the context of DPM. (#2227)
+- Ensure consistent installation hint with chosen sandbox. (#2221)
 
 ## 2.3.0
 

--- a/src/earlybird.ml
+++ b/src/earlybird.ml
@@ -49,7 +49,7 @@ let check_earlybird_available (sandbox : Sandbox.t) =
          let hint =
            match sandbox with
            | Sandbox.Opam _ -> Some "opam install earlybird"
-           | Esy _ -> Some "esy install earlybird"
+           | Esy _ -> Some "esy add @opam/earlybird"
            | Dune _ -> Some "dune tools install ocamlearlybird"
            | _ -> None
          in

--- a/src/earlybird.ml
+++ b/src/earlybird.ml
@@ -43,8 +43,19 @@ let check_earlybird_available (sandbox : Sandbox.t) =
   |> Promise.Result.fold
        ~ok:(fun (_ : string) -> ())
        ~error:(fun (_ : string) ->
-         "Debugging failed: `earlybird` is not installed in the current sandbox.\n\n\
-          Hint: $ opam install earlybird")
+         let msg =
+           "Debugging failed: `earlybird` is not installed in the current sandbox."
+         in
+         let hint =
+           match sandbox with
+           | Sandbox.Opam _ -> Some "opam install earlybird"
+           | Esy _ -> Some "esy install earlybird"
+           | Dune _ -> Some "dune tools install ocamlearlybird"
+           | _ -> None
+         in
+         match hint with
+         | None -> msg
+         | Some hint -> sprintf "%s\n\nHint: $ %s" msg hint)
 ;;
 
 let createDebugAdapterDescriptor ~instance ~session:_ ~executable:_ =

--- a/src/extension_commands.ml
+++ b/src/extension_commands.ml
@@ -77,6 +77,7 @@ let _upgrade_ocaml_lsp_server =
       match
         Ocaml_lsp.is_version_up_to_date
           (Extension_instance.ocaml_lsp instance |> Option.value_exn)
+          (Extension_instance.sandbox instance)
           (Extension_instance.ocaml_version_exn instance)
       with
       | Ok () -> Promise.return ()
@@ -601,6 +602,7 @@ end = struct
     match
       Ocaml_lsp.is_version_up_to_date
         ocaml_lsp
+        (Extension_instance.sandbox instance)
         (Extension_instance.ocaml_version_exn instance)
     with
     | Ok () -> ()
@@ -827,6 +829,7 @@ module Copy_type_under_cursor = struct
     match
       Ocaml_lsp.is_version_up_to_date
         ocaml_lsp
+        (Extension_instance.sandbox instance)
         (Extension_instance.ocaml_version_exn instance)
     with
     | Ok () -> ()

--- a/src/extension_instance.ml
+++ b/src/extension_instance.ml
@@ -215,7 +215,9 @@ end = struct
         let initialize_result = LanguageClient.initializeResult client in
         let ocaml_lsp = Ocaml_lsp.of_initialize_result initialize_result in
         t.lsp_client <- Some (client, ocaml_lsp);
-        (match Ocaml_lsp.is_version_up_to_date ocaml_lsp (ocaml_version_exn t) with
+        (match
+           Ocaml_lsp.is_version_up_to_date ocaml_lsp (sandbox t) (ocaml_version_exn t)
+         with
          | Ok () -> ()
          | Error (`Msg _) -> ());
         send_configuration t client;

--- a/src/ocaml_lsp.ml
+++ b/src/ocaml_lsp.ml
@@ -230,7 +230,7 @@ let suggest_to_upgrade_ocaml_lsp_server
   | _ -> Promise.return ()
 ;;
 
-let is_version_up_to_date t ocaml_v =
+let is_version_up_to_date t sandbox ocaml_v =
   let ocamllsp_version = get_version_from_serverInfo t in
   let res =
     (* if the server doesn't have a version, we assume it's ancient and we can
@@ -261,11 +261,26 @@ let is_version_up_to_date t ocaml_v =
           | None -> sprintf "to %s" new_
           | Some old -> sprintf "from %s to %s" old new_
         in
-        sprintf
-          "There is a newer version of ocaml-lsp-server available. Consider upgrading \
-           %s. Hint: $ opam install ocaml-lsp-server=%s and restart the lsp server"
-          upgrade
-          new_
+        let msg =
+          sprintf
+            "There is a newer version of ocaml-lsp-server available. Consider upgrading \
+             %s and restart the lsp server. Hint: $ opam install ocaml-lsp-server=%s"
+            upgrade
+            new_
+        in
+        let hint =
+          match sandbox with
+          | Sandbox.Opam _ | Global ->
+            Some (sprintf "$ opam install ocaml-lsp-server=%s" new_)
+          | Dune _ ->
+            Some "upgrade the version of OCaml LSP server used in your dune-project."
+          | Esy _ ->
+            Some "upgrade the version of OCaml LSP server used in your Esy manifest."
+          | Custom _ -> None
+        in
+        (match hint with
+         | None -> msg
+         | Some hint -> sprintf "%s Hint: %s" msg hint)
     in
     `Msg msg)
 ;;

--- a/src/ocaml_lsp.ml
+++ b/src/ocaml_lsp.ml
@@ -264,9 +264,8 @@ let is_version_up_to_date t sandbox ocaml_v =
         let msg =
           sprintf
             "There is a newer version of ocaml-lsp-server available. Consider upgrading \
-             %s and restart the lsp server. Hint: $ opam install ocaml-lsp-server=%s"
+             %s and restart the lsp server."
             upgrade
-            new_
         in
         let hint =
           match sandbox with

--- a/src/ocaml_lsp.mli
+++ b/src/ocaml_lsp.mli
@@ -3,7 +3,13 @@ open Import
 type t
 
 val of_initialize_result : LanguageClient.InitializeResult.t -> t
-val is_version_up_to_date : t -> Ocaml_version.t -> (unit, [ `Msg of string ]) result
+
+val is_version_up_to_date
+  :  t
+  -> Sandbox.t
+  -> Ocaml_version.t
+  -> (unit, [ `Msg of string ]) result
+
 val can_handle_switch_impl_intf : t -> bool
 val can_handle_infer_intf : t -> bool
 val can_handle_typed_holes : t -> bool

--- a/src/type_selection.ml
+++ b/src/type_selection.ml
@@ -48,6 +48,7 @@ let ocaml_lsp_doesnt_support_type_selection instance ocaml_lsp =
   match
     Ocaml_lsp.is_version_up_to_date
       ocaml_lsp
+      (Extension_instance.sandbox instance)
       (Extension_instance.ocaml_version_exn instance)
   with
   | Ok () -> ()


### PR DESCRIPTION
Previously, installation hints were hardcoded to always use Opam. This PR fixes this to ensure consistent hints in the context of DPM, for instance.