### PR TITLE
Walthrough auto-next

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@
 - Redesign how Dune Package Manager is handled. Users now use a two step process, first to select DPM as a sandbox and then to select which dune binary they wish to use in the project (#2199)
 - Enforce that users either enable dune package management by generating a lockfile (as recommended by the dune team) or select a different sandbox. Pressing the escape key will display the select sandbox ui. (2208)
 - Rely on `dune tools env` to retrieve the local OCaml LSP path in the context of DPM. (#2227)
+- Automatically move to the next step of the ocaml walkthrough upon completion of the current step (#2246)
 
 ## 2.3.0
 

--- a/src/command_api.ml
+++ b/src/command_api.ml
@@ -156,6 +156,14 @@ module Internal = struct
   let open_utop = unit_handle "open-utop"
 end
 
+module Walkthrough_step = struct
+  type t =
+    { category : string
+    ; step : string
+    }
+  [@@js]
+end
+
 module Vscode = struct
   let external_handle id ~args_to_js ~return_type =
     let args_of_js _ =
@@ -197,6 +205,14 @@ module Vscode = struct
   let show_simple_browser =
     let args_to_js url = [ [%js.of: string] url ] in
     unit_external_handle "simpleBrowser.show" ~args_to_js
+  ;;
+
+  let open_walkthrough =
+    let args_to_js (category, step) =
+      let target = [%js.of: Walkthrough_step.t] { category; step } in
+      [ target ]
+    in
+    unit_external_handle "workbench.action.openWalkthrough" ~args_to_js
   ;;
 end
 

--- a/src/command_api.mli
+++ b/src/command_api.mli
@@ -63,6 +63,7 @@ module Vscode : sig
   val set_context : (string * bool, unit) handle
   val show_hover : (unit, unit) handle
   val show_simple_browser : (string, unit) handle
+  val open_walkthrough : (string * string, unit) handle
 end
 
 module Command_errors : sig

--- a/src/extension_commands.ml
+++ b/src/extension_commands.ml
@@ -32,6 +32,16 @@ let text_editor_command handle callback =
   command
 ;;
 
+let advance_walkthrough_step step_id =
+  let category = "ocamllabs.ocaml-platform#ocaml-onboarding" in
+  let (_ : unit Promise.t) =
+    let open Promise.Syntax in
+    let* () = Node.setTimeout' ~wait_ms:500 in
+    Command_api.(execute Vscode.open_walkthrough) (category, step_id)
+  in
+  ()
+;;
+
 let _select_sandbox =
   let callback (instance : Extension_instance.t) () =
     let open Promise.Syntax in
@@ -43,7 +53,8 @@ let _select_sandbox =
         Extension_instance.set_sandbox instance new_sandbox;
         let* () = Sandbox.save_to_settings new_sandbox in
         let* () = Extension_instance.update_ocaml_info instance in
-        Extension_instance.start_language_server instance
+        let+ () = Extension_instance.start_language_server instance in
+        advance_walkthrough_step "install-platform-tools"
     in
     ()
   in
@@ -313,7 +324,7 @@ let _install_opam =
             show_message `Error "An error occured while installing opam %s" err
         in
         let+ () = Vscode.Window.withProgress (module Interop.Js.Unit) ~options ~task in
-        ()
+        advance_walkthrough_step "init-opam"
       | Some opam, _ ->
         let* latest_version =
           Cmd.output
@@ -340,7 +351,8 @@ let _install_opam =
            show_message
              `Info
              "opam is already installed and up to date (version %s)."
-             installed_version
+             installed_version;
+           advance_walkthrough_step "init-opam"
          | Ok (true, latest_version, installed_version) ->
            outdated_opam := true;
            let _ =
@@ -398,7 +410,9 @@ let _init_opam =
       | Error err -> show_message `Error "An error occured while initializing opam %s" err
     in
     let (_ : unit Promise.t) =
-      Vscode.Window.withProgress (module Interop.Js.Unit) ~options ~task
+      let open Promise.Syntax in
+      let+ () = Vscode.Window.withProgress (module Interop.Js.Unit) ~options ~task in
+      advance_walkthrough_step "activate-opam-switch"
     in
     ()
   in
@@ -436,7 +450,9 @@ let _install_ocaml_dev =
         show_message `Error "An error occured while installing packages %s" err
     in
     let (_ : unit Promise.t) =
-      Vscode.Window.withProgress (module Interop.Js.Unit) ~options ~task
+      let open Promise.Syntax in
+      let+ () = Vscode.Window.withProgress (module Interop.Js.Unit) ~options ~task in
+      advance_walkthrough_step "check-installation"
     in
     ()
   in
@@ -471,7 +487,9 @@ let _open_utop =
       | Error err -> show_message `Error "An error occured while opening utop %s" err
     in
     let (_ : unit Promise.t) =
-      Vscode.Window.withProgress (module Interop.Js.Unit) ~options ~task
+      let open Promise.Syntax in
+      let+ () = Vscode.Window.withProgress (module Interop.Js.Unit) ~options ~task in
+      advance_walkthrough_step "finish-onboarding"
     in
     ()
   in


### PR DESCRIPTION
This PR implements an auto-next feature for the ocaml walkthrough. 

<img width="1205" height="896" alt="image" src="https://github.com/user-attachments/assets/2517fd9c-86fa-47d6-8d45-c02ac550bc7f" />

The idea is that once a user has completed a step, they should not have to manually click to go to the next step. We should open it for them. 