### PR TITLE
Update OCaml to 5.5.0 and raise js_of_ocaml to >= 6.4

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -22,7 +22,7 @@ jobs:
       - name: Set-up OCaml
         uses: ocaml/setup-ocaml@v3
         with:
-          ocaml-compiler: 5.3.0
+          ocaml-compiler: 5.5.0
 
       - name: Set-up Mise
         uses: jdx/mise-action@v4
@@ -61,7 +61,7 @@ jobs:
       - name: Set-up OCaml
         uses: ocaml/setup-ocaml@v3
         with:
-          ocaml-compiler: 5.3.0
+          ocaml-compiler: 5.5.0
       - uses: ocaml/setup-ocaml/lint-opam@v3
 
   lint-fmt:
@@ -72,7 +72,7 @@ jobs:
       - name: Set-up OCaml
         uses: ocaml/setup-ocaml@v3
         with:
-          ocaml-compiler: 5.3.0
+          ocaml-compiler: 5.5.0
       - uses: ocaml/setup-ocaml/lint-fmt@v3
 
   release:

--- a/.github/workflows/opam-dependency-submission.yml
+++ b/.github/workflows/opam-dependency-submission.yml
@@ -22,5 +22,5 @@ jobs:
       - name: Set-up OCaml
         uses: ocaml/setup-ocaml@v3
         with:
-          ocaml-compiler: 5.3.0
+          ocaml-compiler: 5.5.0
       - uses: ocaml/setup-ocaml/analysis@v3

--- a/Makefile
+++ b/Makefile
@@ -15,7 +15,7 @@ deps:
 
 .PHONY: create_switch
 create_switch:
-	opam switch create . 5.3.0 --no-install
+	opam switch create . 5.5.0 --no-install
 
 .PHONY: switch
 switch: create_switch deps

--- a/dune-project
+++ b/dune-project
@@ -26,9 +26,9 @@
   (vscode
    (= :version))
   (ocaml
-   (= 5.3.0))
+   (= 5.5.0))
   (js_of_ocaml
-   (>= 6.3))
+   (>= 6.4))
   (gen_js_api
    (= 1.1.7))
   (base
@@ -57,7 +57,7 @@
   (ocaml
    (>= 4.08))
   (js_of_ocaml
-   (>= 6.3))
+   (>= 6.4))
   (gen_js_api
    (= 1.1.7))
   (ocamlformat
@@ -73,7 +73,7 @@
   (ocaml
    (>= 4.08))
   (js_of_ocaml
-   (>= 6.3))
+   (>= 6.4))
   (gen_js_api
    (= 1.1.7))
   (promise_jsoo
@@ -96,7 +96,7 @@
   (ocaml
    (>= 4.08))
   (js_of_ocaml
-   (>= 6.3))
+   (>= 6.4))
   (gen_js_api
    (= 1.1.7))
   (promise_jsoo

--- a/vscode-interop.opam
+++ b/vscode-interop.opam
@@ -19,7 +19,7 @@ bug-reports: "https://github.com/ocamllabs/vscode-ocaml-platform/issues"
 depends: [
   "dune" {>= "3.20"}
   "ocaml" {>= "4.08"}
-  "js_of_ocaml" {>= "6.3"}
+  "js_of_ocaml" {>= "6.4"}
   "gen_js_api" {= "1.1.7"}
   "ocamlformat" {= "0.28.1" & with-dev-setup}
   "ocaml-lsp-server" {with-dev-setup}

--- a/vscode-node.opam
+++ b/vscode-node.opam
@@ -19,7 +19,7 @@ bug-reports: "https://github.com/ocamllabs/vscode-ocaml-platform/issues"
 depends: [
   "dune" {>= "3.20"}
   "ocaml" {>= "4.08"}
-  "js_of_ocaml" {>= "6.3"}
+  "js_of_ocaml" {>= "6.4"}
   "gen_js_api" {= "1.1.7"}
   "promise_jsoo" {>= "0.4.3"}
   "jsonoo" {>= "0.3"}

--- a/vscode-ocaml-platform.opam
+++ b/vscode-ocaml-platform.opam
@@ -18,8 +18,8 @@ bug-reports: "https://github.com/ocamllabs/vscode-ocaml-platform/issues"
 depends: [
   "dune" {>= "3.20"}
   "vscode" {= version}
-  "ocaml" {= "5.3.0"}
-  "js_of_ocaml" {>= "6.3"}
+  "ocaml" {= "5.5.0"}
+  "js_of_ocaml" {>= "6.4"}
   "gen_js_api" {= "1.1.7"}
   "base" {>= "v0.17"}
   "promise_jsoo" {>= "0.4.3"}

--- a/vscode.opam
+++ b/vscode.opam
@@ -18,7 +18,7 @@ bug-reports: "https://github.com/ocamllabs/vscode-ocaml-platform/issues"
 depends: [
   "dune" {>= "3.20"}
   "ocaml" {>= "4.08"}
-  "js_of_ocaml" {>= "6.3"}
+  "js_of_ocaml" {>= "6.4"}
   "gen_js_api" {= "1.1.7"}
   "promise_jsoo" {>= "0.4.3"}
   "jsonoo" {>= "0.3"}


### PR DESCRIPTION
## Summary

- Pin the OCaml compiler from 5.3.0 to **5.5.0** in `dune-project`, generated opam files, the Makefile switch helper, and GitHub Actions.
- Raise the `js_of_ocaml` lower bound from `>= 6.3` to **`>= 6.4`** for all packages.

## Test plan

- [x] `dune pkg lock` resolves `ocaml` 5.5.0 and `js_of_ocaml` 6.4.1
- [x] `make build` succeeds with the updated compiler and dependencies
- [x] CI build, lint-opam, and lint-fmt pass on OCaml 5.5.0