### PR TITLE
Use extension URIs for tree view icons

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- Fix custom tree view icons not appearing in Remote WSL by resolving bundled
+  assets as extension URIs. (#945)
 - Expose the `ocaml.server.inlayHints.*` and
   `ocaml.server.shortenMerlinDiagnostics` settings. (#2227)
 - Add syntax highlighting for Dune's parameterised library keywords: the

--- a/src/extension_assets.ml
+++ b/src/extension_assets.ml
@@ -8,3 +8,35 @@ let light_dark_icon ~extension ~light ~dark =
   LightDarkIcon.
     { light = `Uri (uri ~extension ~name:light); dark = `Uri (uri ~extension ~name:dark) }
 ;;
+
+let chat_icon ~extension =
+  light_dark_icon ~extension ~light:"chat-light.svg" ~dark:"chat-dark.svg"
+;;
+
+let collection_icon ~extension =
+  light_dark_icon ~extension ~light:"collection-light.svg" ~dark:"collection-dark.svg"
+;;
+
+let dependency_icon ~extension ~selected =
+  let suffix = if selected then "-selected" else "" in
+  light_dark_icon
+    ~extension
+    ~light:("dependency-light" ^ suffix ^ ".svg")
+    ~dark:("dependency-dark" ^ suffix ^ ".svg")
+;;
+
+let discord_icon ~extension =
+  light_dark_icon ~extension ~light:"discord-light.svg" ~dark:"discord-dark.svg"
+;;
+
+let github_icon ~extension =
+  light_dark_icon ~extension ~light:"github-light.svg" ~dark:"github-dark.svg"
+;;
+
+let package_icon ~extension =
+  light_dark_icon ~extension ~light:"number-light.svg" ~dark:"number-dark.svg"
+;;
+
+let terminal_icon ~extension =
+  light_dark_icon ~extension ~light:"terminal-light.svg" ~dark:"terminal-dark.svg"
+;;

--- a/src/extension_assets.ml
+++ b/src/extension_assets.ml
@@ -1,0 +1,10 @@
+open Import
+
+let uri ~extension ~name =
+  Uri.joinPath (ExtensionContext.extensionUri extension) ~pathSegments:[ "assets"; name ]
+;;
+
+let light_dark_icon ~extension ~light ~dark =
+  LightDarkIcon.
+    { light = `Uri (uri ~extension ~name:light); dark = `Uri (uri ~extension ~name:dark) }
+;;

--- a/src/extension_assets.ml
+++ b/src/extension_assets.ml
@@ -1,42 +1,57 @@
 open Import
 
-let uri ~extension ~name =
-  Uri.joinPath (ExtensionContext.extensionUri extension) ~pathSegments:[ "assets"; name ]
-;;
+type t =
+  { chat : LightDarkIcon.t
+  ; collection : LightDarkIcon.t
+  ; dependency : LightDarkIcon.t
+  ; dependency_selected : LightDarkIcon.t
+  ; discord : LightDarkIcon.t
+  ; github : LightDarkIcon.t
+  ; package : LightDarkIcon.t
+  ; terminal : LightDarkIcon.t
+  }
 
-let light_dark_icon ~extension ~light ~dark =
+let uri ~extension_uri ~name = Uri.joinPath extension_uri ~pathSegments:[ "assets"; name ]
+
+let light_dark_icon ~extension_uri ~light ~dark =
   LightDarkIcon.
-    { light = `Uri (uri ~extension ~name:light); dark = `Uri (uri ~extension ~name:dark) }
+    { light = `Uri (uri ~extension_uri ~name:light)
+    ; dark = `Uri (uri ~extension_uri ~name:dark)
+    }
 ;;
 
-let chat_icon ~extension =
-  light_dark_icon ~extension ~light:"chat-light.svg" ~dark:"chat-dark.svg"
-;;
-
-let collection_icon ~extension =
-  light_dark_icon ~extension ~light:"collection-light.svg" ~dark:"collection-dark.svg"
-;;
-
-let dependency_icon ~extension ~selected =
+let make_dependency_icon ~extension_uri ~selected =
   let suffix = if selected then "-selected" else "" in
   light_dark_icon
-    ~extension
+    ~extension_uri
     ~light:("dependency-light" ^ suffix ^ ".svg")
     ~dark:("dependency-dark" ^ suffix ^ ".svg")
 ;;
 
-let discord_icon ~extension =
-  light_dark_icon ~extension ~light:"discord-light.svg" ~dark:"discord-dark.svg"
+let make ~extension_uri =
+  { chat = light_dark_icon ~extension_uri ~light:"chat-light.svg" ~dark:"chat-dark.svg"
+  ; collection =
+      light_dark_icon
+        ~extension_uri
+        ~light:"collection-light.svg"
+        ~dark:"collection-dark.svg"
+  ; dependency = make_dependency_icon ~extension_uri ~selected:false
+  ; dependency_selected = make_dependency_icon ~extension_uri ~selected:true
+  ; discord =
+      light_dark_icon ~extension_uri ~light:"discord-light.svg" ~dark:"discord-dark.svg"
+  ; github =
+      light_dark_icon ~extension_uri ~light:"github-light.svg" ~dark:"github-dark.svg"
+  ; package =
+      light_dark_icon ~extension_uri ~light:"number-light.svg" ~dark:"number-dark.svg"
+  ; terminal =
+      light_dark_icon ~extension_uri ~light:"terminal-light.svg" ~dark:"terminal-dark.svg"
+  }
 ;;
 
-let github_icon ~extension =
-  light_dark_icon ~extension ~light:"github-light.svg" ~dark:"github-dark.svg"
-;;
-
-let package_icon ~extension =
-  light_dark_icon ~extension ~light:"number-light.svg" ~dark:"number-dark.svg"
-;;
-
-let terminal_icon ~extension =
-  light_dark_icon ~extension ~light:"terminal-light.svg" ~dark:"terminal-dark.svg"
-;;
+let chat_icon t = t.chat
+let collection_icon t = t.collection
+let dependency_icon t ~selected = if selected then t.dependency_selected else t.dependency
+let discord_icon t = t.discord
+let github_icon t = t.github
+let package_icon t = t.package
+let terminal_icon t = t.terminal

--- a/src/extension_assets.ml
+++ b/src/extension_assets.ml
@@ -11,40 +11,22 @@ type t =
   ; terminal : LightDarkIcon.t
   }
 
-let uri ~extension_uri ~name = Uri.joinPath extension_uri ~pathSegments:[ "assets"; name ]
-
-let light_dark_icon ~extension_uri ~light ~dark =
-  LightDarkIcon.
-    { light = `Uri (uri ~extension_uri ~name:light)
-    ; dark = `Uri (uri ~extension_uri ~name:dark)
-    }
-;;
-
-let make_dependency_icon ~extension_uri ~selected =
-  let suffix = if selected then "-selected" else "" in
-  light_dark_icon
-    ~extension_uri
-    ~light:("dependency-light" ^ suffix ^ ".svg")
-    ~dark:("dependency-dark" ^ suffix ^ ".svg")
-;;
-
 let make ~extension_uri =
-  { chat = light_dark_icon ~extension_uri ~light:"chat-light.svg" ~dark:"chat-dark.svg"
-  ; collection =
-      light_dark_icon
-        ~extension_uri
-        ~light:"collection-light.svg"
-        ~dark:"collection-dark.svg"
-  ; dependency = make_dependency_icon ~extension_uri ~selected:false
-  ; dependency_selected = make_dependency_icon ~extension_uri ~selected:true
-  ; discord =
-      light_dark_icon ~extension_uri ~light:"discord-light.svg" ~dark:"discord-dark.svg"
-  ; github =
-      light_dark_icon ~extension_uri ~light:"github-light.svg" ~dark:"github-dark.svg"
-  ; package =
-      light_dark_icon ~extension_uri ~light:"number-light.svg" ~dark:"number-dark.svg"
-  ; terminal =
-      light_dark_icon ~extension_uri ~light:"terminal-light.svg" ~dark:"terminal-dark.svg"
+  let uri name = Uri.joinPath extension_uri ~pathSegments:[ "assets"; name ] in
+  let icon ?(variant = "") stem =
+    LightDarkIcon.
+      { light = `Uri (uri (stem ^ "-light" ^ variant ^ ".svg"))
+      ; dark = `Uri (uri (stem ^ "-dark" ^ variant ^ ".svg"))
+      }
+  in
+  { chat = icon "chat"
+  ; collection = icon "collection"
+  ; dependency = icon "dependency"
+  ; dependency_selected = icon ~variant:"-selected" "dependency"
+  ; discord = icon "discord"
+  ; github = icon "github"
+  ; package = icon "number"
+  ; terminal = icon "terminal"
   }
 ;;
 

--- a/src/extension_assets.mli
+++ b/src/extension_assets.mli
@@ -1,9 +1,12 @@
-(** Resolve assets bundled with the extension as VS Code URIs. *)
+val chat_icon : extension:Vscode.ExtensionContext.t -> Vscode.LightDarkIcon.t
+val collection_icon : extension:Vscode.ExtensionContext.t -> Vscode.LightDarkIcon.t
 
-val uri : extension:Vscode.ExtensionContext.t -> name:string -> Vscode.Uri.t
-
-val light_dark_icon
+val dependency_icon
   :  extension:Vscode.ExtensionContext.t
-  -> light:string
-  -> dark:string
+  -> selected:bool
   -> Vscode.LightDarkIcon.t
+
+val discord_icon : extension:Vscode.ExtensionContext.t -> Vscode.LightDarkIcon.t
+val github_icon : extension:Vscode.ExtensionContext.t -> Vscode.LightDarkIcon.t
+val package_icon : extension:Vscode.ExtensionContext.t -> Vscode.LightDarkIcon.t
+val terminal_icon : extension:Vscode.ExtensionContext.t -> Vscode.LightDarkIcon.t

--- a/src/extension_assets.mli
+++ b/src/extension_assets.mli
@@ -1,12 +1,10 @@
-val chat_icon : extension:Vscode.ExtensionContext.t -> Vscode.LightDarkIcon.t
-val collection_icon : extension:Vscode.ExtensionContext.t -> Vscode.LightDarkIcon.t
+type t
 
-val dependency_icon
-  :  extension:Vscode.ExtensionContext.t
-  -> selected:bool
-  -> Vscode.LightDarkIcon.t
-
-val discord_icon : extension:Vscode.ExtensionContext.t -> Vscode.LightDarkIcon.t
-val github_icon : extension:Vscode.ExtensionContext.t -> Vscode.LightDarkIcon.t
-val package_icon : extension:Vscode.ExtensionContext.t -> Vscode.LightDarkIcon.t
-val terminal_icon : extension:Vscode.ExtensionContext.t -> Vscode.LightDarkIcon.t
+val make : extension_uri:Vscode.Uri.t -> t
+val chat_icon : t -> Vscode.LightDarkIcon.t
+val collection_icon : t -> Vscode.LightDarkIcon.t
+val dependency_icon : t -> selected:bool -> Vscode.LightDarkIcon.t
+val discord_icon : t -> Vscode.LightDarkIcon.t
+val github_icon : t -> Vscode.LightDarkIcon.t
+val package_icon : t -> Vscode.LightDarkIcon.t
+val terminal_icon : t -> Vscode.LightDarkIcon.t

--- a/src/extension_assets.mli
+++ b/src/extension_assets.mli
@@ -1,0 +1,9 @@
+(** Resolve assets bundled with the extension as VS Code URIs. *)
+
+val uri : extension:Vscode.ExtensionContext.t -> name:string -> Vscode.Uri.t
+
+val light_dark_icon
+  :  extension:Vscode.ExtensionContext.t
+  -> light:string
+  -> dark:string
+  -> Vscode.LightDarkIcon.t

--- a/src/path.ml
+++ b/src/path.ml
@@ -25,4 +25,3 @@ let is_root = function
 ;;
 
 let parent x = if is_root x then None else Some (dirname x)
-let asset name = of_string (Node.__filename () ^ "/../../assets/" ^ name)

--- a/src/path.mli
+++ b/src/path.mli
@@ -24,4 +24,3 @@ val relative_all : t -> string list -> t
 val with_ext : t -> ext:string -> t
 val parent : t -> t option
 val is_root : t -> bool
-val asset : string -> t

--- a/src/treeview_commands.ml
+++ b/src/treeview_commands.ml
@@ -1,10 +1,10 @@
-let select_sandbox_item =
+let select_sandbox_item extension =
   let icon =
     `LightDark
-      Vscode.LightDarkIcon.
-        { light = `String (Path.asset "collection-light.svg" |> Path.to_string)
-        ; dark = `String (Path.asset "collection-dark.svg" |> Path.to_string)
-        }
+      (Extension_assets.light_dark_icon
+         ~extension
+         ~light:"collection-light.svg"
+         ~dark:"collection-dark.svg")
   in
   let label = `TreeItemLabel (Vscode.TreeItemLabel.create ~label:"Select a Sandbox" ()) in
   let item = Vscode.TreeItem.make_label ~label () in
@@ -16,13 +16,13 @@ let select_sandbox_item =
   item
 ;;
 
-let terminal_item =
+let terminal_item extension =
   let icon =
     `LightDark
-      Vscode.LightDarkIcon.
-        { light = `String (Path.asset "terminal-light.svg" |> Path.to_string)
-        ; dark = `String (Path.asset "terminal-dark.svg" |> Path.to_string)
-        }
+      (Extension_assets.light_dark_icon
+         ~extension
+         ~light:"terminal-light.svg"
+         ~dark:"terminal-dark.svg")
   in
   let label =
     `TreeItemLabel (Vscode.TreeItemLabel.create ~label:"Open a sandboxed terminal" ())
@@ -39,7 +39,7 @@ let terminal_item =
   item
 ;;
 
-let construct_item =
+let construct_item () =
   let icon = `ThemeIcon (Vscode.ThemeIcon.make ~id:"tools" ()) in
   let label =
     `TreeItemLabel
@@ -54,7 +54,7 @@ let construct_item =
   item
 ;;
 
-let jump_item =
+let jump_item () =
   let icon = `ThemeIcon (Vscode.ThemeIcon.make ~id:"fold-up" ()) in
   let label =
     `TreeItemLabel (Vscode.TreeItemLabel.create ~label:"Jump to a specific target" ())
@@ -66,7 +66,7 @@ let jump_item =
   item
 ;;
 
-let type_search_item =
+let type_search_item () =
   let icon = `ThemeIcon (Vscode.ThemeIcon.make ~id:"search-view-icon" ()) in
   let label =
     `TreeItemLabel
@@ -84,7 +84,7 @@ let type_search_item =
   item
 ;;
 
-let navigate_holes_item =
+let navigate_holes_item () =
   let icon = `ThemeIcon (Vscode.ThemeIcon.make ~id:"breakpoints-activate" ()) in
   let label =
     `TreeItemLabel (Vscode.TreeItemLabel.create ~label:"Navigate between typed holes" ())
@@ -101,25 +101,27 @@ let navigate_holes_item =
   item
 ;;
 
-let items =
-  [ select_sandbox_item
-  ; terminal_item
-  ; construct_item
-  ; jump_item
-  ; type_search_item
-  ; navigate_holes_item
+let items extension =
+  [ select_sandbox_item extension
+  ; terminal_item extension
+  ; construct_item ()
+  ; jump_item ()
+  ; type_search_item ()
+  ; navigate_holes_item ()
   ]
 ;;
 
 let getTreeItem ~element = `Value element
 
-let getChildren ?element () =
+let getChildren items ?element () =
   match element with
   | None -> `Value (Some items)
   | Some _ -> `Value (Some [])
 ;;
 
 let register extension =
+  let items = items extension in
+  let getChildren = getChildren items in
   let module TreeDataProvider = Vscode.TreeDataProvider.Make (Vscode.TreeItem) in
   let treeDataProvider = TreeDataProvider.create ~getTreeItem ~getChildren () in
   let disposable =

--- a/src/treeview_commands.ml
+++ b/src/treeview_commands.ml
@@ -1,11 +1,5 @@
 let select_sandbox_item extension =
-  let icon =
-    `LightDark
-      (Extension_assets.light_dark_icon
-         ~extension
-         ~light:"collection-light.svg"
-         ~dark:"collection-dark.svg")
-  in
+  let icon = `LightDark (Extension_assets.collection_icon ~extension) in
   let label = `TreeItemLabel (Vscode.TreeItemLabel.create ~label:"Select a Sandbox" ()) in
   let item = Vscode.TreeItem.make_label ~label () in
   let command =
@@ -17,13 +11,7 @@ let select_sandbox_item extension =
 ;;
 
 let terminal_item extension =
-  let icon =
-    `LightDark
-      (Extension_assets.light_dark_icon
-         ~extension
-         ~light:"terminal-light.svg"
-         ~dark:"terminal-dark.svg")
-  in
+  let icon = `LightDark (Extension_assets.terminal_icon ~extension) in
   let label =
     `TreeItemLabel (Vscode.TreeItemLabel.create ~label:"Open a sandboxed terminal" ())
   in
@@ -39,7 +27,7 @@ let terminal_item extension =
   item
 ;;
 
-let construct_item () =
+let construct_item =
   let icon = `ThemeIcon (Vscode.ThemeIcon.make ~id:"tools" ()) in
   let label =
     `TreeItemLabel
@@ -54,7 +42,7 @@ let construct_item () =
   item
 ;;
 
-let jump_item () =
+let jump_item =
   let icon = `ThemeIcon (Vscode.ThemeIcon.make ~id:"fold-up" ()) in
   let label =
     `TreeItemLabel (Vscode.TreeItemLabel.create ~label:"Jump to a specific target" ())
@@ -66,7 +54,7 @@ let jump_item () =
   item
 ;;
 
-let type_search_item () =
+let type_search_item =
   let icon = `ThemeIcon (Vscode.ThemeIcon.make ~id:"search-view-icon" ()) in
   let label =
     `TreeItemLabel
@@ -84,7 +72,7 @@ let type_search_item () =
   item
 ;;
 
-let navigate_holes_item () =
+let navigate_holes_item =
   let icon = `ThemeIcon (Vscode.ThemeIcon.make ~id:"breakpoints-activate" ()) in
   let label =
     `TreeItemLabel (Vscode.TreeItemLabel.create ~label:"Navigate between typed holes" ())
@@ -104,10 +92,10 @@ let navigate_holes_item () =
 let items extension =
   [ select_sandbox_item extension
   ; terminal_item extension
-  ; construct_item ()
-  ; jump_item ()
-  ; type_search_item ()
-  ; navigate_holes_item ()
+  ; construct_item
+  ; jump_item
+  ; type_search_item
+  ; navigate_holes_item
   ]
 ;;
 

--- a/src/treeview_commands.ml
+++ b/src/treeview_commands.ml
@@ -1,5 +1,5 @@
-let select_sandbox_item extension =
-  let icon = `LightDark (Extension_assets.collection_icon ~extension) in
+let select_sandbox_item assets =
+  let icon = `LightDark (Extension_assets.collection_icon assets) in
   let label = `TreeItemLabel (Vscode.TreeItemLabel.create ~label:"Select a Sandbox" ()) in
   let item = Vscode.TreeItem.make_label ~label () in
   let command =
@@ -10,8 +10,8 @@ let select_sandbox_item extension =
   item
 ;;
 
-let terminal_item extension =
-  let icon = `LightDark (Extension_assets.terminal_icon ~extension) in
+let terminal_item assets =
+  let icon = `LightDark (Extension_assets.terminal_icon assets) in
   let label =
     `TreeItemLabel (Vscode.TreeItemLabel.create ~label:"Open a sandboxed terminal" ())
   in
@@ -89,9 +89,9 @@ let navigate_holes_item =
   item
 ;;
 
-let items extension =
-  [ select_sandbox_item extension
-  ; terminal_item extension
+let items assets =
+  [ select_sandbox_item assets
+  ; terminal_item assets
   ; construct_item
   ; jump_item
   ; type_search_item
@@ -107,8 +107,8 @@ let getChildren items ?element () =
   | Some _ -> `Value (Some [])
 ;;
 
-let register extension =
-  let items = items extension in
+let register extension ~assets =
+  let items = items assets in
   let getChildren = getChildren items in
   let module TreeDataProvider = Vscode.TreeDataProvider.Make (Vscode.TreeItem) in
   let treeDataProvider = TreeDataProvider.create ~getTreeItem ~getChildren () in

--- a/src/treeview_commands.mli
+++ b/src/treeview_commands.mli
@@ -1,2 +1,2 @@
 (** Register the ocaml-commands tree view. *)
-val register : Vscode.ExtensionContext.t -> unit
+val register : Vscode.ExtensionContext.t -> assets:Extension_assets.t -> unit

--- a/src/treeview_help.ml
+++ b/src/treeview_help.ml
@@ -1,11 +1,5 @@
 let discord_item extension =
-  let icon =
-    `LightDark
-      (Extension_assets.light_dark_icon
-         ~extension
-         ~light:"discord-light.svg"
-         ~dark:"discord-dark.svg")
-  in
+  let icon = `LightDark (Extension_assets.discord_icon ~extension) in
   let label = `TreeItemLabel (Vscode.TreeItemLabel.create ~label:"Chat on Discord" ()) in
   let item = Vscode.TreeItem.make_label ~label () in
   let command =
@@ -22,13 +16,7 @@ let discord_item extension =
 ;;
 
 let discuss_item extension =
-  let icon =
-    `LightDark
-      (Extension_assets.light_dark_icon
-         ~extension
-         ~light:"chat-light.svg"
-         ~dark:"chat-dark.svg")
-  in
+  let icon = `LightDark (Extension_assets.chat_icon ~extension) in
   let label =
     `TreeItemLabel (Vscode.TreeItemLabel.create ~label:"Ask a question on Discuss" ())
   in
@@ -46,7 +34,7 @@ let discuss_item extension =
   item
 ;;
 
-let tutorials_item () =
+let tutorials_item =
   let label =
     `TreeItemLabel
       (Vscode.TreeItemLabel.create ~label:"Explore OCaml exercises and tutorials" ())
@@ -67,13 +55,7 @@ let tutorials_item () =
 ;;
 
 let github_item extension =
-  let icon =
-    `LightDark
-      (Extension_assets.light_dark_icon
-         ~extension
-         ~light:"github-light.svg"
-         ~dark:"github-dark.svg")
-  in
+  let icon = `LightDark (Extension_assets.github_icon ~extension) in
   let label =
     `TreeItemLabel (Vscode.TreeItemLabel.create ~label:"Open an issue on Github" ())
   in
@@ -97,7 +79,7 @@ let items extension =
   [ discord_item extension
   ; discuss_item extension
   ; github_item extension
-  ; tutorials_item ()
+  ; tutorials_item
   ]
 ;;
 

--- a/src/treeview_help.ml
+++ b/src/treeview_help.ml
@@ -1,10 +1,10 @@
-let discord_item =
+let discord_item extension =
   let icon =
     `LightDark
-      Vscode.LightDarkIcon.
-        { light = `String (Path.asset "discord-light.svg" |> Path.to_string)
-        ; dark = `String (Path.asset "discord-dark.svg" |> Path.to_string)
-        }
+      (Extension_assets.light_dark_icon
+         ~extension
+         ~light:"discord-light.svg"
+         ~dark:"discord-dark.svg")
   in
   let label = `TreeItemLabel (Vscode.TreeItemLabel.create ~label:"Chat on Discord" ()) in
   let item = Vscode.TreeItem.make_label ~label () in
@@ -21,13 +21,13 @@ let discord_item =
   item
 ;;
 
-let discuss_item =
+let discuss_item extension =
   let icon =
     `LightDark
-      Vscode.LightDarkIcon.
-        { light = `String (Path.asset "chat-light.svg" |> Path.to_string)
-        ; dark = `String (Path.asset "chat-dark.svg" |> Path.to_string)
-        }
+      (Extension_assets.light_dark_icon
+         ~extension
+         ~light:"chat-light.svg"
+         ~dark:"chat-dark.svg")
   in
   let label =
     `TreeItemLabel (Vscode.TreeItemLabel.create ~label:"Ask a question on Discuss" ())
@@ -46,7 +46,7 @@ let discuss_item =
   item
 ;;
 
-let tutorials_item =
+let tutorials_item () =
   let label =
     `TreeItemLabel
       (Vscode.TreeItemLabel.create ~label:"Explore OCaml exercises and tutorials" ())
@@ -66,13 +66,13 @@ let tutorials_item =
   item
 ;;
 
-let github_item =
+let github_item extension =
   let icon =
     `LightDark
-      Vscode.LightDarkIcon.
-        { light = `String (Path.asset "github-light.svg" |> Path.to_string)
-        ; dark = `String (Path.asset "github-dark.svg" |> Path.to_string)
-        }
+      (Extension_assets.light_dark_icon
+         ~extension
+         ~light:"github-light.svg"
+         ~dark:"github-dark.svg")
   in
   let label =
     `TreeItemLabel (Vscode.TreeItemLabel.create ~label:"Open an issue on Github" ())
@@ -93,16 +93,25 @@ let github_item =
   item
 ;;
 
-let items = [ discord_item; discuss_item; github_item; tutorials_item ]
+let items extension =
+  [ discord_item extension
+  ; discuss_item extension
+  ; github_item extension
+  ; tutorials_item ()
+  ]
+;;
+
 let getTreeItem ~element = `Value element
 
-let getChildren ?element () =
+let getChildren items ?element () =
   match element with
   | None -> `Value (Some items)
   | Some _ -> `Value (Some [])
 ;;
 
 let register extension =
+  let items = items extension in
+  let getChildren = getChildren items in
   let module TreeDataProvider = Vscode.TreeDataProvider.Make (Vscode.TreeItem) in
   let treeDataProvider = TreeDataProvider.create ~getTreeItem ~getChildren () in
   let disposable =

--- a/src/treeview_help.ml
+++ b/src/treeview_help.ml
@@ -1,5 +1,5 @@
-let discord_item extension =
-  let icon = `LightDark (Extension_assets.discord_icon ~extension) in
+let discord_item assets =
+  let icon = `LightDark (Extension_assets.discord_icon assets) in
   let label = `TreeItemLabel (Vscode.TreeItemLabel.create ~label:"Chat on Discord" ()) in
   let item = Vscode.TreeItem.make_label ~label () in
   let command =
@@ -15,8 +15,8 @@ let discord_item extension =
   item
 ;;
 
-let discuss_item extension =
-  let icon = `LightDark (Extension_assets.chat_icon ~extension) in
+let discuss_item assets =
+  let icon = `LightDark (Extension_assets.chat_icon assets) in
   let label =
     `TreeItemLabel (Vscode.TreeItemLabel.create ~label:"Ask a question on Discuss" ())
   in
@@ -54,8 +54,8 @@ let tutorials_item =
   item
 ;;
 
-let github_item extension =
-  let icon = `LightDark (Extension_assets.github_icon ~extension) in
+let github_item assets =
+  let icon = `LightDark (Extension_assets.github_icon assets) in
   let label =
     `TreeItemLabel (Vscode.TreeItemLabel.create ~label:"Open an issue on Github" ())
   in
@@ -75,12 +75,8 @@ let github_item extension =
   item
 ;;
 
-let items extension =
-  [ discord_item extension
-  ; discuss_item extension
-  ; github_item extension
-  ; tutorials_item
-  ]
+let items assets =
+  [ discord_item assets; discuss_item assets; github_item assets; tutorials_item ]
 ;;
 
 let getTreeItem ~element = `Value element
@@ -91,8 +87,8 @@ let getChildren items ?element () =
   | Some _ -> `Value (Some [])
 ;;
 
-let register extension =
-  let items = items extension in
+let register extension ~assets =
+  let items = items assets in
   let getChildren = getChildren items in
   let module TreeDataProvider = Vscode.TreeDataProvider.Make (Vscode.TreeItem) in
   let treeDataProvider = TreeDataProvider.create ~getTreeItem ~getChildren () in

--- a/src/treeview_help.mli
+++ b/src/treeview_help.mli
@@ -1,2 +1,2 @@
 (** Register the ocaml-help tree view. *)
-val register : Vscode.ExtensionContext.t -> unit
+val register : Vscode.ExtensionContext.t -> assets:Extension_assets.t -> unit

--- a/src/treeview_sandbox.ml
+++ b/src/treeview_sandbox.ml
@@ -216,8 +216,8 @@ let getChildren ~instance ?element () =
     `Promise items
 ;;
 
-let register extension instance =
-  let icon = Extension_assets.package_icon ~extension in
+let register extension instance ~assets =
+  let icon = Extension_assets.package_icon assets in
   let getTreeItem = getTreeItem icon in
   let getChildren = getChildren ~instance in
   let module EventEmitter = Vscode.EventEmitter.Make (Interop.Js.Or_undefined (Dependency))

--- a/src/treeview_sandbox.ml
+++ b/src/treeview_sandbox.ml
@@ -9,11 +9,11 @@ module Dependency = struct
   let description t = Promise.return (Some (Sandbox.Package.version t))
   let tooltip t = Sandbox.Package.synopsis t
 
-  let icon _ =
-    LightDarkIcon.
-      { light = `String (Path.asset "number-light.svg" |> Path.to_string)
-      ; dark = `String (Path.asset "number-dark.svg" |> Path.to_string)
-      }
+  let make_icon extension =
+    Extension_assets.light_dark_icon
+      ~extension
+      ~light:"number-light.svg"
+      ~dark:"number-dark.svg"
   ;;
 
   let collapsible_state t =
@@ -22,9 +22,9 @@ module Dependency = struct
     else TreeItemCollapsibleState.None
   ;;
 
-  let to_treeitem dependency =
+  let to_treeitem icon dependency =
     let open Promise.Syntax in
-    let icon = `LightDark (icon dependency) in
+    let icon = `LightDark icon in
     let collapsibleState = collapsible_state dependency in
     let label =
       `TreeItemLabel (Vscode.TreeItemLabel.create ~label:(label dependency) ())
@@ -206,7 +206,7 @@ module Command = struct
   ;;
 end
 
-let getTreeItem ~element = `Promise (Dependency.to_treeitem element)
+let getTreeItem icon ~element = `Promise (Dependency.to_treeitem icon element)
 
 let getChildren ~instance ?element () =
   let sandbox = Extension_instance.sandbox instance in
@@ -224,6 +224,8 @@ let getChildren ~instance ?element () =
 ;;
 
 let register extension instance =
+  let icon = Dependency.make_icon extension in
+  let getTreeItem = getTreeItem icon in
   let getChildren = getChildren ~instance in
   let module EventEmitter = Vscode.EventEmitter.Make (Interop.Js.Or_undefined (Dependency))
   in

--- a/src/treeview_sandbox.ml
+++ b/src/treeview_sandbox.ml
@@ -9,13 +9,6 @@ module Dependency = struct
   let description t = Promise.return (Some (Sandbox.Package.version t))
   let tooltip t = Sandbox.Package.synopsis t
 
-  let make_icon extension =
-    Extension_assets.light_dark_icon
-      ~extension
-      ~light:"number-light.svg"
-      ~dark:"number-dark.svg"
-  ;;
-
   let collapsible_state t =
     if Sandbox.Package.has_dependencies t
     then TreeItemCollapsibleState.Collapsed
@@ -224,7 +217,7 @@ let getChildren ~instance ?element () =
 ;;
 
 let register extension instance =
-  let icon = Dependency.make_icon extension in
+  let icon = Extension_assets.package_icon ~extension in
   let getTreeItem = getTreeItem icon in
   let getChildren = getChildren ~instance in
   let module EventEmitter = Vscode.EventEmitter.Make (Interop.Js.Or_undefined (Dependency))

--- a/src/treeview_sandbox.mli
+++ b/src/treeview_sandbox.mli
@@ -1,2 +1,6 @@
 (** Register the ocaml-sandbox tree view *)
-val register : Vscode.ExtensionContext.t -> Extension_instance.t -> unit
+val register
+  :  Vscode.ExtensionContext.t
+  -> Extension_instance.t
+  -> assets:Extension_assets.t
+  -> unit

--- a/src/treeview_switches.ml
+++ b/src/treeview_switches.ml
@@ -39,22 +39,36 @@ module Dependency = struct
     | Package _ -> "opam-package"
   ;;
 
-  let icon dependency is_current_sandbox =
+  type icons =
+    { dependency : LightDarkIcon.t
+    ; dependency_selected : LightDarkIcon.t
+    ; package : LightDarkIcon.t
+    }
+
+  let make_icons extension =
+    { dependency =
+        Extension_assets.light_dark_icon
+          ~extension
+          ~light:"dependency-light.svg"
+          ~dark:"dependency-dark.svg"
+    ; dependency_selected =
+        Extension_assets.light_dark_icon
+          ~extension
+          ~light:"dependency-light-selected.svg"
+          ~dark:"dependency-dark-selected.svg"
+    ; package =
+        Extension_assets.light_dark_icon
+          ~extension
+          ~light:"number-light.svg"
+          ~dark:"number-dark.svg"
+    }
+  ;;
+
+  let icon icons dependency is_current_sandbox =
     match dependency with
     | Switch _ ->
-      let selected = if is_current_sandbox then "-selected" else "" in
-      LightDarkIcon.
-        { light =
-            `String
-              (Path.asset @@ "dependency-light" ^ selected ^ ".svg" |> Path.to_string)
-        ; dark =
-            `String (Path.asset @@ "dependency-dark" ^ selected ^ ".svg" |> Path.to_string)
-        }
-    | Package _ ->
-      LightDarkIcon.
-        { light = `String (Path.asset "number-light.svg" |> Path.to_string)
-        ; dark = `String (Path.asset "number-dark.svg" |> Path.to_string)
-        }
+      if is_current_sandbox then icons.dependency_selected else icons.dependency
+    | Package _ -> icons.package
   ;;
 
   let collapsible_state =
@@ -72,11 +86,11 @@ module Dependency = struct
          else None)
   ;;
 
-  let to_treeitem instance dependency =
+  let to_treeitem icons instance dependency =
     let open Promise.Syntax in
     let current_sandbox = Extension_instance.sandbox instance in
     let is_current_sandbox = equals_opam_sandbox dependency current_sandbox in
-    let icon = `LightDark (icon dependency is_current_sandbox) in
+    let icon = `LightDark (icon icons dependency is_current_sandbox) in
     let* collapsibleState = collapsible_state dependency in
     let label =
       `TreeItemLabel (Vscode.TreeItemLabel.create ~label:(label dependency) ())
@@ -186,7 +200,9 @@ module Command = struct
   ;;
 end
 
-let getTreeItem instance ~element = `Promise (Dependency.to_treeitem instance element)
+let getTreeItem icons instance ~element =
+  `Promise (Dependency.to_treeitem icons instance element)
+;;
 
 let getChildren ?opam ?element () =
   match opam, element with
@@ -203,6 +219,7 @@ let getChildren ?opam ?element () =
 ;;
 
 let register extension instance =
+  let icons = Dependency.make_icons extension in
   let module EventEmitter = Vscode.EventEmitter.Make (Interop.Js.Or_undefined (Dependency))
   in
   let event_emitter = EventEmitter.make () in
@@ -211,7 +228,7 @@ let register extension instance =
     let open Promise.Syntax in
     let+ opam = Opam.make () in
     let getChildren = getChildren ?opam in
-    let getTreeItem = getTreeItem instance in
+    let getTreeItem = getTreeItem icons instance in
     let module TreeDataProvider = Vscode.TreeDataProvider.Make (Dependency) in
     let treeDataProvider =
       TreeDataProvider.create ~getTreeItem ~getChildren ~onDidChangeTreeData:event ()

--- a/src/treeview_switches.ml
+++ b/src/treeview_switches.ml
@@ -46,21 +46,9 @@ module Dependency = struct
     }
 
   let make_icons extension =
-    { dependency =
-        Extension_assets.light_dark_icon
-          ~extension
-          ~light:"dependency-light.svg"
-          ~dark:"dependency-dark.svg"
-    ; dependency_selected =
-        Extension_assets.light_dark_icon
-          ~extension
-          ~light:"dependency-light-selected.svg"
-          ~dark:"dependency-dark-selected.svg"
-    ; package =
-        Extension_assets.light_dark_icon
-          ~extension
-          ~light:"number-light.svg"
-          ~dark:"number-dark.svg"
+    { dependency = Extension_assets.dependency_icon ~extension ~selected:false
+    ; dependency_selected = Extension_assets.dependency_icon ~extension ~selected:true
+    ; package = Extension_assets.package_icon ~extension
     }
   ;;
 

--- a/src/treeview_switches.ml
+++ b/src/treeview_switches.ml
@@ -39,17 +39,10 @@ module Dependency = struct
     | Package _ -> "opam-package"
   ;;
 
-  type icons =
-    { dependency : LightDarkIcon.t
-    ; dependency_selected : LightDarkIcon.t
-    ; package : LightDarkIcon.t
-    }
-
-  let icon icons dependency is_current_sandbox =
+  let icon assets dependency is_current_sandbox =
     match dependency with
-    | Switch _ ->
-      if is_current_sandbox then icons.dependency_selected else icons.dependency
-    | Package _ -> icons.package
+    | Switch _ -> Extension_assets.dependency_icon assets ~selected:is_current_sandbox
+    | Package _ -> Extension_assets.package_icon assets
   ;;
 
   let collapsible_state =
@@ -67,11 +60,11 @@ module Dependency = struct
          else None)
   ;;
 
-  let to_treeitem icons instance dependency =
+  let to_treeitem assets instance dependency =
     let open Promise.Syntax in
     let current_sandbox = Extension_instance.sandbox instance in
     let is_current_sandbox = equals_opam_sandbox dependency current_sandbox in
-    let icon = `LightDark (icon icons dependency is_current_sandbox) in
+    let icon = `LightDark (icon assets dependency is_current_sandbox) in
     let* collapsibleState = collapsible_state dependency in
     let label =
       `TreeItemLabel (Vscode.TreeItemLabel.create ~label:(label dependency) ())
@@ -181,8 +174,8 @@ module Command = struct
   ;;
 end
 
-let getTreeItem icons instance ~element =
-  `Promise (Dependency.to_treeitem icons instance element)
+let getTreeItem assets instance ~element =
+  `Promise (Dependency.to_treeitem assets instance element)
 ;;
 
 let getChildren ?opam ?element () =
@@ -199,14 +192,7 @@ let getChildren ?opam ?element () =
     `Promise items
 ;;
 
-let register extension instance =
-  let icons =
-    Dependency.
-      { dependency = Extension_assets.dependency_icon ~extension ~selected:false
-      ; dependency_selected = Extension_assets.dependency_icon ~extension ~selected:true
-      ; package = Extension_assets.package_icon ~extension
-      }
-  in
+let register extension instance ~assets =
   let module EventEmitter = Vscode.EventEmitter.Make (Interop.Js.Or_undefined (Dependency))
   in
   let event_emitter = EventEmitter.make () in
@@ -215,7 +201,7 @@ let register extension instance =
     let open Promise.Syntax in
     let+ opam = Opam.make () in
     let getChildren = getChildren ?opam in
-    let getTreeItem = getTreeItem icons instance in
+    let getTreeItem = getTreeItem assets instance in
     let module TreeDataProvider = Vscode.TreeDataProvider.Make (Dependency) in
     let treeDataProvider =
       TreeDataProvider.create ~getTreeItem ~getChildren ~onDidChangeTreeData:event ()

--- a/src/treeview_switches.ml
+++ b/src/treeview_switches.ml
@@ -45,13 +45,6 @@ module Dependency = struct
     ; package : LightDarkIcon.t
     }
 
-  let make_icons extension =
-    { dependency = Extension_assets.dependency_icon ~extension ~selected:false
-    ; dependency_selected = Extension_assets.dependency_icon ~extension ~selected:true
-    ; package = Extension_assets.package_icon ~extension
-    }
-  ;;
-
   let icon icons dependency is_current_sandbox =
     match dependency with
     | Switch _ ->
@@ -207,7 +200,13 @@ let getChildren ?opam ?element () =
 ;;
 
 let register extension instance =
-  let icons = Dependency.make_icons extension in
+  let icons =
+    Dependency.
+      { dependency = Extension_assets.dependency_icon ~extension ~selected:false
+      ; dependency_selected = Extension_assets.dependency_icon ~extension ~selected:true
+      ; package = Extension_assets.package_icon ~extension
+      }
+  in
   let module EventEmitter = Vscode.EventEmitter.Make (Interop.Js.Or_undefined (Dependency))
   in
   let event_emitter = EventEmitter.make () in

--- a/src/treeview_switches.mli
+++ b/src/treeview_switches.mli
@@ -1,2 +1,6 @@
 (** Register the ocaml-switches tree view *)
-val register : Vscode.ExtensionContext.t -> Extension_instance.t -> unit
+val register
+  :  Vscode.ExtensionContext.t
+  -> Extension_instance.t
+  -> assets:Extension_assets.t
+  -> unit

--- a/src/vscode_ocaml_platform.ml
+++ b/src/vscode_ocaml_platform.ml
@@ -26,16 +26,19 @@ let notify_configuration_changes instance =
 let activate (extension : ExtensionContext.t) =
   let open Promise.Syntax in
   let instance = Extension_instance.make () in
+  let assets =
+    Extension_assets.make ~extension_uri:(ExtensionContext.extensionUri extension)
+  in
   ExtensionContext.subscribe
     extension
     ~disposable:(Extension_instance.disposable instance);
   ExtensionContext.subscribe extension ~disposable:(notify_configuration_changes instance);
   Dune_formatter.register extension instance;
   Dune_task_provider.register extension instance;
-  Treeview_switches.register extension instance;
-  Treeview_sandbox.register extension instance;
-  Treeview_commands.register extension;
-  Treeview_help.register extension;
+  Treeview_switches.register extension instance ~assets;
+  Treeview_sandbox.register extension instance ~assets;
+  Treeview_commands.register extension ~assets;
+  Treeview_help.register extension ~assets;
   Ast_editor.register extension instance;
   Cm_editor.register extension instance;
   Repl.register extension instance;


### PR DESCRIPTION
## Summary

- Resolve Tree View assets from `ExtensionContext.extensionUri` with `Uri.joinPath`.
- Share light/dark icon construction across Sandbox, Opam Switches, Commands, and Help and feedback.
- Remove `Path.asset` and document the fix in the changelog.

## Root cause

Tree items supplied filesystem path strings derived from the Node `__filename` value. In a Remote WSL session, those paths are created in the extension host environment and cannot be reliably resolved by the local VS Code UI. Passing extension-relative `Uri` values preserves the scheme and authority expected by VS Code.

## Validation

- macOS 26.5.1 arm64
- VS Code 1.128.0
- `bun install --frozen-lockfile`
- `make fmt`
- `git diff --check`
- `make build`
- `make test`
- `make pkg`
- Opened the OCaml Activity Bar in an Extension Development Host and verified Sandbox, Opam Switches, Commands, and Help and feedback.
- Verified the number, dependency, collection, terminal, Discord, chat, and GitHub icons in both light and dark themes.
- Selected an opam switch as the Sandbox and verified selected/unselected switch icons and Sandbox package icons.
- Checked Extension Host logs for URI conversion and icon-loading errors.
- WSL was not tested directly.

Fixes #945