### PR TITLE
Honour Dune workspace paths in preprocessed documents

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -51,7 +51,7 @@ jobs:
           path: ocaml-platform.vsix
 
       - name: Test extension
-        run: xvfb-run -a bun run test
+        run: opam exec -- xvfb-run -a bun run test
 
   lint-opam:
     runs-on: ubuntu-latest

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+- Make “Show Preprocessed Document” use Dune's effective workspace and build
+  context, including custom `DUNE_BUILD_DIR` values and esy build directories.
+  (#728)
 - Add syntax highlighting for Dune's parameterised library keywords: the
   `library_parameter` stanza, the `parameters` and `implements` library fields,
   and the `(instantiate ...)` dependency form together with its `:as` keyword.

--- a/dune-project
+++ b/dune-project
@@ -33,6 +33,8 @@
    (= 1.1.7))
   (base
    (>= v0.17))
+  (csexp
+   (>= 1.5.0))
   (promise_jsoo
    (>= 0.4.3))
   (jsonoo

--- a/flake.nix
+++ b/flake.nix
@@ -52,6 +52,7 @@
             propagatedBuildInputs = [ packages.vscode jsonoo ] ++
               (with pkgs.ocamlPackages; [
                 base
+                csexp
                 gen_js_api
                 js_of_ocaml
                 ocaml-version

--- a/src-bindings/node/node.ml
+++ b/src-bindings/node/node.ml
@@ -138,6 +138,7 @@ module Path = struct
       val dirname : string -> string [@@js.global "@node_path.dirname"]
       val extname : string -> string [@@js.global "@node_path.extname"]
       val isAbsolute : string -> bool [@@js.global "@node_path.isAbsolute"]
+      val relative : string -> string -> string [@@js.global "@node_path.relative"]
       val join : (string list[@js.variadic]) -> string [@@js.global "@node_path.join"]]
 
   let delimiter =
@@ -173,6 +174,7 @@ module Fs = struct
       [@@js.global "@node_fs.access"]
 
       val readdir : string -> string list Promise.t [@@js.global "@node_fs.readdir"]
+      val realpath : string -> string Promise.t [@@js.global "@node_fs.realpath"]
 
       val readFile : string -> options:ReadFileOptions.t -> string Promise.t
       [@@js.global "@node_fs.readFile"]]

--- a/src-bindings/node/node.mli
+++ b/src-bindings/node/node.mli
@@ -98,6 +98,7 @@ module Path : sig
   val dirname : string -> string
   val extname : string -> string
   val isAbsolute : string -> bool
+  val relative : string -> string -> string
   val join : string list -> string
 end
 
@@ -112,6 +113,7 @@ end
 module Fs : sig
   val readDir : string -> (string list, string) result Promise.t
   val readFile : string -> string Promise.t
+  val realpath : string -> string Promise.t
   val exists : string -> bool Promise.t
 end
 

--- a/src/ast_editor.ml
+++ b/src/ast_editor.ml
@@ -63,22 +63,19 @@ module Pp_path : sig
     | Unknown
 
   val get_kind : document:TextDocument.t -> kind
-  val get_pp_path : document:TextDocument.t -> string
+
+  val get_pp_path
+    :  Extension_instance.t
+    -> document:TextDocument.t
+    -> (string, string) result Promise.t
 end = struct
   type kind =
     | Structure of [ `Ocaml | `Reason ]
     | Signature of [ `Ocaml | `Reason ]
     | Unknown
 
-  let relative_document_path ~document =
-    Workspace.asRelativePath ~pathOrUri:(`Uri (TextDocument.uri document)) ()
-  ;;
-
-  let project_root_path () = Workspace.rootPath ()
-
   let get_kind ~document =
-    let relative = relative_document_path ~document in
-    match Stdlib.Filename.extension relative with
+    match Stdlib.Filename.extension (TextDocument.fileName document) with
     | ".ml" -> Structure `Ocaml
     | ".mli" -> Signature `Ocaml
     | ".mlx" -> Structure `Ocaml
@@ -87,12 +84,26 @@ end = struct
     | _ -> Unknown
   ;;
 
-  let get_pp_path ~(document : TextDocument.t) =
-    let relative = relative_document_path ~document in
-    match project_root_path () with
-    | None -> raise (User_error "Project root wasn't found.")
-    | Some root ->
-      let build_root = "_build/default" in
+  let get_pp_path instance ~(document : TextDocument.t) =
+    let document_path = TextDocument.fileName document |> Path.of_string in
+    let cwd = Path.dirname document_path |> Path.of_string in
+    let open Promise.Syntax in
+    let+ workspace =
+      Dune_workspace.discover
+        (Extension_instance.sandbox instance)
+        ~cwd
+        ~source:document_path
+    in
+    let root = Dune_workspace.root workspace in
+    let relative = Path.relative_from root document_path in
+    if not (Path.is_inside ~dir:root document_path)
+    then
+      Error
+        (sprintf
+           "File %s is outside the Dune workspace root %s"
+           (TextDocument.fileName document)
+           (Path.to_string root))
+    else (
       let fname_opt =
         match get_kind ~document with
         | Unknown -> None
@@ -103,84 +114,78 @@ end = struct
         | Structure `Reason -> Some (relative ^ ".pp.ml")
         | Signature `Reason -> Some (relative ^ ".pp.mli")
       in
-      (match fname_opt with
-       | Some fname ->
-         let ( / ) = Stdlib.Filename.concat in
-         root / build_root / fname
-       | None ->
-         let uri = Uri.toString (TextDocument.uri document) () in
-         raise (User_error (sprintf "File %s has unknown file extension" uri)))
+      match fname_opt with
+      | Some fname ->
+        Ok (Path.(Dune_workspace.build_context workspace / fname) |> Path.to_string)
+      | None ->
+        let uri = Uri.toString (TextDocument.uri document) () in
+        Error (sprintf "File %s has unknown file extension" uri))
   ;;
 end
 
-let fetch_pp_code ~document =
-  let path = Pp_path.get_pp_path ~document in
-  Ppx_tools.get_reparsed_code_from_pp_file ~path
+let fetch_pp_code instance ~document =
+  let open Promise.Syntax in
+  let+ path = Pp_path.get_pp_path instance ~document in
+  Result.bind path ~f:(fun path -> Ppx_tools.get_reparsed_code_from_pp_file ~path)
 ;;
 
-let transform_to_ast instance ~document ~webview =
-  let ast_editor_state = Extension_instance.ast_editor_state instance in
+let transform_to_ast instance ~document ~mode =
   let module Dumpast = Ppx_tools.Dumpast in
-  let make_value result =
-    match result with
-    | Ok ast -> ast
-    | Error error_msg -> raise (User_error error_msg)
-  in
-  match Ast_editor_state.get_current_ast_mode ast_editor_state with
+  match mode with
   | Ast_editor_state.Original_ast ->
-    let origin_json =
-      let text = TextDocument.getText document () in
-      match Pp_path.get_kind ~document with
-      | Structure _ -> make_value (Dumpast.transform text `Impl)
-      | Signature _ -> make_value (Dumpast.transform text `Intf)
-      | Unknown -> raise (User_error "Unknown file extension")
-    in
-    send_msg "ast" ([%js.of: Jsonoo.t] origin_json) ~webview
+    let text = TextDocument.getText document () in
+    Promise.return
+      (match Pp_path.get_kind ~document with
+       | Structure _ -> Dumpast.transform text `Impl
+       | Signature _ -> Dumpast.transform text `Intf
+       | Unknown -> Error "Unknown file extension")
   | Preprocessed_ast ->
-    let pp_value =
-      let path = Pp_path.get_pp_path ~document in
-      match Ppx_tools.get_preprocessed_ast path with
-      | Error err_msg -> raise (User_error err_msg)
-      | Ok res ->
-        let pp_json_res =
-          let pp_code =
-            match fetch_pp_code ~document with
-            | Ok s -> s
-            | Error err_msg -> raise (User_error err_msg)
-          in
-          let lex = Lexing.from_string pp_code in
-          match Ppxlib.Ast_io.get_ast res with
-          | Impl ppml_structure ->
-            let reparsed_structure = Parse.implementation lex in
-            let reparsed_structure =
-              Ppxlib_ast.Selected_ast.Of_ocaml.copy_structure reparsed_structure
-            in
-            Dumpast.reparse ppml_structure reparsed_structure
-          | Intf signature ->
-            let reparsed_signature = Parse.interface lex in
-            let reparsed_signature =
-              Ppxlib_ast.Selected_ast.Of_ocaml.copy_signature reparsed_signature
-            in
-            Dumpast.reparse_signature signature reparsed_signature
+    let open Promise.Result.Syntax in
+    let* path = Pp_path.get_pp_path instance ~document in
+    let* res = Promise.return (Ppx_tools.get_preprocessed_ast path) in
+    let lex = Lexing.from_string (Ppx_tools.reparsed_code_of_ast res) in
+    Promise.return
+      (match Ppxlib.Ast_io.get_ast res with
+       | Impl ppml_structure ->
+         let reparsed_structure = Parse.implementation lex in
+         let reparsed_structure =
+           Ppxlib_ast.Selected_ast.Of_ocaml.copy_structure reparsed_structure
+         in
+         Dumpast.reparse ppml_structure reparsed_structure
+       | Intf signature ->
+         let reparsed_signature = Parse.interface lex in
+         let reparsed_signature =
+           Ppxlib_ast.Selected_ast.Of_ocaml.copy_signature reparsed_signature
+         in
+         Dumpast.reparse_signature signature reparsed_signature)
+;;
+
+let update_ast instance ~document ~webview =
+  let ast_editor_state = Extension_instance.ast_editor_state instance in
+  let mode, request_is_current =
+    Ast_editor_state.start_ast_update ast_editor_state (TextDocument.uri document)
+  in
+  let (_ : unit Promise.t) =
+    let open Promise.Syntax in
+    let+ result = transform_to_ast instance ~document ~mode in
+    if request_is_current ()
+    then (
+      match result with
+      | Ok ast ->
+        let msg_type =
+          match mode with
+          | Ast_editor_state.Original_ast -> "ast"
+          | Preprocessed_ast -> "pp_ast"
         in
-        (match pp_json_res with
-         | Error err_msg -> raise (User_error err_msg)
-         | Ok pp_json -> make_value (Ok pp_json))
-    in
-    send_msg "pp_ast" ([%js.of: Jsonoo.t] pp_value) ~webview
+        send_msg msg_type ([%js.of: Jsonoo.t] ast) ~webview
+      | Error error -> send_msg "error" ([%js.of: string] error) ~webview)
+  in
+  ()
 ;;
 
 let onDidChangeTextDocument_listener instance document webview event =
   let changed_document = TextDocumentChangeEvent.document event in
-  if document_eq document changed_document
-  then (
-    try transform_to_ast instance ~document ~webview with
-    | User_error err_msg -> send_msg "error" ([%js.of: string] err_msg) ~webview)
-;;
-
-let update_ast instance ~document ~webview =
-  try transform_to_ast instance ~document ~webview with
-  | User_error err_msg -> send_msg "error" ([%js.of: string] err_msg) ~webview
+  if document_eq document changed_document then update_ast instance ~document ~webview
 ;;
 
 let onDidReceiveMessage_listener instance webview document msg =
@@ -306,12 +311,11 @@ let resolveCustomTextEditor
         Disposable.dispose onDidChangeTextDocument_disposable)
       ()
   in
-  (try transform_to_ast instance ~document ~webview with
-   | User_error err_msg -> send_msg "error" ([%js.of: string] err_msg) ~webview);
   let p =
     let open Promise.Syntax in
-    let+ r = read_html_file ~webview ~extension () in
-    WebView.set_html webview r
+    let+ html = read_html_file ~webview ~extension () in
+    WebView.set_html webview html;
+    update_ast instance ~document ~webview
   in
   `Promise p
 ;;
@@ -343,7 +347,8 @@ let replace_document_content ~document ~content =
 let open_pp_doc instance ~document =
   let open Promise.Syntax in
   let ast_editor_state = Extension_instance.ast_editor_state instance in
-  match fetch_pp_code ~document with
+  let* content = fetch_pp_code instance ~document in
+  match content with
   | Error e -> Promise.return (Error e)
   | Ok pp_pp_str ->
     let file_name =
@@ -389,7 +394,8 @@ let reload_pp_doc instance ~document =
      with
      | None -> Promise.return (Error "Visible editor wasn't found")
      | Some _ ->
-       (match fetch_pp_code ~document:original_document with
+       let* content = fetch_pp_code instance ~document:original_document in
+       (match content with
         | Error err_msg -> Promise.return (Error err_msg)
         | Ok content ->
           replace_document_content ~content ~document;
@@ -400,6 +406,7 @@ let rec manage_choice instance choice ~document =
   let ast_editor_state = Extension_instance.ast_editor_state instance in
   match choice with
   | Some `Update | Some `Retry ->
+    Dune_workspace.invalidate ();
     let res =
       (match
          (Ast_editor_state.pp_status ast_editor_state) (TextDocument.uri document)

--- a/src/ast_editor_state.ml
+++ b/src/ast_editor_state.ml
@@ -20,17 +20,24 @@ type t =
   ; mutable origin_to_pp_doc_map : (string, string, String.comparator_witness) Map.t
     (** Mapping beween the original and Preprocessed Document used to
         simultaneously communicate with a common webview. *)
+  ; mutable ast_update_generation : int
+    (** Monotonically increasing identifier for AST update requests. *)
+  ; mutable current_ast_updates : (string, int, String.comparator_witness) Map.t
+    (** The latest AST update request for each original document. *)
   }
 
 let make () =
   let webview_map = Map.empty (module String) in
   let dirty_original_doc_set = Set.empty (module String) in
   let origin_to_pp_doc_map = Map.empty (module String) in
+  let current_ast_updates = Map.empty (module String) in
   { webview_map
   ; current_ast_mode = Original_ast
   ; hover_disposable = None
   ; dirty_original_doc_set
   ; origin_to_pp_doc_map
+  ; ast_update_generation = 0
+  ; current_ast_updates
   }
 ;;
 
@@ -63,6 +70,21 @@ let associate_origin_and_pp t ~origin_uri ~pp_doc_uri =
 
 let get_current_ast_mode t = t.current_ast_mode
 let set_current_ast_mode t v = t.current_ast_mode <- v
+
+let start_ast_update t uri =
+  t.ast_update_generation <- t.ast_update_generation + 1;
+  let generation = t.ast_update_generation in
+  let key = Uri.toString uri () in
+  t.current_ast_updates <- Map.set t.current_ast_updates ~key ~data:generation;
+  let mode = t.current_ast_mode in
+  let request_is_current () =
+    Poly.equal mode t.current_ast_mode
+    && Map.find t.current_ast_updates key
+       |> Option.value_map ~default:false ~f:(Int.equal generation)
+  in
+  mode, request_is_current
+;;
+
 let get_hover_disposable t = t.hover_disposable
 let set_hover_disposable t hover_disposable = t.hover_disposable <- hover_disposable
 
@@ -102,7 +124,8 @@ let set_webview t uri webview =
 
 let remove_webview t uri =
   let key = Uri.toString uri () in
-  t.webview_map <- Map.remove t.webview_map key
+  t.webview_map <- Map.remove t.webview_map key;
+  t.current_ast_updates <- Map.remove t.current_ast_updates key
 ;;
 
 let pp_status t uri =

--- a/src/ast_editor_state.mli
+++ b/src/ast_editor_state.mli
@@ -15,6 +15,13 @@ val find_webview_by_doc : t -> Uri.t -> WebView.t option
 val associate_origin_and_pp : t -> origin_uri:Uri.t -> pp_doc_uri:Uri.t -> unit
 val get_current_ast_mode : t -> ast_mode
 val set_current_ast_mode : t -> ast_mode -> unit
+
+(** Register a new AST update request for a document. Returns the mode the
+    request was started in, together with a function telling whether the
+    request is still the latest one for that document and the mode is still
+    current. *)
+val start_ast_update : t -> Uri.t -> ast_mode * (unit -> bool)
+
 val get_hover_disposable : t -> Disposable.t option
 val set_hover_disposable : t -> Disposable.t option -> unit
 val entry_exists : t -> origin_doc:Uri.t -> pp_doc:Uri.t -> bool

--- a/src/cmd.ml
+++ b/src/cmd.ml
@@ -78,14 +78,15 @@ let check ?env t =
     Spawn s
 ;;
 
-let run ?cwd ?env ?stdin cmd =
+let run ?cwd ?env ?stdin ?(log_output = true) cmd =
   let cwd = Option.map cwd ~f:Path.to_string in
   let logger event =
     let (lazy output) = Output.command_output_channel in
     match event with
     | ChildProcess.Spawned ->
       Vscode.OutputChannel.appendLine output ~value:("$ " ^ to_string cmd)
-    | Stdout data | Stderr data -> Vscode.OutputChannel.append output ~value:data
+    | Stdout data | Stderr data ->
+      if log_output then Vscode.OutputChannel.append output ~value:data
     | Closed -> Vscode.OutputChannel.appendLine output ~value:""
     | ProcessError err -> log_value "process error" @@ [%js.of: Node.JsError.t] err
   in
@@ -96,19 +97,20 @@ let run ?cwd ?env ?stdin cmd =
   | Shell command_line -> ChildProcess.exec command_line ~logger ?stdin ~options
 ;;
 
-let log ?(result : ChildProcess.return option) (t : t) =
+let log ?(result : ChildProcess.return option) ?(log_output = true) (t : t) =
   let open Jsonoo.Encode in
   let fields =
     match result with
     | None -> []
     | Some result ->
-      [ ( "result"
-        , object_
-            [ "exitCode", int result.exitCode
-            ; "stdout", string result.stdout
-            ; "stderr", string result.stderr
-            ] )
-      ]
+      let result_fields =
+        [ "exitCode", int result.exitCode ]
+        @
+        if log_output
+        then [ "stdout", string result.stdout; "stderr", string result.stderr ]
+        else []
+      in
+      [ "result", object_ result_fields ]
   in
   let fields =
     match t with
@@ -121,11 +123,11 @@ let log ?(result : ChildProcess.return option) (t : t) =
   | Some _ -> log_fields "external command (finished)" fields
 ;;
 
-let output ?cwd ?env ?stdin (t : t) =
+let output ?cwd ?env ?stdin ?(log_output = true) (t : t) =
   let open Promise.Syntax in
   log t;
-  let+ (result : ChildProcess.return) = run ?stdin ?cwd ?env t in
-  log ~result t;
+  let+ (result : ChildProcess.return) = run ?stdin ?cwd ?env ~log_output t in
+  log ~result ~log_output t;
   if result.exitCode = 0
   then Ok result.stdout
   else Error (Printf.sprintf "Command failed with error: \n%s" result.stderr)

--- a/src/cmd.ml
+++ b/src/cmd.ml
@@ -78,15 +78,14 @@ let check ?env t =
     Spawn s
 ;;
 
-let run ?cwd ?env ?stdin ?(log_output = true) cmd =
+let run ?cwd ?env ?stdin cmd =
   let cwd = Option.map cwd ~f:Path.to_string in
   let logger event =
     let (lazy output) = Output.command_output_channel in
     match event with
     | ChildProcess.Spawned ->
       Vscode.OutputChannel.appendLine output ~value:("$ " ^ to_string cmd)
-    | Stdout data | Stderr data ->
-      if log_output then Vscode.OutputChannel.append output ~value:data
+    | Stdout data | Stderr data -> Vscode.OutputChannel.append output ~value:data
     | Closed -> Vscode.OutputChannel.appendLine output ~value:""
     | ProcessError err -> log_value "process error" @@ [%js.of: Node.JsError.t] err
   in
@@ -97,20 +96,19 @@ let run ?cwd ?env ?stdin ?(log_output = true) cmd =
   | Shell command_line -> ChildProcess.exec command_line ~logger ?stdin ~options
 ;;
 
-let log ?(result : ChildProcess.return option) ?(log_output = true) (t : t) =
+let log ?(result : ChildProcess.return option) (t : t) =
   let open Jsonoo.Encode in
   let fields =
     match result with
     | None -> []
     | Some result ->
-      let result_fields =
-        [ "exitCode", int result.exitCode ]
-        @
-        if log_output
-        then [ "stdout", string result.stdout; "stderr", string result.stderr ]
-        else []
-      in
-      [ "result", object_ result_fields ]
+      [ ( "result"
+        , object_
+            [ "exitCode", int result.exitCode
+            ; "stdout", string result.stdout
+            ; "stderr", string result.stderr
+            ] )
+      ]
   in
   let fields =
     match t with
@@ -123,11 +121,11 @@ let log ?(result : ChildProcess.return option) ?(log_output = true) (t : t) =
   | Some _ -> log_fields "external command (finished)" fields
 ;;
 
-let output ?cwd ?env ?stdin ?(log_output = true) (t : t) =
+let output ?cwd ?env ?stdin (t : t) =
   let open Promise.Syntax in
   log t;
-  let+ (result : ChildProcess.return) = run ?stdin ?cwd ?env ~log_output t in
-  log ~result ~log_output t;
+  let+ (result : ChildProcess.return) = run ?stdin ?cwd ?env t in
+  log ~result t;
   if result.exitCode = 0
   then Ok result.stdout
   else Error (Printf.sprintf "Command failed with error: \n%s" result.stderr)

--- a/src/cmd.mli
+++ b/src/cmd.mli
@@ -20,17 +20,12 @@ val to_spawn : t -> spawn
 val append : spawn -> string list -> spawn
 val check_spawn : ?env:string Interop.Dict.t -> spawn -> spawn Or_error.t Promise.t
 val check : ?env:string Interop.Dict.t -> t -> t Or_error.t Promise.t
-
-(* [log_output] controls whether captured stdout and stderr are copied to the
-   command and extension logs. Set it to [false] for machine-readable or
-   potentially sensitive output; the returned output is unaffected. *)
-val log : ?result:ChildProcess.return -> ?log_output:bool -> t -> unit
+val log : ?result:ChildProcess.return -> t -> unit
 
 val output
   :  ?cwd:Path.t
   -> ?env:string Interop.Dict.t
   -> ?stdin:string
-  -> ?log_output:bool
   -> t
   -> (stdout, stderr) result Promise.t
 
@@ -40,6 +35,5 @@ val run
   :  ?cwd:Path.t
   -> ?env:string Interop.Dict.t
   -> ?stdin:stderr
-  -> ?log_output:bool
   -> t
   -> ChildProcess.return Promise.t

--- a/src/cmd.mli
+++ b/src/cmd.mli
@@ -20,12 +20,17 @@ val to_spawn : t -> spawn
 val append : spawn -> string list -> spawn
 val check_spawn : ?env:string Interop.Dict.t -> spawn -> spawn Or_error.t Promise.t
 val check : ?env:string Interop.Dict.t -> t -> t Or_error.t Promise.t
-val log : ?result:ChildProcess.return -> t -> unit
+
+(* [log_output] controls whether captured stdout and stderr are copied to the
+   command and extension logs. Set it to [false] for machine-readable or
+   potentially sensitive output; the returned output is unaffected. *)
+val log : ?result:ChildProcess.return -> ?log_output:bool -> t -> unit
 
 val output
   :  ?cwd:Path.t
   -> ?env:string Interop.Dict.t
   -> ?stdin:string
+  -> ?log_output:bool
   -> t
   -> (stdout, stderr) result Promise.t
 
@@ -35,5 +40,6 @@ val run
   :  ?cwd:Path.t
   -> ?env:string Interop.Dict.t
   -> ?stdin:stderr
+  -> ?log_output:bool
   -> t
   -> ChildProcess.return Promise.t

--- a/src/dune
+++ b/src/dune
@@ -4,6 +4,7 @@
   (pps gen_js_api.ppx))
  (libraries
   base
+  csexp
   gen_js_api
   js_of_ocaml
   jsonoo

--- a/src/dune.ml
+++ b/src/dune.ml
@@ -90,6 +90,13 @@ module Dune_version = struct
       Stdlib.compare (major, minor, patch) (3, 24, 0) >= 0
     | Preview (y, m, d) -> Stdlib.compare (y, m, d) (2026, 6, 11) >= 0
   ;;
+
+  let at_least t (major, minor, patch) =
+    not (Ordering.is_less (compare t (Release (major, minor, patch))))
+  ;;
+
+  let supports_root_environment t = at_least t (3, 21, 0)
+  let supports_cross_target_environment t = at_least t (3, 22, 0)
 end
 
 let construct_dune_path path = Path.(of_string (String.strip path) / "dune")

--- a/src/dune.mli
+++ b/src/dune.mli
@@ -7,6 +7,8 @@ module Dune_version : sig
   val to_string : t -> string
   val from_string : string -> t option
   val is_valid : t -> bool
+  val supports_root_environment : t -> bool
+  val supports_cross_target_environment : t -> bool
 end
 
 val construct_dune_path : string -> Path.t

--- a/src/dune_workspace.ml
+++ b/src/dune_workspace.ml
@@ -55,7 +55,8 @@ module Environment = struct
     | Sandbox.Esy (esy, manifest) ->
       let open Promise.Syntax in
       let+ output =
-        Esy.exec esy manifest ~args:[ "command-env"; "--json" ] |> Cmd.output ~cwd
+        Esy.exec esy manifest ~args:[ "command-env"; "--json" ]
+        |> Cmd.output ~cwd ~log_output:false
       in
       (match output with
        | Error error ->
@@ -74,7 +75,8 @@ module Environment = struct
               ~section:"Dune workspace"
               "Unable to parse `esy command-env --json` output.";
             process ()))
-    | Opam _ | Global | Custom _ | Dune _ -> Promise.return (process ())
+    | Sandbox.Opam _ | Sandbox.Global | Sandbox.Custom _ | Sandbox.Dune _ ->
+      Promise.return (process ())
   ;;
 
   let needs_version_check t = Option.is_some t.root || Option.is_some t.cross_target
@@ -214,18 +216,27 @@ let make { root; build_dir } ~context =
 type cache_key =
   { sandbox : Sandbox.t
   ; cwd : Path.t
+  ; source : Path.t
   ; build_dir : string option
   ; root : string option
   ; workspace : string option
   ; cross_target : string option
   }
 
-let cache : (cache_key * t) list ref = ref []
+type cache_entry =
+  { id : int
+  ; key : cache_key
+  ; workspace : t Promise.t
+  }
+
+let cache : cache_entry list ref = ref []
+let next_cache_id = ref 0
 let invalidate () = cache := []
 
-let cache_key sandbox ~cwd =
+let cache_key sandbox ~cwd ~source =
   { sandbox
   ; cwd
+  ; source
   ; build_dir = Process.Env.get "DUNE_BUILD_DIR"
   ; root = Process.Env.get "DUNE_ROOT"
   ; workspace = Process.Env.get "DUNE_WORKSPACE"
@@ -236,14 +247,29 @@ let cache_key sandbox ~cwd =
 let cache_key_equal left right =
   Sandbox.equal left.sandbox right.sandbox
   && Path.equal left.cwd right.cwd
+  && Path.equal left.source right.source
   && Option.equal String.equal left.build_dir right.build_dir
   && Option.equal String.equal left.root right.root
   && Option.equal String.equal left.workspace right.workspace
   && Option.equal String.equal left.cross_target right.cross_target
 ;;
 
+let find_cached key =
+  List.find_map !cache ~f:(fun entry ->
+    if cache_key_equal entry.key key then Some entry.workspace else None)
+;;
+
+let remove_cache_entry id =
+  cache := List.filter !cache ~f:(fun entry -> not (Int.equal entry.id id))
+;;
+
+let sandbox_environment_is_opaque = function
+  | Sandbox.Opam _ | Sandbox.Custom _ -> true
+  | Sandbox.Esy _ | Sandbox.Global | Sandbox.Dune _ -> false
+;;
+
 let dune_output sandbox ~cwd args =
-  Sandbox.get_command sandbox "dune" args `Command |> Cmd.output ~cwd
+  Sandbox.get_command sandbox "dune" args `Command |> Cmd.output ~cwd ~log_output:false
 ;;
 
 let contexts_of_output output =
@@ -341,7 +367,7 @@ let query_merlin_context sandbox ~cwd ~source ~(layout : layout) ~contexts =
   let build_dirs = [ layout.build_dir; physical_build_dir ] in
   let request = Csexp.(to_string (List [ Atom "File"; Atom (Path.to_string source) ])) in
   let command = Sandbox.get_command sandbox "dune" [ "ocaml-merlin" ] `Command in
-  let+ output = Cmd.output command ~cwd ~stdin:request in
+  let+ output = Cmd.output command ~cwd ~stdin:request ~log_output:false in
   Result.bind output ~f:(merlin_context_of_output ~build_dirs ~contexts)
 ;;
 
@@ -361,61 +387,74 @@ let select_context
     let+ merlin_context = query_merlin_context sandbox ~cwd ~source ~layout ~contexts in
     (match merlin_context with
      | Ok context -> context
-     | Error _ -> fallback)
+     | Error error ->
+       log_chan
+         `Info
+         ~section:"Dune workspace"
+         "Unable to identify the Merlin build context; using %s: %s"
+         fallback
+         error;
+       fallback)
+;;
+
+let discover_uncached sandbox ~cwd ~source =
+  let open Promise.Syntax in
+  let* environment = Environment.selected_sandbox sandbox ~cwd in
+  let* environment = environment_for_dune sandbox environment ~cwd in
+  let* root = root_of_environment environment ~cwd in
+  let fallback_layout = layout_of_environment environment ~root in
+  let* has_workspace_file = Fs.exists Path.(root / "dune-workspace" |> to_string) in
+  let needs_dune_description =
+    sandbox_environment_is_opaque sandbox
+    || Option.is_some environment.workspace
+    || has_workspace_file
+  in
+  let* contexts_result =
+    if needs_dune_description then query_contexts sandbox ~cwd else Promise.return (Ok [])
+  in
+  let contexts =
+    match contexts_result with
+    | Ok contexts -> contexts
+    | Error error ->
+      log_chan
+        `Warn
+        ~section:"Dune workspace"
+        "Unable to run `dune describe contexts`; using a fallback context: %s"
+        error;
+      []
+  in
+  let preferred_context = fallback_context environment contexts in
+  let* layout =
+    if needs_dune_description
+    then query_layout sandbox ~cwd ~context:preferred_context ~fallback:fallback_layout
+    else Promise.return fallback_layout
+  in
+  let* context =
+    select_context
+      sandbox
+      environment
+      ~cwd
+      ~source
+      ~layout
+      ~fallback:preferred_context
+      contexts
+  in
+  Promise.return (make layout ~context)
 ;;
 
 let discover sandbox ~cwd ~source =
-  let key = cache_key sandbox ~cwd in
-  match List.Assoc.find !cache key ~equal:cache_key_equal with
-  | Some workspace -> Promise.return workspace
+  let key = cache_key sandbox ~cwd ~source in
+  match find_cached key with
+  | Some workspace -> workspace
   | None ->
-    let open Promise.Syntax in
-    let* environment = Environment.selected_sandbox sandbox ~cwd in
-    let* environment = environment_for_dune sandbox environment ~cwd in
-    let* root = root_of_environment environment ~cwd in
-    let fallback_layout = layout_of_environment environment ~root in
-    let* has_workspace_file = Fs.exists Path.(root / "dune-workspace" |> to_string) in
-    let authoritative_workspace =
-      match sandbox with
-      | Sandbox.Opam _ | Custom _ -> true
-      | Global | Esy _ | Dune _ -> false
+    next_cache_id := !next_cache_id + 1;
+    let id = !next_cache_id in
+    let workspace =
+      discover_uncached sandbox ~cwd ~source
+      |> Promise.catch ~rejected:(fun error ->
+        remove_cache_entry id;
+        Promise.reject error)
     in
-    let needs_contexts =
-      authoritative_workspace
-      || Option.is_some environment.workspace
-      || has_workspace_file
-    in
-    let* contexts_result =
-      if needs_contexts then query_contexts sandbox ~cwd else Promise.return (Ok [])
-    in
-    let contexts =
-      match contexts_result with
-      | Ok contexts -> contexts
-      | Error error ->
-        log_chan
-          `Warn
-          ~section:"Dune workspace"
-          "Unable to run `dune describe contexts`; using Dune's default context: %s"
-          error;
-        []
-    in
-    let preferred_context = fallback_context environment contexts in
-    let* layout =
-      if authoritative_workspace
-      then query_layout sandbox ~cwd ~context:preferred_context ~fallback:fallback_layout
-      else Promise.return fallback_layout
-    in
-    let* context =
-      select_context
-        sandbox
-        environment
-        ~cwd
-        ~source
-        ~layout
-        ~fallback:preferred_context
-        contexts
-    in
-    let workspace = make layout ~context in
-    cache := (key, workspace) :: !cache;
-    Promise.return workspace
+    cache := { id; key; workspace } :: !cache;
+    workspace
 ;;

--- a/src/dune_workspace.ml
+++ b/src/dune_workspace.ml
@@ -1,0 +1,421 @@
+open Import
+
+type t =
+  { root : Path.t
+  ; build_context : Path.t
+  }
+
+type layout =
+  { root : Path.t
+  ; build_dir : Path.t
+  }
+
+let root (t : t) = t.root
+let build_context (t : t) = t.build_context
+
+module Environment = struct
+  type t =
+    { build_dir : string option
+    ; root : string option
+    ; workspace : string option
+    ; cross_target : string option
+    }
+
+  let non_empty = function
+    | Some value when not (String.is_empty value) -> Some value
+    | None | Some _ -> None
+  ;;
+
+  let process () =
+    { build_dir = Process.Env.get "DUNE_BUILD_DIR" |> non_empty
+    ; root = Process.Env.get "DUNE_ROOT" |> non_empty
+    ; workspace = Process.Env.get "DUNE_WORKSPACE" |> non_empty
+    ; cross_target = Process.Env.get "DUNE_CROSS_TARGET" |> non_empty
+    }
+  ;;
+
+  let json_field json name =
+    if property_exists json name
+    then Jsonoo.Decode.field name Jsonoo.Decode.string json |> Option.some |> non_empty
+    else None
+  ;;
+
+  let of_json json =
+    let inherited = process () in
+    { build_dir = Option.first_some (json_field json "DUNE_BUILD_DIR") inherited.build_dir
+    ; root = Option.first_some (json_field json "DUNE_ROOT") inherited.root
+    ; workspace = Option.first_some (json_field json "DUNE_WORKSPACE") inherited.workspace
+    ; cross_target =
+        Option.first_some (json_field json "DUNE_CROSS_TARGET") inherited.cross_target
+    }
+  ;;
+
+  let selected_sandbox sandbox ~cwd =
+    match sandbox with
+    | Sandbox.Esy (esy, manifest) ->
+      let open Promise.Syntax in
+      let+ output =
+        Esy.exec esy manifest ~args:[ "command-env"; "--json" ] |> Cmd.output ~cwd
+      in
+      (match output with
+       | Error error ->
+         log_chan
+           `Warn
+           ~section:"Dune workspace"
+           "Unable to read the esy command environment: %s"
+           error;
+         process ()
+       | Ok output ->
+         (match Jsonoo.try_parse_opt output with
+          | Some json -> of_json json
+          | None ->
+            log_chan
+              `Warn
+              ~section:"Dune workspace"
+              "Unable to parse `esy command-env --json` output.";
+            process ()))
+    | Opam _ | Global | Custom _ | Dune _ -> Promise.return (process ())
+  ;;
+
+  let needs_version_check t = Option.is_some t.root || Option.is_some t.cross_target
+
+  let for_dune_version t version =
+    { t with
+      root =
+        (if Dune.Dune_version.supports_root_environment version then t.root else None)
+    ; cross_target =
+        (if Dune.Dune_version.supports_cross_target_environment version
+         then t.cross_target
+         else None)
+    }
+  ;;
+end
+
+let resolve_from ~base path =
+  let path = Path.of_string path in
+  if Path.is_absolute path then path else Path.(base / to_string path)
+;;
+
+let find_root ~from =
+  let priority = function
+    | `Workspace -> 0
+    | `Project -> 1
+  in
+  let rec loop dir candidate =
+    let open Promise.Syntax in
+    let* has_workspace, has_project =
+      Promise.all2
+        ( Fs.exists Path.(dir / "dune-workspace" |> to_string)
+        , Fs.exists Path.(dir / "dune-project" |> to_string) )
+    in
+    let candidate =
+      let found =
+        if has_workspace
+        then Some `Workspace
+        else if has_project
+        then Some `Project
+        else None
+      in
+      match found, candidate with
+      | None, candidate -> candidate
+      | Some kind, None -> Some (kind, dir)
+      | Some kind, Some (candidate_kind, _) when priority kind <= priority candidate_kind
+        -> Some (kind, dir)
+      | Some _, Some _ -> candidate
+    in
+    match Path.parent dir with
+    | None -> Promise.return candidate
+    | Some parent -> loop parent candidate
+  in
+  let open Promise.Syntax in
+  let+ candidate = loop from None in
+  match candidate with
+  | Some (_, root) -> root
+  | None -> from
+;;
+
+let field_values fields name =
+  List.filter_map fields ~f:(function
+    | Csexp.List [ Atom field_name; Atom value ] when String.equal field_name name ->
+      Some value
+    | Atom _ | List _ -> None)
+;;
+
+let find_field fields name = List.hd (field_values fields name)
+
+let of_canonical_sexp input =
+  match Csexp.parse_string input with
+  | Error (pos, message) -> Error (Printf.sprintf "at byte %d: %s" pos message)
+  | Ok (Csexp.Atom _) -> Error "expected a list of workspace fields"
+  | Ok (List fields) ->
+    (match find_field fields "root", find_field fields "build_context" with
+     | Some root, Some build_context ->
+       let root = Path.of_string root in
+       let build_context = resolve_from ~base:root build_context in
+       (match Path.parent build_context with
+        | Some build_dir -> Ok { root; build_dir }
+        | None -> Error "Dune workspace description has an invalid build_context field")
+     | None, _ -> Error "Dune workspace description has no root field"
+     | _, None -> Error "Dune workspace description has no build_context field")
+;;
+
+let root_of_environment (environment : Environment.t) ~cwd =
+  match environment.root with
+  | None -> find_root ~from:cwd
+  | Some root -> Promise.return (resolve_from ~base:cwd root)
+;;
+
+let default_context (environment : Environment.t) =
+  match environment.cross_target with
+  | None -> "default"
+  | Some target -> "default." ^ target
+;;
+
+let layout_of_environment (environment : Environment.t) ~root =
+  let build_dir =
+    match environment.build_dir with
+    | None -> Path.(root / "_build")
+    | Some build_dir -> resolve_from ~base:root build_dir
+  in
+  { root; build_dir }
+;;
+
+let preserve_equivalent_root ~fallback described =
+  let open Promise.Syntax in
+  let* fallback_realpath, described_realpath =
+    Promise.all2
+      ( Promise.Result.from_catch (Fs.realpath (Path.to_string fallback.root))
+      , Promise.Result.from_catch (Fs.realpath (Path.to_string described.root)) )
+  in
+  let equal =
+    match Platform.t with
+    | Win32 -> Path.iequal
+    | Darwin | Linux | Other -> Path.equal
+  in
+  match fallback_realpath, described_realpath with
+  | Ok fallback_realpath, Ok described_realpath
+    when equal (Path.of_string fallback_realpath) (Path.of_string described_realpath) ->
+    Promise.return { described with root = fallback.root }
+  | Ok _, Ok _ | Error _, _ | _, Error _ -> Promise.return described
+;;
+
+let realpath_or_original path =
+  let open Promise.Syntax in
+  let+ realpath = Promise.Result.from_catch (Fs.realpath (Path.to_string path)) in
+  match realpath with
+  | Ok realpath -> Path.of_string realpath
+  | Error _ -> path
+;;
+
+let make { root; build_dir } ~context =
+  { root; build_context = Path.(build_dir / context) }
+;;
+
+type cache_key =
+  { sandbox : Sandbox.t
+  ; cwd : Path.t
+  ; build_dir : string option
+  ; root : string option
+  ; workspace : string option
+  ; cross_target : string option
+  }
+
+let cache : (cache_key * t) list ref = ref []
+let invalidate () = cache := []
+
+let cache_key sandbox ~cwd =
+  { sandbox
+  ; cwd
+  ; build_dir = Process.Env.get "DUNE_BUILD_DIR"
+  ; root = Process.Env.get "DUNE_ROOT"
+  ; workspace = Process.Env.get "DUNE_WORKSPACE"
+  ; cross_target = Process.Env.get "DUNE_CROSS_TARGET"
+  }
+;;
+
+let cache_key_equal left right =
+  Sandbox.equal left.sandbox right.sandbox
+  && Path.equal left.cwd right.cwd
+  && Option.equal String.equal left.build_dir right.build_dir
+  && Option.equal String.equal left.root right.root
+  && Option.equal String.equal left.workspace right.workspace
+  && Option.equal String.equal left.cross_target right.cross_target
+;;
+
+let dune_output sandbox ~cwd args =
+  Sandbox.get_command sandbox "dune" args `Command |> Cmd.output ~cwd
+;;
+
+let contexts_of_output output =
+  String.split_lines output
+  |> List.filter_map ~f:(fun context ->
+    let context = String.strip context in
+    if String.is_empty context then None else Some context)
+;;
+
+let fallback_context (environment : Environment.t) contexts =
+  let preferred = default_context environment in
+  if List.mem contexts preferred ~equal:String.equal
+  then preferred
+  else (
+    let cross_context =
+      Option.bind environment.cross_target ~f:(fun target ->
+        List.find contexts ~f:(String.is_suffix ~suffix:("." ^ target)))
+    in
+    Option.first_some cross_context (List.hd contexts) |> Option.value ~default:preferred)
+;;
+
+let query_contexts sandbox ~cwd =
+  let open Promise.Syntax in
+  let+ contexts = dune_output sandbox ~cwd [ "describe"; "contexts" ] in
+  Result.map contexts ~f:contexts_of_output
+;;
+
+let query_layout sandbox ~cwd ~context ~fallback =
+  let args =
+    [ "describe"; "workspace"; "--format=csexp"; "--lang=0.1"; "--context=" ^ context ]
+  in
+  let open Promise.Syntax in
+  let* described = dune_output sandbox ~cwd args in
+  match described with
+  | Error error ->
+    log_chan
+      `Warn
+      ~section:"Dune workspace"
+      "Unable to run `dune describe workspace`; using Dune's environment/default path \
+       layout: %s"
+      error;
+    Promise.return fallback
+  | Ok output ->
+    (match of_canonical_sexp output with
+     | Ok layout -> preserve_equivalent_root ~fallback layout
+     | Error error ->
+       log_chan
+         `Warn
+         ~section:"Dune workspace"
+         "Unable to decode `dune describe workspace`: %s"
+         error;
+       Promise.return fallback)
+;;
+
+let environment_for_dune sandbox environment ~cwd =
+  if not (Environment.needs_version_check environment)
+  then Promise.return environment
+  else
+    let open Promise.Syntax in
+    let+ output = dune_output sandbox ~cwd [ "--version" ] in
+    match output with
+    | Error _ -> environment
+    | Ok output ->
+      (match Dune.Dune_version.from_string (String.strip output) with
+       | None -> environment
+       | Some version -> Environment.for_dune_version environment version)
+;;
+
+let merlin_context_of_output ~build_dirs ~contexts output =
+  let context_of_path path =
+    let path = Path.of_string path in
+    List.find contexts ~f:(fun context ->
+      List.exists build_dirs ~f:(fun build_dir ->
+        Path.is_inside ~dir:Path.(build_dir / context) path))
+  in
+  match Csexp.parse_string output with
+  | Error (pos, message) -> Error (Printf.sprintf "at byte %d: %s" pos message)
+  | Ok (Csexp.Atom _) -> Error "expected a list of Merlin configuration fields"
+  | Ok (List fields) ->
+    let from_paths paths = List.find_map paths ~f:context_of_path in
+    (match
+       Option.first_some
+         (from_paths (field_values fields "INDEX"))
+         (from_paths (List.rev (field_values fields "B")))
+     with
+     | Some context -> Ok context
+     | None -> Error "Merlin configuration does not identify a build context")
+;;
+
+let query_merlin_context sandbox ~cwd ~source ~(layout : layout) ~contexts =
+  let open Promise.Syntax in
+  let* source, physical_build_dir =
+    Promise.all2 (realpath_or_original source, realpath_or_original layout.build_dir)
+  in
+  let build_dirs = [ layout.build_dir; physical_build_dir ] in
+  let request = Csexp.(to_string (List [ Atom "File"; Atom (Path.to_string source) ])) in
+  let command = Sandbox.get_command sandbox "dune" [ "ocaml-merlin" ] `Command in
+  let+ output = Cmd.output command ~cwd ~stdin:request in
+  Result.bind output ~f:(merlin_context_of_output ~build_dirs ~contexts)
+;;
+
+let select_context
+      sandbox
+      (environment : Environment.t)
+      ~cwd
+      ~source
+      ~layout
+      ~fallback
+      contexts
+  =
+  match environment.cross_target, contexts with
+  | Some _, _ | None, ([] | [ _ ]) -> Promise.return fallback
+  | None, _ :: _ :: _ ->
+    let open Promise.Syntax in
+    let+ merlin_context = query_merlin_context sandbox ~cwd ~source ~layout ~contexts in
+    (match merlin_context with
+     | Ok context -> context
+     | Error _ -> fallback)
+;;
+
+let discover sandbox ~cwd ~source =
+  let key = cache_key sandbox ~cwd in
+  match List.Assoc.find !cache key ~equal:cache_key_equal with
+  | Some workspace -> Promise.return workspace
+  | None ->
+    let open Promise.Syntax in
+    let* environment = Environment.selected_sandbox sandbox ~cwd in
+    let* environment = environment_for_dune sandbox environment ~cwd in
+    let* root = root_of_environment environment ~cwd in
+    let fallback_layout = layout_of_environment environment ~root in
+    let* has_workspace_file = Fs.exists Path.(root / "dune-workspace" |> to_string) in
+    let authoritative_workspace =
+      match sandbox with
+      | Sandbox.Opam _ | Custom _ -> true
+      | Global | Esy _ | Dune _ -> false
+    in
+    let needs_contexts =
+      authoritative_workspace
+      || Option.is_some environment.workspace
+      || has_workspace_file
+    in
+    let* contexts_result =
+      if needs_contexts then query_contexts sandbox ~cwd else Promise.return (Ok [])
+    in
+    let contexts =
+      match contexts_result with
+      | Ok contexts -> contexts
+      | Error error ->
+        log_chan
+          `Warn
+          ~section:"Dune workspace"
+          "Unable to run `dune describe contexts`; using Dune's default context: %s"
+          error;
+        []
+    in
+    let preferred_context = fallback_context environment contexts in
+    let* layout =
+      if authoritative_workspace
+      then query_layout sandbox ~cwd ~context:preferred_context ~fallback:fallback_layout
+      else Promise.return fallback_layout
+    in
+    let* context =
+      select_context
+        sandbox
+        environment
+        ~cwd
+        ~source
+        ~layout
+        ~fallback:preferred_context
+        contexts
+    in
+    let workspace = make layout ~context in
+    cache := (key, workspace) :: !cache;
+    Promise.return workspace
+;;

--- a/src/dune_workspace.ml
+++ b/src/dune_workspace.ml
@@ -55,8 +55,7 @@ module Environment = struct
     | Sandbox.Esy (esy, manifest) ->
       let open Promise.Syntax in
       let+ output =
-        Esy.exec esy manifest ~args:[ "command-env"; "--json" ]
-        |> Cmd.output ~cwd ~log_output:false
+        Esy.exec esy manifest ~args:[ "command-env"; "--json" ] |> Cmd.output ~cwd
       in
       (match output with
        | Error error ->
@@ -269,7 +268,7 @@ let sandbox_environment_is_opaque = function
 ;;
 
 let dune_output sandbox ~cwd args =
-  Sandbox.get_command sandbox "dune" args `Command |> Cmd.output ~cwd ~log_output:false
+  Sandbox.get_command sandbox "dune" args `Command |> Cmd.output ~cwd
 ;;
 
 let contexts_of_output output =
@@ -367,7 +366,7 @@ let query_merlin_context sandbox ~cwd ~source ~(layout : layout) ~contexts =
   let build_dirs = [ layout.build_dir; physical_build_dir ] in
   let request = Csexp.(to_string (List [ Atom "File"; Atom (Path.to_string source) ])) in
   let command = Sandbox.get_command sandbox "dune" [ "ocaml-merlin" ] `Command in
-  let+ output = Cmd.output command ~cwd ~stdin:request ~log_output:false in
+  let+ output = Cmd.output command ~cwd ~stdin:request in
   Result.bind output ~f:(merlin_context_of_output ~build_dirs ~contexts)
 ;;
 

--- a/src/dune_workspace.mli
+++ b/src/dune_workspace.mli
@@ -1,0 +1,20 @@
+(** The paths selected by Dune for a workspace and build context. *)
+type t
+
+val root : t -> Path.t
+val build_context : t -> Path.t
+
+(** Resolve Dune's effective workspace paths in the selected sandbox.
+
+    This gives [DUNE_BUILD_DIR], [DUNE_ROOT], [DUNE_WORKSPACE], and
+    [DUNE_CROSS_TARGET] priority when the selected Dune supports them. It asks
+    Dune for workspace-specific paths and uses Dune's Merlin protocol to select
+    the editor context when needed. Other Dune variables, including its XDG and
+    cache variables, do not change the location of preprocessed build artifacts.
+    If Dune is busy, this falls back to the environment and Dune's default
+    layout. *)
+val discover : Sandbox.t -> cwd:Path.t -> source:Path.t -> t Promise.t
+
+(** Clear the cached discovery results, for example before retrying after a
+    rebuild or sandbox change. *)
+val invalidate : unit -> unit

--- a/src/path.ml
+++ b/src/path.ml
@@ -16,7 +16,17 @@ let basename = Node.Path.basename
 let join x y = Node.Path.join [ x; y ]
 let ( / ) = join
 let relative = join
+let relative_from = Node.Path.relative
 let relative_all p xs = List.fold_left xs ~f:join ~init:p
+
+let is_inside ~dir path =
+  let relative = relative_from dir path in
+  not
+    (is_absolute (of_string relative)
+     || String.equal relative ".."
+     || String.is_prefix relative ~prefix:(".." ^ String.of_char sep))
+;;
+
 let with_ext x ~ext = x ^ ext
 
 let is_root = function

--- a/src/path.mli
+++ b/src/path.mli
@@ -20,6 +20,15 @@ val basename : t -> string
 val join : t -> t -> t
 val ( / ) : t -> string -> t
 val relative : t -> string -> t
+
+(** [relative_from base path] is the relative path from [base] to [path]
+    (unlike {!relative}, which appends a segment). *)
+val relative_from : t -> t -> string
+
+(** [is_inside ~dir path] is whether [path] stays within [dir], i.e. the
+    relative path from [dir] to [path] does not escape [dir]. *)
+val is_inside : dir:t -> t -> bool
+
 val relative_all : t -> string list -> t
 val with_ext : t -> ext:string -> t
 val parent : t -> t option

--- a/src/ppx_tools/ppx_tools.ml
+++ b/src/ppx_tools/ppx_tools.ml
@@ -8,14 +8,16 @@ let get_preprocessed_ast path =
   | Error e -> Error e
 ;;
 
+let reparsed_code_of_ast source =
+  match Ppxlib.Ast_io.get_ast source with
+  | Impl structure ->
+    let structure = Ppxlib_ast.Selected_ast.To_ocaml.copy_structure structure in
+    Stdlib.Format.asprintf "%a" Pprintast.structure structure
+  | Intf signature ->
+    let signature = Ppxlib_ast.Selected_ast.To_ocaml.copy_signature signature in
+    Stdlib.Format.asprintf "%a" Pprintast.signature signature
+;;
+
 let get_reparsed_code_from_pp_file ~path =
-  get_preprocessed_ast path
-  |> Result.map ~f:(fun source ->
-    match Ppxlib.Ast_io.get_ast source with
-    | Impl structure ->
-      let structure = Ppxlib_ast.Selected_ast.To_ocaml.copy_structure structure in
-      Stdlib.Format.asprintf "%a" Pprintast.structure structure
-    | Intf signature ->
-      let signature = Ppxlib_ast.Selected_ast.To_ocaml.copy_signature signature in
-      Stdlib.Format.asprintf "%a" Pprintast.signature signature)
+  get_preprocessed_ast path |> Result.map ~f:reparsed_code_of_ast
 ;;

--- a/src/ppx_tools/ppx_tools.mli
+++ b/src/ppx_tools/ppx_tools.mli
@@ -1,4 +1,5 @@
 module Dumpast : module type of Dumpast
 
+val reparsed_code_of_ast : Ppxlib.Ast_io.t -> string
 val get_reparsed_code_from_pp_file : path:string -> (string, string) result
 val get_preprocessed_ast : string -> (Ppxlib.Ast_io.t, string) result

--- a/tests/suite/basic/preprocessedDocument.test.js
+++ b/tests/suite/basic/preprocessedDocument.test.js
@@ -10,11 +10,27 @@ const vscode = require("vscode");
 const root = path.resolve(__dirname, "../../../");
 
 const duneEnvVars = ["DUNE_BUILD_DIR", "DUNE_ROOT", "DUNE_WORKSPACE", "DUNE_CROSS_TARGET"];
+const duneShimEnvVars = [
+  "OCAML_PLATFORM_TEST_DUNE_PATH",
+  "OCAML_PLATFORM_TEST_DUNE_BUILD_DIR",
+  "OCAML_PLATFORM_TEST_DUNE_FAIL_CONTEXTS",
+];
 const execFilePromise = promisify(execFile);
 // Resolved eagerly at load time, before extension activation can start a dune
 // build that locks the repository's build directory. When the resolution
 // fails, runDune falls back to the inherited PATH (as in opam environments).
 const compilerBinPromise = findCompilerBin().catch(() => undefined);
+
+function saveEnvironment(names) {
+  return Object.fromEntries(names.map((name) => [name, process.env[name]]));
+}
+
+function restoreEnvironment(saved) {
+  for (const [name, value] of Object.entries(saved)) {
+    if (value === undefined) delete process.env[name];
+    else process.env[name] = value;
+  }
+}
 
 async function activateExtension() {
   const extension = vscode.extensions.getExtension("ocamllabs.ocaml-platform");
@@ -56,7 +72,53 @@ async function runDune(cwd, args) {
   await execFilePromise("dune", args, { cwd, env });
 }
 
-async function showPreprocessedDocument(source, marker) {
+async function createDuneBuildDirShim(buildDir) {
+  const compilerBin = await compilerBinPromise;
+  if (process.platform === "win32" || compilerBin === undefined) return undefined;
+
+  const inheritedPath = process.env.PATH ?? "";
+  const toolPath = `${compilerBin}${path.delimiter}${inheritedPath}`;
+  const shimDir = await fs.mkdtemp(path.join(os.tmpdir(), "ocaml-platform-dune-shim-"));
+  const shim = path.join(shimDir, "dune");
+  const source = `#!/usr/bin/env node
+const { spawnSync } = require("node:child_process");
+
+const environment = {
+  ...process.env,
+  PATH: process.env.OCAML_PLATFORM_TEST_DUNE_PATH,
+  DUNE_BUILD_DIR: process.env.OCAML_PLATFORM_TEST_DUNE_BUILD_DIR,
+};
+delete environment.OCAML_PLATFORM_TEST_DUNE_PATH;
+delete environment.OCAML_PLATFORM_TEST_DUNE_BUILD_DIR;
+delete environment.OCAML_PLATFORM_TEST_DUNE_FAIL_CONTEXTS;
+
+if (
+  process.env.OCAML_PLATFORM_TEST_DUNE_FAIL_CONTEXTS === "1" &&
+  process.argv[2] === "describe" &&
+  process.argv[3] === "contexts"
+) {
+  process.exit(1);
+}
+
+const result = spawnSync("dune", process.argv.slice(2), {
+  env: environment,
+  stdio: "inherit",
+});
+if (result.error !== undefined) {
+  console.error(result.error.message);
+  process.exit(1);
+}
+process.exit(result.status ?? 1);
+`;
+  await fs.writeFile(shim, source, { mode: 0o755 });
+  await fs.chmod(shim, 0o755);
+  process.env.OCAML_PLATFORM_TEST_DUNE_PATH = toolPath;
+  process.env.OCAML_PLATFORM_TEST_DUNE_BUILD_DIR = buildDir;
+  process.env.PATH = `${shimDir}${path.delimiter}${toolPath}`;
+  return shimDir;
+}
+
+async function showPreprocessedDocument(source) {
   const document = await vscode.workspace.openTextDocument(vscode.Uri.file(source));
   const preprocessedUri = vscode.Uri.parse(`post-ppx: ${source}?`).toString();
   await vscode.window.showTextDocument(document);
@@ -64,8 +126,7 @@ async function showPreprocessedDocument(source, marker) {
 
   for (let attempt = 0; attempt < 300; attempt++) {
     const document = vscode.workspace.textDocuments.find(
-      (candidate) =>
-        candidate.uri.toString() === preprocessedUri && candidate.getText().includes(marker),
+      (candidate) => candidate.uri.toString() === preprocessedUri && candidate.getText().length > 0,
     );
     if (document !== undefined) return document;
     await setTimeout(100);
@@ -78,17 +139,14 @@ suite("preprocessed document", () => {
   let cleanupDirs;
 
   setup(async () => {
-    savedDuneEnv = Object.fromEntries(duneEnvVars.map((name) => [name, process.env[name]]));
+    savedDuneEnv = saveEnvironment(duneEnvVars);
     for (const name of duneEnvVars) delete process.env[name];
     cleanupDirs = [];
     await activateExtension();
   });
 
   teardown(async () => {
-    for (const name of duneEnvVars) {
-      if (savedDuneEnv[name] === undefined) delete process.env[name];
-      else process.env[name] = savedDuneEnv[name];
-    }
+    restoreEnvironment(savedDuneEnv);
     await vscode.commands.executeCommand("workbench.action.closeAllEditors");
     await Promise.all(cleanupDirs.map((dir) => fs.rm(dir, { recursive: true, force: true })));
   });
@@ -97,8 +155,50 @@ suite("preprocessed document", () => {
     this.timeout(60_000);
 
     const source = path.join(root, "src", "path.ml");
-    const preprocessed = await showPreprocessedDocument(source, "let relative_from");
+    const preprocessed = await showPreprocessedDocument(source);
     assert.match(preprocessed.getText(), /let relative_from/);
+  });
+
+  test("uses the build directory reported by Dune when contexts are unavailable", async function () {
+    this.timeout(60_000);
+
+    const project = await fs.mkdtemp(path.join(os.tmpdir(), "ocaml-platform-described-layout-"));
+    cleanupDirs.push(project);
+    const reportedBuildDir = await fs.mkdtemp(
+      path.join(os.tmpdir(), "ocaml-platform-reported-build-"),
+    );
+    cleanupDirs.push(reportedBuildDir);
+    const source = path.join(project, "reported_layout.ml");
+    const expectedSource = path.join(root, "_build", "default", "src", "ast_editor.pp.ml");
+    const decoySource = path.join(root, "_build", "default", "src", "path.pp.ml");
+    const expectedPreprocessed = path.join(reportedBuildDir, "default", "reported_layout.pp.ml");
+    const fallbackPreprocessed = path.join(project, "_build", "default", "reported_layout.pp.ml");
+
+    await Promise.all([
+      fs.writeFile(path.join(project, "dune-project"), "(lang dune 3.20)\n"),
+      fs.writeFile(path.join(project, "dune-workspace"), "(lang dune 3.20)\n"),
+      fs.writeFile(source, "let reported_layout = ()\n"),
+      fs.mkdir(path.dirname(expectedPreprocessed), { recursive: true }),
+      fs.mkdir(path.dirname(fallbackPreprocessed), { recursive: true }),
+    ]);
+    await Promise.all([
+      fs.copyFile(expectedSource, expectedPreprocessed),
+      fs.copyFile(decoySource, fallbackPreprocessed),
+    ]);
+
+    const savedShimEnv = saveEnvironment(["PATH", ...duneShimEnvVars]);
+    try {
+      process.env.OCAML_PLATFORM_TEST_DUNE_FAIL_CONTEXTS = "1";
+      const shimDir = await createDuneBuildDirShim(reportedBuildDir);
+      if (shimDir === undefined) this.skip();
+      cleanupDirs.push(shimDir);
+
+      const preprocessed = await showPreprocessedDocument(source);
+      assert.match(preprocessed.getText(), /let get_nonce/);
+      assert.doesNotMatch(preprocessed.getText(), /let relative_from/);
+    } finally {
+      restoreEnvironment(savedShimEnv);
+    }
   });
 
   test("uses a named context declared by dune-workspace", async function () {
@@ -126,7 +226,7 @@ suite("preprocessed document", () => {
     ]);
     await fs.copyFile(builtPreprocessedSource, namedPreprocessedSource);
 
-    const preprocessed = await showPreprocessedDocument(source, "let relative_from");
+    const preprocessed = await showPreprocessedDocument(source);
     assert.match(preprocessed.getText(), /let relative_from/);
   });
 
@@ -157,7 +257,7 @@ suite("preprocessed document", () => {
     await runDune(project, ["build", `@_build/${context}/check`]);
     await fs.copyFile(distinctPreprocessed, contextPreprocessed);
 
-    const preprocessed = await showPreprocessedDocument(source, "let get_nonce");
+    const preprocessed = await showPreprocessedDocument(source);
     assert.match(preprocessed.getText(), /let get_nonce/);
   });
 
@@ -185,7 +285,7 @@ suite("preprocessed document", () => {
     ]);
     await fs.copyFile(builtPreprocessedSource, namedPreprocessedSource);
 
-    const preprocessed = await showPreprocessedDocument(source, "let get_nonce");
+    const preprocessed = await showPreprocessedDocument(source);
     assert.match(preprocessed.getText(), /let get_nonce/);
   });
 
@@ -216,7 +316,7 @@ suite("preprocessed document", () => {
     process.env.DUNE_BUILD_DIR = customBuildDir;
     process.env.DUNE_ROOT = nested;
 
-    const preprocessed = await showPreprocessedDocument(source, "let get_nonce");
+    const preprocessed = await showPreprocessedDocument(source);
     assert.match(preprocessed.getText(), /let get_nonce/);
   });
 
@@ -243,7 +343,7 @@ suite("preprocessed document", () => {
     process.env.DUNE_ROOT = root;
     process.env.DUNE_CROSS_TARGET = "extension_test";
 
-    const preprocessed = await showPreprocessedDocument(source, "let get_nonce");
+    const preprocessed = await showPreprocessedDocument(source);
     assert.match(preprocessed.getText(), /let get_nonce/);
   });
 });

--- a/tests/suite/basic/preprocessedDocument.test.js
+++ b/tests/suite/basic/preprocessedDocument.test.js
@@ -1,0 +1,249 @@
+const assert = require("node:assert/strict");
+const { execFile } = require("node:child_process");
+const fs = require("node:fs/promises");
+const os = require("node:os");
+const path = require("node:path");
+const { setTimeout } = require("node:timers/promises");
+const { promisify } = require("node:util");
+const vscode = require("vscode");
+
+const root = path.resolve(__dirname, "../../../");
+
+const duneEnvVars = ["DUNE_BUILD_DIR", "DUNE_ROOT", "DUNE_WORKSPACE", "DUNE_CROSS_TARGET"];
+const execFilePromise = promisify(execFile);
+// Resolved eagerly at load time, before extension activation can start a dune
+// build that locks the repository's build directory. When the resolution
+// fails, runDune falls back to the inherited PATH (as in opam environments).
+const compilerBinPromise = findCompilerBin().catch(() => undefined);
+
+async function activateExtension() {
+  const extension = vscode.extensions.getExtension("ocamllabs.ocaml-platform");
+  assert.notStrictEqual(extension, undefined, "The OCaml Platform extension must be installed");
+  await extension.activate();
+}
+
+async function duneVersionAtLeast(major, minor) {
+  const version = await new Promise((resolve) => {
+    execFile("dune", ["--version"], (error, stdout) => resolve(error ? undefined : stdout.trim()));
+  });
+  if (version === undefined) return false;
+  const release = version.match(/^(\d+)\.(\d+)/);
+  // Nightly builds report a description instead of a release number and
+  // support everything the extension version-gates on.
+  if (release === null) return true;
+  const [, currentMajor, currentMinor] = release.map(Number);
+  return currentMajor > major || (currentMajor === major && currentMinor >= minor);
+}
+
+async function findCompilerBin() {
+  const toolEnv = { ...process.env };
+  for (const name of duneEnvVars) delete toolEnv[name];
+  delete toolEnv.DUNE_RPC;
+  delete toolEnv.INSIDE_DUNE;
+  const { stdout } = await execFilePromise("dune", ["exec", "--", "ocamlc", "-where"], {
+    cwd: root,
+    env: toolEnv,
+  });
+  return path.resolve(stdout.trim(), "..", "..", "bin");
+}
+
+async function runDune(cwd, args) {
+  const env = { ...process.env };
+  delete env.DUNE_RPC;
+  delete env.INSIDE_DUNE;
+  const compilerBin = await compilerBinPromise;
+  if (compilerBin !== undefined) env.PATH = `${compilerBin}${path.delimiter}${env.PATH ?? ""}`;
+  await execFilePromise("dune", args, { cwd, env });
+}
+
+async function showPreprocessedDocument(source, marker) {
+  const document = await vscode.workspace.openTextDocument(vscode.Uri.file(source));
+  const preprocessedUri = vscode.Uri.parse(`post-ppx: ${source}?`).toString();
+  await vscode.window.showTextDocument(document);
+  await vscode.commands.executeCommand("ocaml.show-preprocessed-document");
+
+  for (let attempt = 0; attempt < 300; attempt++) {
+    const document = vscode.workspace.textDocuments.find(
+      (candidate) =>
+        candidate.uri.toString() === preprocessedUri && candidate.getText().includes(marker),
+    );
+    if (document !== undefined) return document;
+    await setTimeout(100);
+  }
+  assert.fail("Timed out waiting for the preprocessed document");
+}
+
+suite("preprocessed document", () => {
+  let savedDuneEnv;
+  let cleanupDirs;
+
+  setup(async () => {
+    savedDuneEnv = Object.fromEntries(duneEnvVars.map((name) => [name, process.env[name]]));
+    for (const name of duneEnvVars) delete process.env[name];
+    cleanupDirs = [];
+    await activateExtension();
+  });
+
+  teardown(async () => {
+    for (const name of duneEnvVars) {
+      if (savedDuneEnv[name] === undefined) delete process.env[name];
+      else process.env[name] = savedDuneEnv[name];
+    }
+    await vscode.commands.executeCommand("workbench.action.closeAllEditors");
+    await Promise.all(cleanupDirs.map((dir) => fs.rm(dir, { recursive: true, force: true })));
+  });
+
+  test("uses Dune's default build context", async function () {
+    this.timeout(60_000);
+
+    const source = path.join(root, "src", "path.ml");
+    const preprocessed = await showPreprocessedDocument(source, "let relative_from");
+    assert.match(preprocessed.getText(), /let relative_from/);
+  });
+
+  test("uses a named context declared by dune-workspace", async function () {
+    this.timeout(60_000);
+
+    const project = await fs.mkdtemp(path.join(os.tmpdir(), "ocaml-platform-workspace-"));
+    cleanupDirs.push(project);
+    const source = path.join(project, "named_context.ml");
+    const builtPreprocessedSource = path.join(root, "_build", "default", "src", "path.pp.ml");
+    const namedPreprocessedSource = path.join(
+      project,
+      "_build",
+      "editor_test",
+      "named_context.pp.ml",
+    );
+
+    await Promise.all([
+      fs.writeFile(path.join(project, "dune-project"), "(lang dune 3.0)\n"),
+      fs.writeFile(
+        path.join(project, "dune-workspace"),
+        "(lang dune 3.0)\n(context (default (name editor_test)))\n",
+      ),
+      fs.writeFile(source, "let named_context = ()\n"),
+      fs.mkdir(path.dirname(namedPreprocessedSource), { recursive: true }),
+    ]);
+    await fs.copyFile(builtPreprocessedSource, namedPreprocessedSource);
+
+    const preprocessed = await showPreprocessedDocument(source, "let relative_from");
+    assert.match(preprocessed.getText(), /let relative_from/);
+  });
+
+  test("uses the context selected for Merlin", async function () {
+    this.timeout(180_000);
+    if (!(await duneVersionAtLeast(3, 20))) this.skip();
+
+    const project = await fs.mkdtemp(path.join(os.tmpdir(), "ocaml-platform-merlin-"));
+    cleanupDirs.push(project);
+    const context = "editor_test";
+    const workspace = path.join(project, "dune-workspace");
+    const source = path.join(project, "editor_context.ml");
+    // The Merlin-selected context holds a different module's artifact, so
+    // falling back to the default context cannot produce the expected marker.
+    const distinctPreprocessed = path.join(root, "_build", "default", "src", "ast_editor.pp.ml");
+    const contextPreprocessed = path.join(project, "_build", context, "editor_context.pp.ml");
+
+    process.env.DUNE_WORKSPACE = workspace;
+    await Promise.all([
+      fs.writeFile(path.join(project, "dune-project"), "(lang dune 3.20)\n"),
+      fs.writeFile(path.join(project, "dune"), "(library (name editor_context))\n"),
+      fs.writeFile(source, "let editor_context = ()\n"),
+      fs.writeFile(
+        workspace,
+        `(lang dune 3.20)\n(context (default (name default)))\n(context (default (name ${context}) (merlin)))\n`,
+      ),
+    ]);
+    await runDune(project, ["build", `@_build/${context}/check`]);
+    await fs.copyFile(distinctPreprocessed, contextPreprocessed);
+
+    const preprocessed = await showPreprocessedDocument(source, "let get_nonce");
+    assert.match(preprocessed.getText(), /let get_nonce/);
+  });
+
+  test("honours DUNE_WORKSPACE with a named context", async function () {
+    this.timeout(60_000);
+
+    const project = await fs.mkdtemp(path.join(os.tmpdir(), "ocaml-platform-workspace-env-"));
+    cleanupDirs.push(project);
+    const workspace = path.join(project, "dune-workspace.editor-test");
+    const source = path.join(project, "env_context.ml");
+    const builtPreprocessedSource = path.join(root, "_build", "default", "src", "ast_editor.pp.ml");
+    const namedPreprocessedSource = path.join(
+      project,
+      "_build",
+      "env_context",
+      "env_context.pp.ml",
+    );
+
+    process.env.DUNE_WORKSPACE = workspace;
+    await Promise.all([
+      fs.writeFile(path.join(project, "dune-project"), "(lang dune 3.0)\n"),
+      fs.writeFile(workspace, "(lang dune 3.0)\n(context (default (name env_context)))\n"),
+      fs.writeFile(source, "let env_context = ()\n"),
+      fs.mkdir(path.dirname(namedPreprocessedSource), { recursive: true }),
+    ]);
+    await fs.copyFile(builtPreprocessedSource, namedPreprocessedSource);
+
+    const preprocessed = await showPreprocessedDocument(source, "let get_nonce");
+    assert.match(preprocessed.getText(), /let get_nonce/);
+  });
+
+  test("honours DUNE_ROOT and an absolute DUNE_BUILD_DIR", async function () {
+    this.timeout(60_000);
+    if (!(await duneVersionAtLeast(3, 21))) this.skip();
+
+    // Both directories carry a dune-project, so automatic root discovery
+    // picks the outer one; only honouring DUNE_ROOT (the inner one) and the
+    // custom build directory leads to the artifact placed below.
+    const project = await fs.mkdtemp(path.join(os.tmpdir(), "ocaml-platform-root-"));
+    cleanupDirs.push(project);
+    const customBuildDir = await fs.mkdtemp(path.join(os.tmpdir(), "ocaml-platform-build-"));
+    cleanupDirs.push(customBuildDir);
+    const nested = path.join(project, "nested");
+    const source = path.join(nested, "env_root.ml");
+    const builtPreprocessedSource = path.join(root, "_build", "default", "src", "ast_editor.pp.ml");
+    const customPreprocessedSource = path.join(customBuildDir, "default", "env_root.pp.ml");
+
+    await fs.mkdir(nested, { recursive: true });
+    await Promise.all([
+      fs.writeFile(path.join(project, "dune-project"), "(lang dune 3.0)\n"),
+      fs.writeFile(path.join(nested, "dune-project"), "(lang dune 3.0)\n"),
+      fs.writeFile(source, "let env_root = ()\n"),
+      fs.mkdir(path.dirname(customPreprocessedSource), { recursive: true }),
+    ]);
+    await fs.copyFile(builtPreprocessedSource, customPreprocessedSource);
+    process.env.DUNE_BUILD_DIR = customBuildDir;
+    process.env.DUNE_ROOT = nested;
+
+    const preprocessed = await showPreprocessedDocument(source, "let get_nonce");
+    assert.match(preprocessed.getText(), /let get_nonce/);
+  });
+
+  test("resolves a relative DUNE_BUILD_DIR and DUNE_CROSS_TARGET", async function () {
+    this.timeout(60_000);
+    if (!(await duneVersionAtLeast(3, 22))) this.skip();
+
+    const source = path.join(root, "src", "dune_workspace.ml");
+    // The cross-target context holds a different module's artifact, so
+    // falling back to the default context cannot produce the expected marker.
+    const builtPreprocessedSource = path.join(root, "_build", "default", "src", "ast_editor.pp.ml");
+    const customBuildDir = await fs.mkdtemp(path.join(root, ".ocaml-platform-build-"));
+    cleanupDirs.push(customBuildDir);
+    const customPreprocessedSource = path.join(
+      customBuildDir,
+      "default.extension_test",
+      "src",
+      "dune_workspace.pp.ml",
+    );
+
+    await fs.mkdir(path.dirname(customPreprocessedSource), { recursive: true });
+    await fs.copyFile(builtPreprocessedSource, customPreprocessedSource);
+    process.env.DUNE_BUILD_DIR = path.basename(customBuildDir);
+    process.env.DUNE_ROOT = root;
+    process.env.DUNE_CROSS_TARGET = "extension_test";
+
+    const preprocessed = await showPreprocessedDocument(source, "let get_nonce");
+    assert.match(preprocessed.getText(), /let get_nonce/);
+  });
+});

--- a/vscode-ocaml-platform.opam
+++ b/vscode-ocaml-platform.opam
@@ -22,6 +22,7 @@ depends: [
   "js_of_ocaml" {>= "6.4"}
   "gen_js_api" {= "1.1.7"}
   "base" {>= "v0.17"}
+  "csexp" {>= "1.5.0"}
   "promise_jsoo" {>= "0.4.3"}
   "jsonoo" {>= "0.3"}
   "ocaml-version" {>= "4.0"}


### PR DESCRIPTION
## Summary

- resolve preprocessed artefacts from Dune's effective workspace and build context
- honour `DUNE_BUILD_DIR`, `DUNE_ROOT`, `DUNE_WORKSPACE`, and `DUNE_CROSS_TARGET`, including values supplied by an esy command environment
- use Dune's workspace descriptions and Merlin protocol to select named editor contexts
- preserve safe AST updates while workspace discovery runs asynchronously
- add integration coverage for default, named, Merlin-selected, custom-root, custom-build-directory, and cross-target layouts

## Background

Show Preprocessed Document previously assumed that every artefact lived under `_build/default`. This fails when Dune or a sandbox selects another workspace root, build directory, or build context.

The extension now follows the paths and context selected by Dune, while retaining a conservative fallback when Dune cannot answer a workspace query.

## User impact

Preprocessed documents and the AST explorer now work with custom Dune build directories, named contexts, cross-compilation contexts, symlinked workspaces, and esy-managed build directories.

## Validation

- `dune build --auto-promote @fmt` (runs `ocamlformat` 0.28.1)
- `dune build @fmt @runtest @install src/vscode_ocaml_platform.bc.js`
- `make build`
- `bun run lint`
- the main VS Code integration suite passes all 8 tests
- the separate upstream E2E activation assertion passes; its LSP hover assertion times out in this local environment because no hover response becomes available

Fixes #728
