### PR TITLE
Expose additional OCaml LSP settings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- Expose the `ocaml.server.inlayHints.*` and
+  `ocaml.server.shortenMerlinDiagnostics` settings. (#2227)
 - Add syntax highlighting for Dune's parameterised library keywords: the
   `library_parameter` stanza, the `parameters` and `implements` library fields,
   and the `(instantiate ...)` dependency form together with its `:as` keyword.

--- a/package.json
+++ b/package.json
@@ -372,6 +372,26 @@
           "default": true,
           "markdownDescription": "Enable/Disable dune diagnostics"
         },
+        "ocaml.server.inlayHints.hintPatternVariables": {
+          "type": "boolean",
+          "default": false,
+          "markdownDescription": "Enable/Disable inlay hints for pattern variables"
+        },
+        "ocaml.server.inlayHints.hintLetBindings": {
+          "type": "boolean",
+          "default": false,
+          "markdownDescription": "Enable/Disable inlay hints for let bindings"
+        },
+        "ocaml.server.inlayHints.hintFunctionParams": {
+          "type": "boolean",
+          "default": false,
+          "markdownDescription": "Enable/Disable inlay hints for function parameters"
+        },
+        "ocaml.server.shortenMerlinDiagnostics": {
+          "type": "boolean",
+          "default": false,
+          "markdownDescription": "Shorten multi-line Merlin diagnostic ranges to their first line"
+        },
         "ocaml.commands.typeSelection.outputChannelResults": {
           "type": "boolean",
           "default": true,

--- a/package.json
+++ b/package.json
@@ -352,6 +352,11 @@
           "default": [],
           "markdownDescription": "Extra arguments to pass to ocamllsp."
         },
+        "ocaml.server.extendedHover": {
+          "type": "boolean",
+          "default": false,
+          "markdownDescription": "Enable/Disable extended hover"
+        },
         "ocaml.server.codelens.enable": {
           "type": "boolean",
           "default": true,
@@ -361,11 +366,6 @@
           "type": "boolean",
           "default": false,
           "markdownDescription": "Enable/Disable codelens for nested let bindings"
-        },
-        "ocaml.server.extendedHover": {
-          "type": "boolean",
-          "default": false,
-          "markdownDescription": "Enable/Disable extended hover"
         },
         "ocaml.server.duneDiagnostics": {
           "type": "boolean",
@@ -387,6 +387,11 @@
           "default": false,
           "markdownDescription": "Enable/Disable inlay hints for function parameters"
         },
+        "ocaml.server.syntaxDocumentation": {
+          "type": "boolean",
+          "default": false,
+          "markdownDescription": "Enable/Disable syntax documentation"
+        },
         "ocaml.server.shortenMerlinDiagnostics": {
           "type": "boolean",
           "default": false,
@@ -401,11 +406,6 @@
           "type": "boolean",
           "default": false,
           "markdownDescription": "Enable/Disable clearing of the output channel before showing a new result."
-        },
-        "ocaml.server.syntaxDocumentation": {
-          "type": "boolean",
-          "default": false,
-          "markdownDescription": "Enable/Disable syntax documentation"
         },
         "ocaml.commands.typedHoles.constructAfterNavigate": {
           "type": "boolean",

--- a/src/extension_instance.ml
+++ b/src/extension_instance.ml
@@ -25,6 +25,11 @@ let send_configuration t client =
     Option.map (Settings.get setting) ~f:(fun enable ->
       Ocaml_lsp.OcamllspSettingEnable.create ~enable)
   in
+  let extendedHover = enable_setting Settings.server_extendedHover_setting in
+  let standardHover =
+    Option.map t.standard_hover ~f:(fun enable ->
+      Ocaml_lsp.OcamllspSettingEnable.create ~enable)
+  in
   let codelens =
     Option.map (Settings.get Settings.server_codelens_setting) ~f:(fun enable ->
       Ocaml_lsp.OcamllspSettingCodeLens.create
@@ -32,11 +37,6 @@ let send_configuration t client =
           (Settings.get Settings.server_codelens_for_nested_bindings_setting)
         ~enable
         ())
-  in
-  let extendedHover = enable_setting Settings.server_extendedHover_setting in
-  let standardHover =
-    Option.map t.standard_hover ~f:(fun enable ->
-      Ocaml_lsp.OcamllspSettingEnable.create ~enable)
   in
   let duneDiagnostics = enable_setting Settings.server_duneDiagnostics_setting in
   let inlayHints =
@@ -59,19 +59,19 @@ let send_configuration t client =
            ?hintFunctionParams
            ())
   in
+  let syntaxDocumentation = enable_setting Settings.server_syntaxDocumentation_setting in
   let shortenMerlinDiagnostics =
     enable_setting Settings.server_shortenMerlinDiagnostics_setting
   in
-  let syntaxDocumentation = enable_setting Settings.server_syntaxDocumentation_setting in
   let settings =
     Ocaml_lsp.OcamllspSettings.create
-      ~codelens
       ~extendedHover
       ~standardHover
+      ~codelens
       ~duneDiagnostics
       ~inlayHints
-      ~shortenMerlinDiagnostics
       ~syntaxDocumentation
+      ~shortenMerlinDiagnostics
   in
   let payload =
     let settings =

--- a/src/extension_instance.ml
+++ b/src/extension_instance.ml
@@ -39,6 +39,29 @@ let send_configuration t client =
       Ocaml_lsp.OcamllspSettingEnable.create ~enable)
   in
   let duneDiagnostics = enable_setting Settings.server_duneDiagnostics_setting in
+  let inlayHints =
+    let hintPatternVariables =
+      Settings.get Settings.server_inlayHints_hintPatternVariables_setting
+    in
+    let hintLetBindings =
+      Settings.get Settings.server_inlayHints_hintLetBindings_setting
+    in
+    let hintFunctionParams =
+      Settings.get Settings.server_inlayHints_hintFunctionParams_setting
+    in
+    match hintPatternVariables, hintLetBindings, hintFunctionParams with
+    | None, None, None -> None
+    | _ ->
+      Some
+        (Ocaml_lsp.OcamllspSettingInlayHints.create
+           ?hintPatternVariables
+           ?hintLetBindings
+           ?hintFunctionParams
+           ())
+  in
+  let shortenMerlinDiagnostics =
+    enable_setting Settings.server_shortenMerlinDiagnostics_setting
+  in
   let syntaxDocumentation = enable_setting Settings.server_syntaxDocumentation_setting in
   let settings =
     Ocaml_lsp.OcamllspSettings.create
@@ -46,6 +69,8 @@ let send_configuration t client =
       ~extendedHover
       ~standardHover
       ~duneDiagnostics
+      ~inlayHints
+      ~shortenMerlinDiagnostics
       ~syntaxDocumentation
   in
   let payload =

--- a/src/ocaml_lsp.ml
+++ b/src/ocaml_lsp.ml
@@ -43,43 +43,43 @@ module OcamllspSettings = struct
 
   include
     [%js:
-      val codelens : t -> OcamllspSettingCodeLens.t or_undefined [@@js.get]
       val extendedHover : t -> OcamllspSettingEnable.t or_undefined [@@js.get]
       val standardHover : t -> OcamllspSettingEnable.t or_undefined [@@js.get]
+      val codelens : t -> OcamllspSettingCodeLens.t or_undefined [@@js.get]
       val duneDiagnostics : t -> OcamllspSettingEnable.t or_undefined [@@js.get]
       val inlayHints : t -> OcamllspSettingInlayHints.t or_undefined [@@js.get]
-      val shortenMerlinDiagnostics : t -> OcamllspSettingEnable.t or_undefined [@@js.get]
       val syntaxDocumentation : t -> OcamllspSettingEnable.t or_undefined [@@js.get]
+      val shortenMerlinDiagnostics : t -> OcamllspSettingEnable.t or_undefined [@@js.get]
 
       val create
-        :  ?codelens:OcamllspSettingCodeLens.t
-        -> ?extendedHover:OcamllspSettingEnable.t
+        :  ?extendedHover:OcamllspSettingEnable.t
         -> ?standardHover:OcamllspSettingEnable.t
+        -> ?codelens:OcamllspSettingCodeLens.t
         -> ?duneDiagnostics:OcamllspSettingEnable.t
         -> ?inlayHints:OcamllspSettingInlayHints.t
-        -> ?shortenMerlinDiagnostics:OcamllspSettingEnable.t
         -> ?syntaxDocumentation:OcamllspSettingEnable.t
+        -> ?shortenMerlinDiagnostics:OcamllspSettingEnable.t
         -> unit
         -> t
       [@@js.builder]]
 
   let create
-        ~codelens
         ~extendedHover
         ~standardHover
+        ~codelens
         ~duneDiagnostics
         ~inlayHints
-        ~shortenMerlinDiagnostics
         ~syntaxDocumentation
+        ~shortenMerlinDiagnostics
     =
     create
-      ?codelens
       ?extendedHover
       ?standardHover
+      ?codelens
       ?duneDiagnostics
       ?inlayHints
-      ?shortenMerlinDiagnostics
       ?syntaxDocumentation
+      ?shortenMerlinDiagnostics
       ()
   ;;
 end

--- a/src/ocaml_lsp.ml
+++ b/src/ocaml_lsp.ml
@@ -20,6 +20,24 @@ module OcamllspSettingCodeLens = struct
       val create : ?forNestedBindings:bool -> enable:bool -> unit -> t [@@js.builder]]
 end
 
+module OcamllspSettingInlayHints = struct
+  include Interface.Make ()
+
+  include
+    [%js:
+      val hintPatternVariables : t -> bool or_undefined [@@js.get]
+      val hintLetBindings : t -> bool or_undefined [@@js.get]
+      val hintFunctionParams : t -> bool or_undefined [@@js.get]
+
+      val create
+        :  ?hintPatternVariables:bool
+        -> ?hintLetBindings:bool
+        -> ?hintFunctionParams:bool
+        -> unit
+        -> t
+      [@@js.builder]]
+end
+
 module OcamllspSettings = struct
   include Interface.Make ()
 
@@ -29,6 +47,8 @@ module OcamllspSettings = struct
       val extendedHover : t -> OcamllspSettingEnable.t or_undefined [@@js.get]
       val standardHover : t -> OcamllspSettingEnable.t or_undefined [@@js.get]
       val duneDiagnostics : t -> OcamllspSettingEnable.t or_undefined [@@js.get]
+      val inlayHints : t -> OcamllspSettingInlayHints.t or_undefined [@@js.get]
+      val shortenMerlinDiagnostics : t -> OcamllspSettingEnable.t or_undefined [@@js.get]
       val syntaxDocumentation : t -> OcamllspSettingEnable.t or_undefined [@@js.get]
 
       val create
@@ -36,18 +56,29 @@ module OcamllspSettings = struct
         -> ?extendedHover:OcamllspSettingEnable.t
         -> ?standardHover:OcamllspSettingEnable.t
         -> ?duneDiagnostics:OcamllspSettingEnable.t
+        -> ?inlayHints:OcamllspSettingInlayHints.t
+        -> ?shortenMerlinDiagnostics:OcamllspSettingEnable.t
         -> ?syntaxDocumentation:OcamllspSettingEnable.t
         -> unit
         -> t
       [@@js.builder]]
 
-  let create ~codelens ~extendedHover ~standardHover ~duneDiagnostics ~syntaxDocumentation
+  let create
+        ~codelens
+        ~extendedHover
+        ~standardHover
+        ~duneDiagnostics
+        ~inlayHints
+        ~shortenMerlinDiagnostics
+        ~syntaxDocumentation
     =
     create
       ?codelens
       ?extendedHover
       ?standardHover
       ?duneDiagnostics
+      ?inlayHints
+      ?shortenMerlinDiagnostics
       ?syntaxDocumentation
       ()
   ;;

--- a/src/ocaml_lsp.mli
+++ b/src/ocaml_lsp.mli
@@ -52,21 +52,21 @@ end
 module OcamllspSettings : sig
   include Ojs.T
 
-  val codelens : t -> OcamllspSettingCodeLens.t option
   val extendedHover : t -> OcamllspSettingEnable.t option
   val standardHover : t -> OcamllspSettingEnable.t option
+  val codelens : t -> OcamllspSettingCodeLens.t option
   val duneDiagnostics : t -> OcamllspSettingEnable.t option
   val inlayHints : t -> OcamllspSettingInlayHints.t option
-  val shortenMerlinDiagnostics : t -> OcamllspSettingEnable.t option
   val syntaxDocumentation : t -> OcamllspSettingEnable.t option
+  val shortenMerlinDiagnostics : t -> OcamllspSettingEnable.t option
 
   val create
-    :  codelens:OcamllspSettingCodeLens.t option
-    -> extendedHover:OcamllspSettingEnable.t option
+    :  extendedHover:OcamllspSettingEnable.t option
     -> standardHover:OcamllspSettingEnable.t option
+    -> codelens:OcamllspSettingCodeLens.t option
     -> duneDiagnostics:OcamllspSettingEnable.t option
     -> inlayHints:OcamllspSettingInlayHints.t option
-    -> shortenMerlinDiagnostics:OcamllspSettingEnable.t option
     -> syntaxDocumentation:OcamllspSettingEnable.t option
+    -> shortenMerlinDiagnostics:OcamllspSettingEnable.t option
     -> t
 end

--- a/src/ocaml_lsp.mli
+++ b/src/ocaml_lsp.mli
@@ -34,6 +34,21 @@ module OcamllspSettingCodeLens : sig
   val create : ?forNestedBindings:bool -> enable:bool -> unit -> t
 end
 
+module OcamllspSettingInlayHints : sig
+  include Ojs.T
+
+  val hintPatternVariables : t -> bool option
+  val hintLetBindings : t -> bool option
+  val hintFunctionParams : t -> bool option
+
+  val create
+    :  ?hintPatternVariables:bool
+    -> ?hintLetBindings:bool
+    -> ?hintFunctionParams:bool
+    -> unit
+    -> t
+end
+
 module OcamllspSettings : sig
   include Ojs.T
 
@@ -41,6 +56,8 @@ module OcamllspSettings : sig
   val extendedHover : t -> OcamllspSettingEnable.t option
   val standardHover : t -> OcamllspSettingEnable.t option
   val duneDiagnostics : t -> OcamllspSettingEnable.t option
+  val inlayHints : t -> OcamllspSettingInlayHints.t option
+  val shortenMerlinDiagnostics : t -> OcamllspSettingEnable.t option
   val syntaxDocumentation : t -> OcamllspSettingEnable.t option
 
   val create
@@ -48,6 +65,8 @@ module OcamllspSettings : sig
     -> extendedHover:OcamllspSettingEnable.t option
     -> standardHover:OcamllspSettingEnable.t option
     -> duneDiagnostics:OcamllspSettingEnable.t option
+    -> inlayHints:OcamllspSettingInlayHints.t option
+    -> shortenMerlinDiagnostics:OcamllspSettingEnable.t option
     -> syntaxDocumentation:OcamllspSettingEnable.t option
     -> t
 end

--- a/src/settings.ml
+++ b/src/settings.ml
@@ -117,6 +117,14 @@ let server_args_setting =
     ~to_json:Jsonoo.Encode.(list string)
 ;;
 
+let server_extendedHover_setting =
+  create_setting
+    ~scope:ConfigurationTarget.Workspace
+    ~key:"ocaml.server.extendedHover"
+    ~of_json:Jsonoo.Decode.bool
+    ~to_json:Jsonoo.Encode.bool
+;;
+
 let server_codelens_setting =
   create_setting
     ~scope:ConfigurationTarget.Workspace
@@ -130,14 +138,6 @@ let server_codelens_for_nested_bindings_setting =
     ~scope:ConfigurationTarget.Workspace
     ~key:"ocaml.server.codelens"
     ~of_json:Jsonoo.Decode.(try_default false (field "forNestedBindings" bool))
-    ~to_json:Jsonoo.Encode.bool
-;;
-
-let server_extendedHover_setting =
-  create_setting
-    ~scope:ConfigurationTarget.Workspace
-    ~key:"ocaml.server.extendedHover"
-    ~of_json:Jsonoo.Decode.bool
     ~to_json:Jsonoo.Encode.bool
 ;;
 
@@ -173,18 +173,18 @@ let server_inlayHints_hintFunctionParams_setting =
     ~to_json:Jsonoo.Encode.bool
 ;;
 
-let server_shortenMerlinDiagnostics_setting =
-  create_setting
-    ~scope:ConfigurationTarget.Workspace
-    ~key:"ocaml.server.shortenMerlinDiagnostics"
-    ~of_json:Jsonoo.Decode.bool
-    ~to_json:Jsonoo.Encode.bool
-;;
-
 let server_syntaxDocumentation_setting =
   create_setting
     ~scope:ConfigurationTarget.Workspace
     ~key:"ocaml.server.syntaxDocumentation"
+    ~of_json:Jsonoo.Decode.bool
+    ~to_json:Jsonoo.Encode.bool
+;;
+
+let server_shortenMerlinDiagnostics_setting =
+  create_setting
+    ~scope:ConfigurationTarget.Workspace
+    ~key:"ocaml.server.shortenMerlinDiagnostics"
     ~of_json:Jsonoo.Decode.bool
     ~to_json:Jsonoo.Encode.bool
 ;;

--- a/src/settings.ml
+++ b/src/settings.ml
@@ -149,6 +149,38 @@ let server_duneDiagnostics_setting =
     ~to_json:Jsonoo.Encode.bool
 ;;
 
+let server_inlayHints_hintPatternVariables_setting =
+  create_setting
+    ~scope:ConfigurationTarget.Workspace
+    ~key:"ocaml.server.inlayHints.hintPatternVariables"
+    ~of_json:Jsonoo.Decode.bool
+    ~to_json:Jsonoo.Encode.bool
+;;
+
+let server_inlayHints_hintLetBindings_setting =
+  create_setting
+    ~scope:ConfigurationTarget.Workspace
+    ~key:"ocaml.server.inlayHints.hintLetBindings"
+    ~of_json:Jsonoo.Decode.bool
+    ~to_json:Jsonoo.Encode.bool
+;;
+
+let server_inlayHints_hintFunctionParams_setting =
+  create_setting
+    ~scope:ConfigurationTarget.Workspace
+    ~key:"ocaml.server.inlayHints.hintFunctionParams"
+    ~of_json:Jsonoo.Decode.bool
+    ~to_json:Jsonoo.Encode.bool
+;;
+
+let server_shortenMerlinDiagnostics_setting =
+  create_setting
+    ~scope:ConfigurationTarget.Workspace
+    ~key:"ocaml.server.shortenMerlinDiagnostics"
+    ~of_json:Jsonoo.Decode.bool
+    ~to_json:Jsonoo.Encode.bool
+;;
+
 let server_syntaxDocumentation_setting =
   create_setting
     ~scope:ConfigurationTarget.Workspace

--- a/src/settings.mli
+++ b/src/settings.mli
@@ -35,14 +35,14 @@ val substitute_workspace_vars : string -> string
 
 val server_extraEnv : unit -> string Interop.Dict.t option
 val server_args_setting : string list setting
+val server_extendedHover_setting : bool setting
 val server_codelens_setting : bool setting
 val server_codelens_for_nested_bindings_setting : bool setting
-val server_extendedHover_setting : bool setting
 val server_duneDiagnostics_setting : bool setting
 val server_inlayHints_hintPatternVariables_setting : bool setting
 val server_inlayHints_hintLetBindings_setting : bool setting
 val server_inlayHints_hintFunctionParams_setting : bool setting
-val server_shortenMerlinDiagnostics_setting : bool setting
 val server_syntaxDocumentation_setting : bool setting
+val server_shortenMerlinDiagnostics_setting : bool setting
 val server_typedHolesConstructAfterNavigate_setting : bool setting
 val server_constructRecursiveCalls_setting : bool setting

--- a/src/settings.mli
+++ b/src/settings.mli
@@ -39,6 +39,10 @@ val server_codelens_setting : bool setting
 val server_codelens_for_nested_bindings_setting : bool setting
 val server_extendedHover_setting : bool setting
 val server_duneDiagnostics_setting : bool setting
+val server_inlayHints_hintPatternVariables_setting : bool setting
+val server_inlayHints_hintLetBindings_setting : bool setting
+val server_inlayHints_hintFunctionParams_setting : bool setting
+val server_shortenMerlinDiagnostics_setting : bool setting
 val server_syntaxDocumentation_setting : bool setting
 val server_typedHolesConstructAfterNavigate_setting : bool setting
 val server_constructRecursiveCalls_setting : bool setting


### PR DESCRIPTION
## Summary

- expose OCaml LSP's per-category inlay hint settings for pattern variables, let bindings, and function parameters
- expose `shortenMerlinDiagnostics`
- forward all four settings through `workspace/didChangeConfiguration`

## Why

OCaml LSP supports these settings, but the VS Code extension did not declare or forward them. Users therefore could not select which OCaml type inlay hints to show or opt into shorter multi-line Merlin diagnostic ranges.

`shortenMerlinDiagnostics` provides the client-side presentation option requested in #1187.

Closes #1187

## Validation

- `dune build @all @runtest`
- `make build`
- `bun run lint`
- validated the four contributed settings and defaults in `package.json`

The local VS Code unit suites passed. The LSP hover e2e requires an installed `ocamllsp` in an opam switch and could not run in the fresh worktree environment; CI provides that environment.
