### PR TITLE
Some fixes to `run-file` features

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,7 +35,7 @@
 - Clean up all child processes spawned by the extension when quitting VS Code. (#2244)
 - Update the list of available OCaml LSP versions. (#2245)
 - Upgrade dune when it is outdated. (#2224)
-- Add a run button to launch bytecode executable directly from the UI and provide tasks to run workspace executables with Dune. (#2190)
+- Add a run button to launch bytecode executable directly from the UI and provide tasks to run workspace executables with Dune. (#2190, #2254)
 - Check the OCaml version used only if OCaml LSP is detected, this ehance user experience in the context of DPM. (#2238)
 
 ## 2.3.0

--- a/src/cmd.ml
+++ b/src/cmd.ml
@@ -78,10 +78,10 @@ let check ?env t =
     Spawn s
 ;;
 
-let run ?output ?cwd ?env ?stdin cmd =
+let run ?cwd ?env ?stdin cmd =
   let cwd = Option.map cwd ~f:Path.to_string in
   let logger event =
-    let (lazy output) = Option.value output ~default:Output.command_output_channel in
+    let (lazy output) = Output.command_output_channel in
     match event with
     | ChildProcess.Spawned ->
       Vscode.OutputChannel.appendLine output ~value:("$ " ^ to_string cmd)

--- a/src/cmd.mli
+++ b/src/cmd.mli
@@ -33,8 +33,7 @@ val output
 val equal_spawn : spawn -> spawn -> bool
 
 val run
-  :  ?output:OutputChannel.t Lazy.t
-  -> ?cwd:Path.t
+  :  ?cwd:Path.t
   -> ?env:string Interop.Dict.t
   -> ?stdin:stderr
   -> t

--- a/src/cmd.mli
+++ b/src/cmd.mli
@@ -16,6 +16,7 @@ type stderr = string
 
 (* surround a string with quotes if it has spaces *)
 val quote : string -> string
+val to_string : t -> string
 val to_spawn : t -> spawn
 val append : spawn -> string list -> spawn
 val check_spawn : ?env:string Interop.Dict.t -> spawn -> spawn Or_error.t Promise.t

--- a/src/output.ml
+++ b/src/output.ml
@@ -14,5 +14,3 @@ let extension_output_channel =
 let command_output_channel =
   lazy (Vscode.Window.createOutputChannel ~name:"OCaml Commands" ())
 ;;
-
-let run_output_channel = lazy (Vscode.Window.createOutputChannel ~name:"Run OCaml" ())

--- a/src/output.mli
+++ b/src/output.mli
@@ -9,5 +9,3 @@ val extension_output_channel : Vscode.OutputChannel.t Lazy.t
 (** [command_output_channel] is the output channel for user-friendly logs of
     shell commands *)
 val command_output_channel : Vscode.OutputChannel.t Lazy.t
-
-val run_output_channel : Vscode.OutputChannel.t Lazy.t

--- a/src/runnable.ml
+++ b/src/runnable.ml
@@ -94,6 +94,18 @@ let active_text_doc () =
     else None)
 ;;
 
+let terms_tbl : (string, Terminal_sandbox.t) Hashtbl.t = Hashtbl.create (module String)
+
+let spawn_term sandbox exec =
+  let term =
+    Terminal_sandbox.create
+      ~name:(sprintf {|Run "%s"|} exec.Dune_describe.mod_path)
+      sandbox
+  in
+  let _ = Hashtbl.add terms_tbl ~key:exec.mod_path ~data:term in
+  term
+;;
+
 let _run_file =
   let callback instance () =
     let open Promise.Syntax in
@@ -115,8 +127,14 @@ let _run_file =
                TextDocument.save doc
              | _ -> Promise.return false
            in
+           let term =
+             match Hashtbl.find terms_tbl exec.mod_path with
+             | None -> spawn_term sandbox exec
+             | Some previous when Option.is_some (Terminal.exitStatus previous) ->
+               spawn_term sandbox exec
+             | Some term -> term
+           in
            let command = exec_cmd ctx exec [] in
-           let term = Terminal_sandbox.create ~name:"Run OCaml" sandbox in
            Terminal_sandbox.show ~preserveFocus:true term;
            Terminal_sandbox.send term command)
     in
@@ -128,7 +146,7 @@ let _run_file =
 let register extension _instance =
   let disposable =
     Disposable.make ~dispose:(fun () ->
-      Lazy.peek Output.run_output_channel |> Option.iter ~f:OutputChannel.dispose)
+      Hashtbl.iter ~f:Terminal_sandbox.dispose terms_tbl)
   in
   ExtensionContext.subscribe extension ~disposable
 ;;

--- a/src/runnable.ml
+++ b/src/runnable.ml
@@ -62,21 +62,6 @@ let exec_cmd project_ctx (exec : Dune_describe.executable) args =
   Spawn { Cmd.bin = Path.of_string program; args } |> Cmd.to_string
 ;;
 
-let executable_choice_menu (execs : Dune_describe.executable list) =
-  let choices =
-    List.map
-      ~f:(fun exec ->
-        QuickPickItem.create ~label:exec.name ~detail:exec.exec_path (), exec)
-      execs
-  and options =
-    QuickPickOptions.create
-      ~canPickMany:false
-      ~placeHolder:"Which executable do you want to run?"
-      ()
-  in
-  Window.showQuickPickItems ~choices ~options ()
-;;
-
 let active_text_doc () =
   Window.activeTextEditor ()
   |> Option.bind ~f:(fun text_editor ->
@@ -92,6 +77,33 @@ let active_text_doc () =
          | None -> Some (abs_path, doc)
          | Some rel_path -> Some (rel_path, doc)))
     else None)
+;;
+
+let executable_choice_menu (execs : Dune_describe.executable list) =
+  let text_doc = active_text_doc () in
+  let choices =
+    List.map
+      ~f:(fun exec ->
+        let is_current_doc =
+          match text_doc with
+          | None -> false
+          | Some (path, _) -> String.equal path exec.mod_path
+        in
+        ( QuickPickItem.create
+            ~label:exec.name
+            ~detail:exec.exec_path
+            ~alwaysShow:is_current_doc
+            ()
+        , exec ))
+      execs
+  and options =
+    QuickPickOptions.create
+      ~placeHolder:"Which executable do you want to run?"
+      ~canPickMany:false
+      ~matchOnDetail:true
+      ()
+  in
+  Window.showQuickPickItems ~choices ~options ()
 ;;
 
 let terms_tbl : (string, Terminal_sandbox.t) Hashtbl.t = Hashtbl.create (module String)

--- a/src/runnable.ml
+++ b/src/runnable.ml
@@ -53,13 +53,13 @@ let find_executables sandbox project_ctx =
     Some execs
 ;;
 
-let exec_cmd sandbox project_ctx (exec : Dune_describe.executable) args =
+let exec_cmd project_ctx (exec : Dune_describe.executable) args =
   let program, args =
     match project_ctx with
     | Dune -> "dune", [ "exec"; exec.exec_path; "--" ] @ args
     | Unknown -> "ocaml", [ "-I"; "+str"; "-I"; "+unix"; exec.mod_path ] @ args
   in
-  Sandbox.get_command sandbox program args `Exec
+  Spawn { Cmd.bin = Path.of_string program; args } |> Cmd.to_string
 ;;
 
 let executable_choice_menu (execs : Dune_describe.executable list) =
@@ -99,31 +99,26 @@ let _run_file =
     let open Promise.Syntax in
     let (_ : unit Promise.t) =
       let sandbox = Extension_instance.sandbox instance in
-      OutputChannel.show ~preserveFocus:true (Lazy.force Output.run_output_channel) ();
       let* ctx = project_context () in
       let* result = find_executables sandbox ctx in
       match result with
       | None ->
         Promise.return (show_message `Error "Output parsing of dune describe failed")
       | Some executables ->
-        let* selected = executable_choice_menu executables in
+        let+ selected = executable_choice_menu executables in
         (match selected with
-         | None -> Promise.return ()
+         | None -> ()
          | Some exec ->
-           let* _ =
+           let _ =
              match active_text_doc () with
              | Some (rel_path, doc) when String.(rel_path = exec.mod_path) ->
                TextDocument.save doc
              | _ -> Promise.return false
            in
-           let cmd = exec_cmd sandbox ctx exec [] in
-           let+ _ =
-             Cmd.run
-               ?cwd:(Sandbox.workspace_root ())
-               ~output:Output.run_output_channel
-               cmd
-           in
-           ())
+           let command = exec_cmd ctx exec [] in
+           let term = Terminal_sandbox.create ~name:"Run OCaml" sandbox in
+           Terminal_sandbox.show ~preserveFocus:true term;
+           Terminal_sandbox.send term command)
     in
     ()
   in


### PR DESCRIPTION
- Use terminal instead of an output channel (this adds support for colored compiler diagnostics)
- Dedicate a terminal per executable; if the user has already tried to run it, the previous terminal is reused. If the user closes the previously used term, we create another one.
- Always show the executable corresponding to the current viewed file in the executable dropdown if present