### PR TITLE
Upgrade dune when it is outdated

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@
 - Redesign how Dune Package Manager is handled. Users now use a two step process, first to select DPM as a sandbox and then to select which dune binary they wish to use in the project (#2199)
 - Enforce that users either enable dune package management by generating a lockfile (as recommended by the dune team) or select a different sandbox. Pressing the escape key will display the select sandbox ui. (2208)
 - Rely on `dune tools env` to retrieve the local OCaml LSP path in the context of DPM. (#2227)
+- Upgrade dune when it is outdated. (#2224)
 
 ## 2.3.0
 

--- a/src/command_api.ml
+++ b/src/command_api.ml
@@ -154,6 +154,7 @@ module Internal = struct
   let init_opam = unit_handle "init-opam"
   let install_ocaml_dev = unit_handle "install-ocaml-dev"
   let open_utop = unit_handle "open-utop"
+  let upgrade_dune = unit_handle "upgrade-dune"
 end
 
 module Vscode = struct

--- a/src/command_api.mli
+++ b/src/command_api.mli
@@ -55,6 +55,7 @@ module Internal : sig
   val init_opam : (unit, unit) handle
   val install_ocaml_dev : (unit, unit) handle
   val open_utop : (unit, unit) handle
+  val upgrade_dune : (unit, unit) handle
 end
 
 module Vscode : sig

--- a/src/dune.ml
+++ b/src/dune.ml
@@ -125,7 +125,8 @@ let get_upgrade_dune_cmd t =
     let* opam = Opam.make () in
     (match opam with
      | None -> Promise.return (Error "Opam not found")
-     | Some opam -> Opam.upgrade ~packages:[ "dune" ] opam switch |> Cmd.output ~cwd:t.root)
+     | Some opam ->
+       Opam.upgrade ~packages:[ "dune" ] opam switch |> Cmd.output ~cwd:t.root)
   | None ->
     Cmd.output
       (Cmd.Shell "curl -fsSL https://get.dune.build/install | sh -s - --release latest")

--- a/src/dune.ml
+++ b/src/dune.ml
@@ -97,13 +97,14 @@ let construct_dune_path path = Path.(of_string (String.strip path) / "dune")
 type t =
   { root : Path.t
   ; bin : Cmd.spawn
+  ; is_opam : bool
   }
 
-let make ~working_dir ~dune_path =
+let make ~working_dir ~dune_path ?(is_opam = true) () =
   let open Promise.Syntax in
   let* spawn = Cmd.check_spawn { Cmd.bin = dune_path; args = [] } in
   match spawn with
-  | Ok bin -> Promise.return (Some { root = working_dir; bin })
+  | Ok bin -> Promise.return (Some { root = working_dir; bin; is_opam })
   | Error _ ->
     log_chan `Info ~section:"dune package management" "Dune not found in the environment.";
     Promise.return None
@@ -150,6 +151,7 @@ let equal d1 d2 =
 
 let root t = t.root
 let dune_path t = t.bin.bin
+let is_opam t = t.is_opam
 
 let is_dune_in_switch opam switch =
   let open Promise.Syntax in
@@ -168,6 +170,7 @@ let is_dune_in_switch opam switch =
     command
       { root = Path.of_string ""
       ; bin = { Cmd.bin = construct_dune_path path; args = [] }
+      ; is_opam = true
       }
       ~args:[ "--version" ]
     |> Cmd.output

--- a/src/dune.ml
+++ b/src/dune.ml
@@ -121,14 +121,31 @@ let exec_pkg ~cmd ?(args = []) t = Cmd.Spawn (Cmd.append t.bin ([ "pkg"; cmd ] @
 let get_upgrade_dune_cmd t =
   match t.is_opam with
   | true ->
-    let open Promise.Option.Syntax in
-    let* opam = Opam.make () in
-    let+ switch = Opam.switch_show ~cwd:t.root opam in
-    Opam.upgrade ~packages:[ "dune" ] opam switch
+    let root =
+      let open Option.O in
+      let* bin_dir = Path.parent t.bin.bin in
+      let* opam_dir = Path.parent bin_dir in
+      Path.parent opam_dir
+    in
+    (match root with
+     | None -> Promise.return (Error "Workspace root not found from dune path")
+     | Some root ->
+       let open Promise.Syntax in
+       let* opam = Opam.make () in
+       (match opam with
+        | None -> Promise.return (Error "Opam not found")
+        | Some opam ->
+          let* switch = Opam.switch_show ~cwd:root opam in
+          (match switch with
+           | None ->
+             Promise.return
+               (Error "Current opam switch where dune is located is not found")
+           | Some switch ->
+             Opam.upgrade ~packages:[ "dune" ] opam switch |> Cmd.output ~cwd:root)))
   | false ->
-    Promise.return
-      (Some
-         (Cmd.Shell "curl -fsSL https://get.dune.build/install | sh -s - --release latest"))
+    Cmd.output
+      (Cmd.Shell "curl -fsSL https://get.dune.build/install | sh -s - --release latest")
+      ~cwd:(Path.of_string "")
 ;;
 
 let is_dpm_enabled t =

--- a/src/dune.ml
+++ b/src/dune.ml
@@ -97,14 +97,14 @@ let construct_dune_path path = Path.(of_string (String.strip path) / "dune")
 type t =
   { root : Path.t
   ; bin : Cmd.spawn
-  ; is_opam : bool
+  ; opam_switch : Opam.Switch.t option
   }
 
-let make ~working_dir ~dune_path ?(is_opam = true) () =
+let make ~working_dir ~dune_path ?opam_switch () =
   let open Promise.Syntax in
   let* spawn = Cmd.check_spawn { Cmd.bin = dune_path; args = [] } in
   match spawn with
-  | Ok bin -> Promise.return (Some { root = working_dir; bin; is_opam })
+  | Ok bin -> Promise.return (Some { root = working_dir; bin; opam_switch })
   | Error _ ->
     log_chan `Info ~section:"dune package management" "Dune not found in the environment.";
     Promise.return None
@@ -119,30 +119,14 @@ let exec ~target ?(args = []) t =
 let exec_pkg ~cmd ?(args = []) t = Cmd.Spawn (Cmd.append t.bin ([ "pkg"; cmd ] @ args))
 
 let get_upgrade_dune_cmd t =
-  match t.is_opam with
-  | true ->
-    let root =
-      let open Option.O in
-      let* bin_dir = Path.parent t.bin.bin in
-      let* opam_dir = Path.parent bin_dir in
-      Path.parent opam_dir
-    in
-    (match root with
-     | None -> Promise.return (Error "Workspace root not found from dune path")
-     | Some root ->
-       let open Promise.Syntax in
-       let* opam = Opam.make () in
-       (match opam with
-        | None -> Promise.return (Error "Opam not found")
-        | Some opam ->
-          let* switch = Opam.switch_show ~cwd:root opam in
-          (match switch with
-           | None ->
-             Promise.return
-               (Error "Current opam switch where dune is located is not found")
-           | Some switch ->
-             Opam.upgrade ~packages:[ "dune" ] opam switch |> Cmd.output ~cwd:root)))
-  | false ->
+  match t.opam_switch with
+  | Some switch ->
+    let open Promise.Syntax in
+    let* opam = Opam.make () in
+    (match opam with
+     | None -> Promise.return (Error "Opam not found")
+     | Some opam -> Opam.upgrade ~packages:[ "dune" ] opam switch |> Cmd.output ~cwd:t.root)
+  | None ->
     Cmd.output
       (Cmd.Shell "curl -fsSL https://get.dune.build/install | sh -s - --release latest")
       ~cwd:(Path.of_string "")
@@ -181,7 +165,8 @@ let equal d1 d2 =
 
 let root t = t.root
 let dune_path t = t.bin.bin
-let is_opam t = t.is_opam
+let opam_switch t = t.opam_switch
+let is_opam t = Option.is_some t.opam_switch
 
 let is_dune_in_switch opam switch =
   let open Promise.Syntax in
@@ -200,7 +185,7 @@ let is_dune_in_switch opam switch =
     command
       { root = Path.of_string ""
       ; bin = { Cmd.bin = construct_dune_path path; args = [] }
-      ; is_opam = true
+      ; opam_switch = Some switch
       }
       ~args:[ "--version" ]
     |> Cmd.output

--- a/src/dune.ml
+++ b/src/dune.ml
@@ -118,6 +118,19 @@ let exec ~target ?(args = []) t =
 
 let exec_pkg ~cmd ?(args = []) t = Cmd.Spawn (Cmd.append t.bin ([ "pkg"; cmd ] @ args))
 
+let get_upgrade_dune_cmd t =
+  match t.is_opam with
+  | true ->
+    let open Promise.Option.Syntax in
+    let* opam = Opam.make () in
+    let+ switch = Opam.switch_show ~cwd:t.root opam in
+    Opam.upgrade ~packages:[ "dune" ] opam switch
+  | false ->
+    Promise.return
+      (Some
+         (Cmd.Shell "curl -fsSL https://get.dune.build/install | sh -s - --release latest"))
+;;
+
 let is_dpm_enabled t =
   let open Promise.Syntax in
   let+ { exitCode; _ } = Cmd.run ~cwd:t.root (exec_pkg ~cmd:"enabled" t) in

--- a/src/dune.mli
+++ b/src/dune.mli
@@ -30,7 +30,7 @@ val exec : target:string -> ?args:string list -> t -> Cmd.t
 val exec_pkg : cmd:string -> ?args:string list -> t -> Cmd.t
 
 (** Get command to upgrade dune to the latest version *)
-val get_upgrade_dune_cmd : t -> Cmd.t option Promise.t
+val get_upgrade_dune_cmd : t -> (string, string) result Promise.t
 
 (** Run `dune tools <exec/which>` *)
 val tools

--- a/src/dune.mli
+++ b/src/dune.mli
@@ -14,6 +14,7 @@ val construct_dune_path : string -> Path.t
 type t =
   { root : Path.t
   ; bin : Cmd.spawn
+  ; is_opam : bool
   }
 
 (** Check if dune package management is enable. *)
@@ -45,7 +46,12 @@ val is_ocamllsp_present : t -> bool Promise.t
 (** Check if amy two instances of dune pkg management projects are equal *)
 val equal : t -> t -> bool
 
-val make : working_dir:Path.t -> dune_path:Path.t -> t option Promise.t
+val make
+  :  working_dir:Path.t
+  -> dune_path:Path.t
+  -> ?is_opam:bool
+  -> unit
+  -> t option Promise.t
 
 val get_opam_dunes
   :  Opam.t option
@@ -57,3 +63,4 @@ val get_system_dune_path : unit -> (string * Dune_version.t) option Promise.t
 val root : t -> Path.t
 
 val dune_path : t -> Path.t
+val is_opam : t -> bool

--- a/src/dune.mli
+++ b/src/dune.mli
@@ -29,6 +29,9 @@ val exec : target:string -> ?args:string list -> t -> Cmd.t
 (** Run specific `dune pkg <foo> commands` *)
 val exec_pkg : cmd:string -> ?args:string list -> t -> Cmd.t
 
+(** Get command to upgrade dune to the latest version *)
+val get_upgrade_dune_cmd : t -> Cmd.t option Promise.t
+
 (** Run `dune tools <exec/which>` *)
 val tools
   :  tool:string

--- a/src/dune.mli
+++ b/src/dune.mli
@@ -14,7 +14,7 @@ val construct_dune_path : string -> Path.t
 type t =
   { root : Path.t
   ; bin : Cmd.spawn
-  ; is_opam : bool
+  ; opam_switch : Opam.Switch.t option
   }
 
 (** Check if dune package management is enable. *)
@@ -52,7 +52,7 @@ val equal : t -> t -> bool
 val make
   :  working_dir:Path.t
   -> dune_path:Path.t
-  -> ?is_opam:bool
+  -> ?opam_switch:Opam.Switch.t
   -> unit
   -> t option Promise.t
 
@@ -66,4 +66,5 @@ val get_system_dune_path : unit -> (string * Dune_version.t) option Promise.t
 val root : t -> Path.t
 
 val dune_path : t -> Path.t
+val opam_switch : t -> Opam.Switch.t option
 val is_opam : t -> bool

--- a/src/extension_commands.ml
+++ b/src/extension_commands.ml
@@ -221,9 +221,7 @@ let _upgrade_dune =
         let* () = Vscode.Window.withProgress (module Interop.Js.Unit) ~options ~task in
         Extension_instance.start_language_server instance
       | _ ->
-        show_message
-          `Warn
-          "Select Dune Package Management to execute this action.";
+        show_message `Warn "Select Dune Package Management to execute this action.";
         Promise.return ()
     in
     ()

--- a/src/extension_commands.ml
+++ b/src/extension_commands.ml
@@ -207,7 +207,7 @@ let _upgrade_dune =
     let pick_sandbox ?(msg = "") () =
       let* selection =
         Window.showErrorMessage
-          ~message:("An error occurred while upgrading dune. %s" ^ msg)
+          ~message:("An error occurred while upgrading dune. " ^ msg)
           ~choices:[ "Select a different sandbox", `Select_sandbox ]
           ()
       in
@@ -227,14 +227,10 @@ let _upgrade_dune =
             ()
         in
         let task ~progress:_ ~token:_ =
-          let* cmd = Dune.get_upgrade_dune_cmd dune in
-          match cmd with
-          | Some cmd ->
-            let* res = Cmd.output cmd ~cwd:(Dune.root dune) in
-            (match res with
-             | Ok _ -> Sandbox.save_to_settings (Dune dune)
-             | Error err -> pick_sandbox ~msg:err ())
-          | None -> pick_sandbox ~msg:"Opam or current switch not found." ()
+          let* res = Dune.get_upgrade_dune_cmd dune in
+          match res with
+          | Ok _ -> Sandbox.save_to_settings (Dune dune)
+          | Error err -> pick_sandbox ~msg:err ()
         in
         let* () = Vscode.Window.withProgress (module Interop.Js.Unit) ~options ~task in
         Extension_instance.start_language_server instance

--- a/src/extension_commands.ml
+++ b/src/extension_commands.ml
@@ -223,11 +223,7 @@ let _upgrade_dune =
       | _ ->
         show_message
           `Warn
-          "upgrade-dune: This command can only be executed in a Dune Package Management \
-           sandbox.";
-        log
-          "upgrade-dune: This command can only be executed in a Dune Package Management \
-           sandbox.";
+          "Select Dune Package Management to execute this action.";
         Promise.return ()
     in
     ()

--- a/src/extension_commands.ml
+++ b/src/extension_commands.ml
@@ -162,17 +162,31 @@ let _run_dune_pkg_lock =
             ()
         in
         let task ~progress:_ ~token:_ =
-          let+ result =
+          let* result =
             Dune.exec_pkg ~cmd:"lock" dune |> Cmd.output ~cwd:(Dune.root dune)
           in
           match result with
-          | Ok _ -> ()
+          | Ok _ -> Sandbox.save_to_settings (Dune dune)
           | Error err ->
-            show_message `Error "An error occurred while running dune pkg lock: %s" err
+            let* selection =
+              Window.showErrorMessage
+                ~message:("An error occurred while running dune pkg lock: " ^ err)
+                ~choices:
+                  [ "Upgrade dune", `Upgrade_dune
+                  ; "Select a different sandbox", `Select_sandbox
+                  ]
+                ()
+            in
+            (match selection with
+             | Some `Upgrade_dune ->
+               Command_api.(execute Internal.install_ocaml_lsp_server) ()
+             | Some `Select_sandbox | None ->
+               Command_api.(execute Internal.select_sandbox) ())
+            >>= (function
+             | _ -> Promise.return ())
         in
-        let+ () = Vscode.Window.withProgress (module Interop.Js.Unit) ~options ~task in
-        let _ = Extension_instance.start_language_server instance in
-        ()
+        let* () = Vscode.Window.withProgress (module Interop.Js.Unit) ~options ~task in
+        Extension_instance.start_language_server instance
       | _ ->
         show_message
           `Warn

--- a/src/extension_commands.ml
+++ b/src/extension_commands.ml
@@ -180,10 +180,8 @@ let _run_dune_pkg_lock =
             in
             (match selection with
              | Some `Upgrade_dune -> Command_api.(execute Internal.upgrade_dune) ()
-             | Some `Select_sandbox | None ->
-               Command_api.(execute Internal.select_sandbox) ())
-            >>= (function
-             | _ -> Promise.return ())
+             | Some `Select_sandbox -> Command_api.(execute Internal.select_sandbox) ()
+             | None -> Command_api.(execute Internal.select_sandbox) ())
         in
         let* () = Vscode.Window.withProgress (module Interop.Js.Unit) ~options ~task in
         Extension_instance.start_language_server instance
@@ -212,10 +210,8 @@ let _upgrade_dune =
           ~choices:[ "Select a different sandbox", `Select_sandbox ]
           ()
       in
-      (match selection with
-       | Some `Select_sandbox | None -> Command_api.(execute Internal.select_sandbox) ())
-      >>= function
-      | _ -> Promise.return ()
+      match selection with
+      | Some `Select_sandbox | None -> Command_api.(execute Internal.select_sandbox) ()
     in
     let _ =
       match Extension_instance.sandbox instance with

--- a/src/extension_commands.ml
+++ b/src/extension_commands.ml
@@ -180,8 +180,8 @@ let _run_dune_pkg_lock =
             in
             (match selection with
              | Some `Upgrade_dune -> Command_api.(execute Internal.upgrade_dune) ()
-             | Some `Select_sandbox -> Command_api.(execute Internal.select_sandbox) ()
-             | None -> Command_api.(execute Internal.select_sandbox) ())
+             | Some `Select_sandbox | None ->
+               Command_api.(execute Internal.select_sandbox) ())
         in
         let* () = Vscode.Window.withProgress (module Interop.Js.Unit) ~options ~task in
         Extension_instance.start_language_server instance

--- a/src/extension_commands.ml
+++ b/src/extension_commands.ml
@@ -172,14 +172,10 @@ let _run_dune_pkg_lock =
             let* selection =
               Window.showErrorMessage
                 ~message:("An error occurred while running dune pkg lock: " ^ err)
-                ~choices:
-                  [ "Upgrade dune", `Upgrade_dune
-                  ; "Select a different sandbox", `Select_sandbox
-                  ]
+                ~choices:[ "Select a different sandbox", `Select_sandbox ]
                 ()
             in
             (match selection with
-             | Some `Upgrade_dune -> Command_api.(execute Internal.upgrade_dune) ()
              | Some `Select_sandbox | None ->
                Command_api.(execute Internal.select_sandbox) ())
         in

--- a/src/extension_commands.ml
+++ b/src/extension_commands.ml
@@ -178,8 +178,7 @@ let _run_dune_pkg_lock =
                 ()
             in
             (match selection with
-             | Some `Upgrade_dune ->
-               Command_api.(execute Internal.install_ocaml_lsp_server) ()
+             | Some `Upgrade_dune -> Command_api.(execute Internal.upgrade_dune) ()
              | Some `Select_sandbox | None ->
                Command_api.(execute Internal.select_sandbox) ())
             >>= (function
@@ -200,6 +199,58 @@ let _run_dune_pkg_lock =
     ()
   in
   command Command_api.Internal.run_dune_pkg_lock callback
+;;
+
+let _upgrade_dune =
+  let callback (instance : Extension_instance.t) () =
+    let open Promise.Syntax in
+    let pick_sandbox ?(msg = "") () =
+      let* selection =
+        Window.showErrorMessage
+          ~message:("An error occurred while upgrading dune. %s" ^ msg)
+          ~choices:[ "Select a different sandbox", `Select_sandbox ]
+          ()
+      in
+      (match selection with
+       | Some `Select_sandbox | None -> Command_api.(execute Internal.select_sandbox) ())
+      >>= function
+      | _ -> Promise.return ()
+    in
+    let _ =
+      match Extension_instance.sandbox instance with
+      | Dune dune ->
+        let options =
+          ProgressOptions.create
+            ~location:(`ProgressLocation Notification)
+            ~title:"Upgrading dune ..."
+            ~cancellable:false
+            ()
+        in
+        let task ~progress:_ ~token:_ =
+          let* cmd = Dune.get_upgrade_dune_cmd dune in
+          match cmd with
+          | Some cmd ->
+            let* res = Cmd.output cmd ~cwd:(Dune.root dune) in
+            (match res with
+             | Ok _ -> Sandbox.save_to_settings (Dune dune)
+             | Error err -> pick_sandbox ~msg:err ())
+          | None -> pick_sandbox ~msg:"Opam or current switch not found." ()
+        in
+        let* () = Vscode.Window.withProgress (module Interop.Js.Unit) ~options ~task in
+        Extension_instance.start_language_server instance
+      | _ ->
+        show_message
+          `Warn
+          "upgrade-dune: This command can only be executed in a Dune Package Management \
+           sandbox.";
+        log
+          "upgrade-dune: This command can only be executed in a Dune Package Management \
+           sandbox.";
+        Promise.return ()
+    in
+    ()
+  in
+  command Command_api.Internal.upgrade_dune callback
 ;;
 
 let _restart_language_server =

--- a/src/extension_commands.ml
+++ b/src/extension_commands.ml
@@ -163,24 +163,17 @@ let _run_dune_pkg_lock =
             ()
         in
         let task ~progress:_ ~token:_ =
-          let* result =
+          let+ result =
             Dune.exec_pkg ~cmd:"lock" dune |> Cmd.output ~cwd:(Dune.root dune)
           in
           match result with
-          | Ok _ -> Sandbox.save_to_settings (Dune dune)
+          | Ok _ -> ()
           | Error err ->
-            let* selection =
-              Window.showErrorMessage
-                ~message:("An error occurred while running dune pkg lock: " ^ err)
-                ~choices:[ "Select a different sandbox", `Select_sandbox ]
-                ()
-            in
-            (match selection with
-             | Some `Select_sandbox | None ->
-               Command_api.(execute Internal.select_sandbox) ())
+            show_message `Error "An error occurred while running dune pkg lock: %s" err
         in
-        let* () = Vscode.Window.withProgress (module Interop.Js.Unit) ~options ~task in
-        Extension_instance.start_language_server instance
+        let+ () = Vscode.Window.withProgress (module Interop.Js.Unit) ~options ~task in
+        let _ = Extension_instance.start_language_server instance in
+        ()
       | _ ->
         show_message
           `Warn

--- a/src/sandbox.ml
+++ b/src/sandbox.ml
@@ -151,7 +151,7 @@ module Setting = struct
     | Esy of Esy.Manifest.t
     | Global
     | Custom of string
-    | Dune of Path.t * bool (* path to dune and is_opam flag *)
+    | Dune of Path.t * bool (* path to dune and is_opam: a flag indicating if the dune instance is installed into an Opam switch. *)
 
   let kind : t -> Kind.t = function
     | Opam _ -> Opam

--- a/src/sandbox.ml
+++ b/src/sandbox.ml
@@ -151,8 +151,8 @@ module Setting = struct
     | Esy of Esy.Manifest.t
     | Global
     | Custom of string
-    | Dune of Path.t * bool
-  (* path to dune and is_opam: a flag indicating if the dune instance is installed into an Opam switch. *)
+    | Dune of Path.t * Opam.Switch.t option
+  (* path to dune and optional opam switch if the dune instance is installed into an opam switch. *)
 
   let kind : t -> Kind.t = function
     | Opam _ -> Opam
@@ -185,13 +185,14 @@ module Setting = struct
       Custom template
     | Dune ->
       let path = Jsonoo.Decode.field "path" decode_vars json in
-      let is_opam =
-        Jsonoo.Decode.field "is_opam" Jsonoo.Decode.string json
-        |> function
-        | "true" -> true
-        | _ -> false
+      let opam_switch =
+        try
+          let sw_str = Jsonoo.Decode.field "opam_switch" Jsonoo.Decode.string json in
+          Opam.Switch.of_string sw_str
+        with
+        | _ -> None
       in
-      Dune (Path.of_string path, is_opam)
+      Dune (Path.of_string path, opam_switch)
   ;;
 
   let to_json (t : t) =
@@ -205,12 +206,18 @@ module Setting = struct
         [ kind; "root", encode_vars @@ (manifest |> Esy.Manifest.path |> Path.to_string) ]
     | Opam switch -> object_ [ kind; "switch", encode_vars @@ Opam.Switch.name switch ]
     | Custom template -> object_ [ kind; "template", string template ]
-    | Dune (path, is_opam) ->
-      object_
+    | Dune (path, opam_switch) ->
+      let fields =
         [ kind
         ; "path", string (Path.to_string path)
-        ; "is_opam", string (Bool.to_string is_opam)
         ]
+      in
+      let fields =
+        match opam_switch with
+        | Some switch -> fields @ [ "opam_switch", string (Opam.Switch.name switch) ]
+        | None -> fields
+      in
+      object_ fields
   ;;
 
   let t = Settings.create_setting ~scope:Workspace ~key:"sandbox" ~of_json ~to_json
@@ -269,10 +276,10 @@ let of_settings () : t option Promise.t =
          None))
   | Some Global -> Promise.return (Some Global)
   | Some (Custom template) -> Promise.return (Some (Custom template))
-  | Some (Dune (path, is_opam)) ->
+  | Some (Dune (path, opam_switch)) ->
     let open Promise.Option.Syntax in
     let* root = Promise.return (workspace_root ()) in
-    let* dune = Dune.make ~working_dir:root ~dune_path:path ~is_opam () in
+    let* dune = Dune.make ~working_dir:root ~dune_path:path ?opam_switch () in
     Promise.return (Some (Dune dune))
 ;;
 
@@ -380,8 +387,8 @@ let save_to_settings sandbox =
       | Custom template -> Setting.Custom template
       | Dune dune ->
         let path = Dune.dune_path dune in
-        let is_opam = Dune.is_opam dune in
-        Setting.Dune (path, is_opam)
+        let opam_switch = Dune.opam_switch dune in
+        Setting.Dune (path, opam_switch)
     in
     Settings.set ~section:"ocaml" Setting.t (to_setting sandbox)
   in
@@ -498,7 +505,6 @@ let custom_dune_input_validation root =
     Dune.make
       ~working_dir:root
       ~dune_path:(Path.of_string (String.strip path_str))
-      ~is_opam:false
       ()
 ;;
 
@@ -532,7 +538,7 @@ let get_active_switch_for_dpm opam_dunes = function
               ~detail:
                 (Printf.sprintf "%s" (Path.to_string (Dune.construct_dune_path path)))
               ()
-          , `Opam_dune (Dune.construct_dune_path path) ))
+          , `Opam_dune (Dune.construct_dune_path path, switch) ))
       else None)
 ;;
 
@@ -563,7 +569,7 @@ let get_non_active_opam_dunes opam_dunes current_switch =
              switch_name)
         ~detail:(Printf.sprintf "%s" (Path.to_string (Dune.construct_dune_path path)))
         ()
-    , `Opam_dune (Dune.construct_dune_path path) )
+    , `Opam_dune (Dune.construct_dune_path path, switch) )
   in
   List.map ~f:to_item global_dunes, List.map ~f:to_item local_dunes
 ;;
@@ -637,9 +643,10 @@ let select_dune_binary () =
        let* choice = Window.showQuickPickItems ~choices ~options () in
        (match choice with
         | None | Some `Separator -> Promise.return None
-        | Some (`Opam_dune path) -> Dune.make ~working_dir:root ~dune_path:path ()
+        | Some (`Opam_dune (path, switch)) ->
+          Dune.make ~working_dir:root ~dune_path:path ~opam_switch:switch ()
         | Some (`System_dune path) ->
-          Dune.make ~working_dir:root ~dune_path:path ~is_opam:false ()
+          Dune.make ~working_dir:root ~dune_path:path ()
         | Some `Custom_dune -> custom_dune_input_validation root))
 ;;
 
@@ -730,11 +737,11 @@ let sandbox_candidates ~workspace_folders =
        | None -> Promise.return None
        | Some root ->
          let* dune_binary = find_all_dune_binaries root opam () in
-         let dune_path, is_opam =
+         let dune_path, opam_switch =
            match dune_binary with
-           | _, _, Some (path, _) -> Some path, false
-           | (path, _, _) :: _, _, _ -> Some path, true
-           | _ -> None, false
+           | _, _, Some (path, _) -> Some path, None
+           | (path, switch, _) :: _, _, _ -> Some path, Some switch
+           | _ -> None, None
          in
          (match dune_path with
           | None -> Promise.return None
@@ -743,7 +750,7 @@ let sandbox_candidates ~workspace_folders =
               Dune.make
                 ~working_dir:root
                 ~dune_path:(Path.of_string dune_path)
-                ~is_opam
+                ?opam_switch
                 ()
             in
             (match dune with

--- a/src/sandbox.ml
+++ b/src/sandbox.ml
@@ -207,11 +207,7 @@ module Setting = struct
     | Opam switch -> object_ [ kind; "switch", encode_vars @@ Opam.Switch.name switch ]
     | Custom template -> object_ [ kind; "template", string template ]
     | Dune (path, opam_switch) ->
-      let fields =
-        [ kind
-        ; "path", string (Path.to_string path)
-        ]
-      in
+      let fields = [ kind; "path", string (Path.to_string path) ] in
       let fields =
         match opam_switch with
         | Some switch -> fields @ [ "opam_switch", string (Opam.Switch.name switch) ]
@@ -502,10 +498,7 @@ let custom_dune_input_validation root =
   match input with
   | None -> Promise.return None
   | Some path_str ->
-    Dune.make
-      ~working_dir:root
-      ~dune_path:(Path.of_string (String.strip path_str))
-      ()
+    Dune.make ~working_dir:root ~dune_path:(Path.of_string (String.strip path_str)) ()
 ;;
 
 let get_active_switch_for_dpm opam_dunes = function
@@ -645,8 +638,7 @@ let select_dune_binary () =
         | None | Some `Separator -> Promise.return None
         | Some (`Opam_dune (path, switch)) ->
           Dune.make ~working_dir:root ~dune_path:path ~opam_switch:switch ()
-        | Some (`System_dune path) ->
-          Dune.make ~working_dir:root ~dune_path:path ()
+        | Some (`System_dune path) -> Dune.make ~working_dir:root ~dune_path:path ()
         | Some `Custom_dune -> custom_dune_input_validation root))
 ;;
 

--- a/src/sandbox.ml
+++ b/src/sandbox.ml
@@ -151,7 +151,7 @@ module Setting = struct
     | Esy of Esy.Manifest.t
     | Global
     | Custom of string
-    | Dune of Path.t (* path to dune *)
+    | Dune of Path.t * bool (* path to dune and is_opam flag *)
 
   let kind : t -> Kind.t = function
     | Opam _ -> Opam
@@ -184,7 +184,13 @@ module Setting = struct
       Custom template
     | Dune ->
       let path = Jsonoo.Decode.field "path" decode_vars json in
-      Dune (Path.of_string path)
+      let is_opam =
+        Jsonoo.Decode.field "is_opam" Jsonoo.Decode.string json
+        |> function
+        | "true" -> true
+        | _ -> false
+      in
+      Dune (Path.of_string path, is_opam)
   ;;
 
   let to_json (t : t) =
@@ -198,7 +204,12 @@ module Setting = struct
         [ kind; "root", encode_vars @@ (manifest |> Esy.Manifest.path |> Path.to_string) ]
     | Opam switch -> object_ [ kind; "switch", encode_vars @@ Opam.Switch.name switch ]
     | Custom template -> object_ [ kind; "template", string template ]
-    | Dune path -> object_ [ kind; "path", string (Path.to_string path) ]
+    | Dune (path, is_opam) ->
+      object_
+        [ kind
+        ; "path", string (Path.to_string path)
+        ; "is_opam", string (Bool.to_string is_opam)
+        ]
   ;;
 
   let t = Settings.create_setting ~scope:Workspace ~key:"sandbox" ~of_json ~to_json
@@ -257,10 +268,10 @@ let of_settings () : t option Promise.t =
          None))
   | Some Global -> Promise.return (Some Global)
   | Some (Custom template) -> Promise.return (Some (Custom template))
-  | Some (Dune path) ->
+  | Some (Dune (path, is_opam)) ->
     let open Promise.Option.Syntax in
     let* root = Promise.return (workspace_root ()) in
-    let* dune = Dune.make ~working_dir:root ~dune_path:path in
+    let* dune = Dune.make ~working_dir:root ~dune_path:path ~is_opam () in
     Promise.return (Some (Dune dune))
 ;;
 
@@ -303,7 +314,7 @@ let detect_opam_sandbox ~project_root opam () =
 
 let detect_dune_pkg ~project_root () =
   let open Promise.Syntax in
-  Dune.make ~working_dir:project_root ~dune_path:project_root
+  Dune.make ~working_dir:project_root ~dune_path:project_root ()
   >>= function
   | Some dune ->
     Dune.is_dpm_enabled dune >>| fun dpm -> if dpm then Some (Dune dune) else None
@@ -368,7 +379,8 @@ let save_to_settings sandbox =
       | Custom template -> Setting.Custom template
       | Dune dune ->
         let path = Dune.dune_path dune in
-        Setting.Dune path
+        let is_opam = Dune.is_opam dune in
+        Setting.Dune (path, is_opam)
     in
     Settings.set ~section:"ocaml" Setting.t (to_setting sandbox)
   in
@@ -482,7 +494,11 @@ let custom_dune_input_validation root =
   match input with
   | None -> Promise.return None
   | Some path_str ->
-    Dune.make ~working_dir:root ~dune_path:(Path.of_string (String.strip path_str))
+    Dune.make
+      ~working_dir:root
+      ~dune_path:(Path.of_string (String.strip path_str))
+      ~is_opam:false
+      ()
 ;;
 
 let get_active_switch_for_dpm opam_dunes = function
@@ -590,7 +606,7 @@ let select_dune_binary () =
            in
            Some
              ( create ~label ~description:"System Dune" ~detail:path ()
-             , `Opam_dune (Path.of_string path) )
+             , `System_dune (Path.of_string path) )
          | None -> None
        in
        let custom_dune_item =
@@ -620,7 +636,9 @@ let select_dune_binary () =
        let* choice = Window.showQuickPickItems ~choices ~options () in
        (match choice with
         | None | Some `Separator -> Promise.return None
-        | Some (`Opam_dune path) -> Dune.make ~working_dir:root ~dune_path:path
+        | Some (`Opam_dune path) -> Dune.make ~working_dir:root ~dune_path:path ()
+        | Some (`System_dune path) ->
+          Dune.make ~working_dir:root ~dune_path:path ~is_opam:false ()
         | Some `Custom_dune -> custom_dune_input_validation root))
 ;;
 
@@ -711,17 +729,21 @@ let sandbox_candidates ~workspace_folders =
        | None -> Promise.return None
        | Some root ->
          let* dune_binary = find_all_dune_binaries root opam () in
-         let dune_path =
+         let dune_path, is_opam =
            match dune_binary with
-           | _, _, Some (path, _) -> Some path
-           | (path, _, _) :: _, _, _ -> Some path
-           | _ -> None
+           | _, _, Some (path, _) -> Some path, false
+           | (path, _, _) :: _, _, _ -> Some path, true
+           | _ -> None, false
          in
          (match dune_path with
           | None -> Promise.return None
           | Some dune_path ->
             let+ dune =
-              Dune.make ~working_dir:root ~dune_path:(Path.of_string dune_path)
+              Dune.make
+                ~working_dir:root
+                ~dune_path:(Path.of_string dune_path)
+                ~is_opam
+                ()
             in
             (match dune with
              | Some dune -> Some { Candidate.sandbox = Dune dune; status = Ok () }

--- a/src/sandbox.ml
+++ b/src/sandbox.ml
@@ -151,7 +151,8 @@ module Setting = struct
     | Esy of Esy.Manifest.t
     | Global
     | Custom of string
-    | Dune of Path.t * bool (* path to dune and is_opam: a flag indicating if the dune instance is installed into an Opam switch. *)
+    | Dune of Path.t * bool
+  (* path to dune and is_opam: a flag indicating if the dune instance is installed into an Opam switch. *)
 
   let kind : t -> Kind.t = function
     | Opam _ -> Opam


### PR DESCRIPTION
This PR introduces a new workflow to upgrade dune either using opam, or getting the latest binary from the nightly website.

cc @voodoos @Tim-ats-d 