### PR TITLE
Update ocamlformat to 0.29.0

### DIFF
--- a/.ocamlformat
+++ b/.ocamlformat
@@ -1,4 +1,4 @@
 # upgrading the version, don't forget to update ocamlformat version in `dune-project`
-version=0.28.1
+version=0.29.0
 profile=janestreet
 parse-docstrings=true

--- a/dune-project
+++ b/dune-project
@@ -26,7 +26,7 @@
   (vscode
    (= :version))
   (ocaml
-   (= 5.5.1))
+   (= 5.5.0))
   (js_of_ocaml
    (>= 6.4))
   (gen_js_api

--- a/dune-project
+++ b/dune-project
@@ -26,7 +26,7 @@
   (vscode
    (= :version))
   (ocaml
-   (= 5.5.0))
+   (= 5.5.1))
   (js_of_ocaml
    (>= 6.4))
   (gen_js_api
@@ -47,7 +47,7 @@
    (>= v0.17.0))
   (ocamlformat
    (and
-    (= 0.28.1)
+    (= 0.29.0)
     :with-dev-setup))
   (ocaml-lsp-server :with-dev-setup)))
 
@@ -64,7 +64,7 @@
    (= 1.1.7))
   (ocamlformat
    (and
-    (= 0.28.1)
+    (= 0.29.0)
     :with-dev-setup))
   (ocaml-lsp-server :with-dev-setup)))
 
@@ -86,7 +86,7 @@
    (= :version))
   (ocamlformat
    (and
-    (= 0.28.1)
+    (= 0.29.0)
     :with-dev-setup))
   (ocaml-lsp-server :with-dev-setup)))
 
@@ -109,6 +109,6 @@
    (= :version))
   (ocamlformat
    (and
-    (= 0.28.1)
+    (= 0.29.0)
     :with-dev-setup))
   (ocaml-lsp-server :with-dev-setup)))

--- a/src/opam.ml
+++ b/src/opam.ml
@@ -124,7 +124,7 @@ module Switch_state : sig
   (** may return [None] if, for example, the switch is empty, i.e., created with
 
       {[
-        opam switch create sw -- empty
+      opam switch create sw -- empty
       ]} *)
   val of_switch : opam -> Switch.t -> t option Promise.t
 

--- a/vscode-interop.opam
+++ b/vscode-interop.opam
@@ -21,7 +21,7 @@ depends: [
   "ocaml" {>= "4.08"}
   "js_of_ocaml" {>= "6.4"}
   "gen_js_api" {= "1.1.7"}
-  "ocamlformat" {= "0.28.1" & with-dev-setup}
+  "ocamlformat" {= "0.29.0" & with-dev-setup}
   "ocaml-lsp-server" {with-dev-setup}
   "odoc" {with-doc}
 ]

--- a/vscode-node.opam
+++ b/vscode-node.opam
@@ -24,7 +24,7 @@ depends: [
   "promise_jsoo" {>= "0.4.3"}
   "jsonoo" {>= "0.3"}
   "vscode-interop" {= version}
-  "ocamlformat" {= "0.28.1" & with-dev-setup}
+  "ocamlformat" {= "0.29.0" & with-dev-setup}
   "ocaml-lsp-server" {with-dev-setup}
   "odoc" {with-doc}
 ]

--- a/vscode-ocaml-platform.opam
+++ b/vscode-ocaml-platform.opam
@@ -18,7 +18,7 @@ bug-reports: "https://github.com/ocamllabs/vscode-ocaml-platform/issues"
 depends: [
   "dune" {>= "3.20"}
   "vscode" {= version}
-  "ocaml" {= "5.5.1"}
+  "ocaml" {= "5.5.0"}
   "js_of_ocaml" {>= "6.4"}
   "gen_js_api" {= "1.1.7"}
   "base" {>= "v0.17"}

--- a/vscode-ocaml-platform.opam
+++ b/vscode-ocaml-platform.opam
@@ -18,7 +18,7 @@ bug-reports: "https://github.com/ocamllabs/vscode-ocaml-platform/issues"
 depends: [
   "dune" {>= "3.20"}
   "vscode" {= version}
-  "ocaml" {= "5.5.0"}
+  "ocaml" {= "5.5.1"}
   "js_of_ocaml" {>= "6.4"}
   "gen_js_api" {= "1.1.7"}
   "base" {>= "v0.17"}
@@ -28,7 +28,7 @@ depends: [
   "ppxlib" {>= "0.36"}
   "opam-file-format" {>= "2.1.6"}
   "sexplib" {>= "v0.17.0"}
-  "ocamlformat" {= "0.28.1" & with-dev-setup}
+  "ocamlformat" {= "0.29.0" & with-dev-setup}
   "ocaml-lsp-server" {with-dev-setup}
   "odoc" {with-doc}
 ]

--- a/vscode.opam
+++ b/vscode.opam
@@ -23,7 +23,7 @@ depends: [
   "promise_jsoo" {>= "0.4.3"}
   "jsonoo" {>= "0.3"}
   "vscode-interop" {= version}
-  "ocamlformat" {= "0.28.1" & with-dev-setup}
+  "ocamlformat" {= "0.29.0" & with-dev-setup}
   "ocaml-lsp-server" {with-dev-setup}
   "odoc" {with-doc}
 ]


### PR DESCRIPTION
## Summary

- update ocamlformat from 0.28.1 to 0.29.0
- keep the ocamlformat configuration version aligned with the development dependency

## Testing

Not run locally; validation is left to CI.