### PR TITLE
Fix portability issues in TextMate grammars

### DIFF
--- a/syntaxes/atd.json
+++ b/syntaxes/atd.json
@@ -22,7 +22,9 @@
             "1": { "name": "keyword.other.atd" },
             "2": { "name": "keyword.other.atd" }
           },
-          "endCaptures": [{ "name": "keyword.other.atd" }],
+          "endCaptures": {
+            "1": { "name": "keyword.other.atd" }
+          },
           "patterns": [{ "include": "$self" }]
         }
       ]

--- a/syntaxes/atd.json
+++ b/syntaxes/atd.json
@@ -23,7 +23,7 @@
             "2": { "name": "keyword.other.atd" }
           },
           "endCaptures": {
-            "1": { "name": "keyword.other.atd" }
+            "0": { "name": "keyword.other.atd" }
           },
           "patterns": [{ "include": "$self" }]
         }

--- a/syntaxes/cram.json
+++ b/syntaxes/cram.json
@@ -135,24 +135,36 @@
         {
           "begin": "\\[\\^?",
           "end": "\\]",
-          "beginCaptures": [{ "name": "keyword.other.regex" }],
-          "endCaptures": [{ "name": "keyword.other.regex" }],
+          "beginCaptures": {
+            "1": { "name": "keyword.other.regex" }
+          },
+          "endCaptures": {
+            "1": { "name": "keyword.other.regex" }
+          },
           "contentName": "source.regex",
           "patterns": [{ "name": "keyword.other.regex", "match": "-" }]
         },
         {
           "begin": "\\((\\?[:=!])?",
           "end": "\\)",
-          "beginCaptures": [{ "name": "keyword.other.regex" }],
-          "endCaptures": [{ "name": "keyword.other.regex" }],
+          "beginCaptures": {
+            "1": { "name": "keyword.other.regex" }
+          },
+          "endCaptures": {
+            "1": { "name": "keyword.other.regex" }
+          },
           "contentName": "source.regex",
           "patterns": [{ "include": "#regex" }]
         },
         {
           "begin": "{",
           "end": "}",
-          "beginCaptures": [{ "name": "keyword.other.regex" }],
-          "endCaptures": [{ "name": "keyword.other.regex" }],
+          "beginCaptures": {
+            "1": { "name": "keyword.other.regex" }
+          },
+          "endCaptures": {
+            "1": { "name": "keyword.other.regex" }
+          },
           "contentName": "source.regex",
           "patterns": [
             {

--- a/syntaxes/cram.json
+++ b/syntaxes/cram.json
@@ -136,10 +136,10 @@
           "begin": "\\[\\^?",
           "end": "\\]",
           "beginCaptures": {
-            "1": { "name": "keyword.other.regex" }
+            "0": { "name": "keyword.other.regex" }
           },
           "endCaptures": {
-            "1": { "name": "keyword.other.regex" }
+            "0": { "name": "keyword.other.regex" }
           },
           "contentName": "source.regex",
           "patterns": [{ "name": "keyword.other.regex", "match": "-" }]
@@ -148,10 +148,10 @@
           "begin": "\\((\\?[:=!])?",
           "end": "\\)",
           "beginCaptures": {
-            "1": { "name": "keyword.other.regex" }
+            "0": { "name": "keyword.other.regex" }
           },
           "endCaptures": {
-            "1": { "name": "keyword.other.regex" }
+            "0": { "name": "keyword.other.regex" }
           },
           "contentName": "source.regex",
           "patterns": [{ "include": "#regex" }]
@@ -160,10 +160,10 @@
           "begin": "{",
           "end": "}",
           "beginCaptures": {
-            "1": { "name": "keyword.other.regex" }
+            "0": { "name": "keyword.other.regex" }
           },
           "endCaptures": {
-            "1": { "name": "keyword.other.regex" }
+            "0": { "name": "keyword.other.regex" }
           },
           "contentName": "source.regex",
           "patterns": [

--- a/syntaxes/dune.json
+++ b/syntaxes/dune.json
@@ -3905,16 +3905,12 @@
           "comment": "variable",
           "begin": "%\\{",
           "end": "\\}",
-          "beginCaptures": [
-            {
-              "name": "keyword.operator.dune"
-            }
-          ],
-          "endCaptures": [
-            {
-              "name": "keyword.operator.dune"
-            }
-          ],
+          "beginCaptures": {
+            "1": { "name": "keyword.operator.dune" }
+          },
+          "endCaptures": {
+            "1": { "name": "keyword.operator.dune" }
+          },
           "patterns": [
             {
               "include": "#variables"
@@ -3965,125 +3961,119 @@
             }
           ]
         }
-      ],
-      "repository": {
-        "escape-characters": {
-          "patterns": [
-            {
-              "comment": "escaped newline",
-              "name": "constant.character.escape.dune",
-              "match": "\\\\$"
-            },
-            {
-              "comment": "escaped character",
-              "name": "constant.character.escape.dune",
-              "match": "\\\\(n|r|b|t|\\\\|\")"
-            },
-            {
-              "comment": "character from decimal ASCII code",
-              "name": "constant.character.escape.dune",
-              "match": "\\\\[[:digit:]]{3}"
-            },
-            {
-              "comment": "character from hexadecimal ASCII code",
-              "name": "constant.character.escape.dune",
-              "match": "\\\\x[[:xdigit:]]{2}"
-            },
-            {
-              "comment": "escaped variable",
-              "begin": "(\\%\\{)",
-              "end": "(\\})",
-              "beginCaptures": [
-                {
-                  "name": "constant.character.escape.dune"
-                }
-              ],
-              "endCaptures": [
-                {
-                  "name": "constant.character.escape.dune"
-                }
-              ],
-              "patterns": [
-                {
-                  "include": "#variables"
-                }
-              ]
-            }
-          ]
+      ]
+    },
+    "escape-characters": {
+      "patterns": [
+        {
+          "comment": "escaped newline",
+          "name": "constant.character.escape.dune",
+          "match": "\\\\$"
         },
-        "variables": {
+        {
+          "comment": "escaped character",
+          "name": "constant.character.escape.dune",
+          "match": "\\\\(n|r|b|t|\\\\|\")"
+        },
+        {
+          "comment": "character from decimal ASCII code",
+          "name": "constant.character.escape.dune",
+          "match": "\\\\[[:digit:]]{3}"
+        },
+        {
+          "comment": "character from hexadecimal ASCII code",
+          "name": "constant.character.escape.dune",
+          "match": "\\\\x[[:xdigit:]]{2}"
+        },
+        {
+          "comment": "escaped variable",
+          "begin": "(\\%\\{)",
+          "end": "(\\})",
+          "beginCaptures": {
+            "1": { "name": "constant.character.escape.dune" }
+          },
+          "endCaptures": {
+            "1": { "name": "constant.character.escape.dune" }
+          },
           "patterns": [
             {
-              "name": "keyword.operator.variable.dune",
-              "match": ":"
-            },
-            {
-              "name": "keyword.operator.variable.dune",
-              "match": "="
-            },
-            {
-              "name": "constant.language.variable.action.dune",
-              "match": "\\^"
-            },
-            {
-              "name": "constant.language.variable.dune",
-              "match": "(?<=\\{)(project_root|workspace_root|profile|context_name)(?=\\})"
-            },
-            {
-              "name": "constant.language.variable.dune",
-              "match": "(?<=\\{)(CC|CXX)(?=\\})"
-            },
-            {
-              "name": "constant.language.variable.dune",
-              "match": "(?<=\\{)(ocaml_bin|ocaml|ocamlc|ocamlopt|ocaml_version|ocaml_where)(?=\\})"
-            },
-            {
-              "name": "constant.language.variable.dune",
-              "match": "(?<=\\{)(ext_obj|ext_asm|ext_lib|ext_dll|ext_exe|ext_plugin)(?=\\})"
-            },
-            {
-              "name": "constant.language.variable.dune",
-              "match": "(?<=\\{)(arch_sixtyfour|architecture|os_type|model|system)(?=\\})"
-            },
-            {
-              "name": "constant.language.variable.action.dune",
-              "match": "(?<=\\{)(target|targets|deps)(?=\\})"
-            },
-            {
-              "name": "constant.language.variable.dune",
-              "match": "(?<=\\{)(null)(?=\\})"
-            },
-            {
-              "name": "constant.language.variable.dune",
-              "match": "(?<=\\{)(ignoring_promoted_rule)(?=\\})"
-            },
-            {
-              "name": "constant.language.variable.dune",
-              "match": "(?<=\\{)(ocaml-config)(?=:)"
-            },
-            {
-              "name": "constant.language.variable.dune",
-              "match": "(?<=\\{)(env)(?=:)"
-            },
-            {
-              "name": "constant.language.variable.dune",
-              "match": "(?<=\\{)(version)(?=:)"
-            },
-            {
-              "name": "constant.language.variable.dune",
-              "match": "(?<=\\{)(cmo|cmi|cma|cmx|cmxa)(?=:)"
-            },
-            {
-              "name": "constant.language.variable.action.dune",
-              "match": "(?<=\\{)(dep|exe|bin|bin-available|lib|lib-private|libexec|libexec-private|lib-available)(?=:)"
-            },
-            {
-              "name": "constant.language.variable.action.dune",
-              "match": "(?<=\\{)(read|read-lines|read-strings)(?=:)"
+              "include": "#variables"
             }
           ]
         }
-      }
+      ]
+    },
+    "variables": {
+      "patterns": [
+        {
+          "name": "keyword.operator.variable.dune",
+          "match": ":"
+        },
+        {
+          "name": "keyword.operator.variable.dune",
+          "match": "="
+        },
+        {
+          "name": "constant.language.variable.action.dune",
+          "match": "\\^"
+        },
+        {
+          "name": "constant.language.variable.dune",
+          "match": "(?<=\\{)(project_root|workspace_root|profile|context_name)(?=\\})"
+        },
+        {
+          "name": "constant.language.variable.dune",
+          "match": "(?<=\\{)(CC|CXX)(?=\\})"
+        },
+        {
+          "name": "constant.language.variable.dune",
+          "match": "(?<=\\{)(ocaml_bin|ocaml|ocamlc|ocamlopt|ocaml_version|ocaml_where)(?=\\})"
+        },
+        {
+          "name": "constant.language.variable.dune",
+          "match": "(?<=\\{)(ext_obj|ext_asm|ext_lib|ext_dll|ext_exe|ext_plugin)(?=\\})"
+        },
+        {
+          "name": "constant.language.variable.dune",
+          "match": "(?<=\\{)(arch_sixtyfour|architecture|os_type|model|system)(?=\\})"
+        },
+        {
+          "name": "constant.language.variable.action.dune",
+          "match": "(?<=\\{)(target|targets|deps)(?=\\})"
+        },
+        {
+          "name": "constant.language.variable.dune",
+          "match": "(?<=\\{)(null)(?=\\})"
+        },
+        {
+          "name": "constant.language.variable.dune",
+          "match": "(?<=\\{)(ignoring_promoted_rule)(?=\\})"
+        },
+        {
+          "name": "constant.language.variable.dune",
+          "match": "(?<=\\{)(ocaml-config)(?=:)"
+        },
+        {
+          "name": "constant.language.variable.dune",
+          "match": "(?<=\\{)(env)(?=:)"
+        },
+        {
+          "name": "constant.language.variable.dune",
+          "match": "(?<=\\{)(version)(?=:)"
+        },
+        {
+          "name": "constant.language.variable.dune",
+          "match": "(?<=\\{)(cmo|cmi|cma|cmx|cmxa)(?=:)"
+        },
+        {
+          "name": "constant.language.variable.action.dune",
+          "match": "(?<=\\{)(dep|exe|bin|bin-available|lib|lib-private|libexec|libexec-private|lib-available)(?=:)"
+        },
+        {
+          "name": "constant.language.variable.action.dune",
+          "match": "(?<=\\{)(read|read-lines|read-strings)(?=:)"
+        }
+      ]
     }
   }
 }

--- a/syntaxes/dune.json
+++ b/syntaxes/dune.json
@@ -3906,10 +3906,10 @@
           "begin": "%\\{",
           "end": "\\}",
           "beginCaptures": {
-            "1": { "name": "keyword.operator.dune" }
+            "0": { "name": "keyword.operator.dune" }
           },
           "endCaptures": {
-            "1": { "name": "keyword.operator.dune" }
+            "0": { "name": "keyword.operator.dune" }
           },
           "patterns": [
             {
@@ -3990,10 +3990,10 @@
           "begin": "(\\%\\{)",
           "end": "(\\})",
           "beginCaptures": {
-            "1": { "name": "constant.character.escape.dune" }
+            "0": { "name": "constant.character.escape.dune" }
           },
           "endCaptures": {
-            "1": { "name": "constant.character.escape.dune" }
+            "0": { "name": "constant.character.escape.dune" }
           },
           "patterns": [
             {

--- a/syntaxes/menhir.json
+++ b/syntaxes/menhir.json
@@ -13,9 +13,13 @@
     {
       "comment": "sequence of rules",
       "begin": "%%",
-      "beginCaptures": [{ "name": "keyword.other.menhir" }],
+      "beginCaptures": {
+        "1": { "name": "keyword.other.menhir" }
+      },
       "end": "%%",
-      "endCaptures": [{ "name": "keyword.other.menhir" }],
+      "endCaptures": {
+        "1": { "name": "keyword.other.menhir" }
+      },
       "patterns": [{ "include": "#comments" }, { "include": "#rules" }]
     },
     { "include": "source.ocaml" }
@@ -44,15 +48,21 @@
         {
           "comment": "ocaml header",
           "begin": "%{",
-          "beginCaptures": [{ "name": "keyword.other.menhir" }],
+          "beginCaptures": {
+            "1": { "name": "keyword.other.menhir" }
+          },
           "end": "%}",
-          "endCaptures": [{ "name": "keyword.other.menhir" }],
+          "endCaptures": {
+            "1": { "name": "keyword.other.menhir" }
+          },
           "patterns": [{ "include": "source.ocaml" }]
         },
         {
           "comment": "token declaration",
           "begin": "%token\\b",
-          "beginCaptures": [{ "name": "keyword.other.menhir" }],
+          "beginCaptures": {
+            "1": { "name": "keyword.other.menhir" }
+          },
           "end": "(?=%)",
           "patterns": [
             { "include": "#type-annotation" },
@@ -65,7 +75,9 @@
         {
           "comment": "associativity declaration",
           "begin": "%(?:nonassoc|left|right)\\b",
-          "beginCaptures": [{ "name": "keyword.other.menhir" }],
+          "beginCaptures": {
+            "1": { "name": "keyword.other.menhir" }
+          },
           "end": "(?=%)",
           "patterns": [
             { "include": "#token-name" },
@@ -78,7 +90,9 @@
         {
           "comment": "type/start/on_error_reduce declaration",
           "begin": "%(?:type|start|on_error_reduce)\\b",
-          "beginCaptures": [{ "name": "keyword.other.menhir" }],
+          "beginCaptures": {
+            "1": { "name": "keyword.other.menhir" }
+          },
           "end": "(?=%)",
           "patterns": [
             { "include": "#type-annotation" },
@@ -96,7 +110,9 @@
         {
           "comment": "attribute declaration",
           "begin": "%(?:attribute\\b|(?=\\[))",
-          "beginCaptures": [{ "name": "keyword.other.menhir" }],
+          "beginCaptures": {
+            "1": { "name": "keyword.other.menhir" }
+          },
           "end": "(?=%)",
           "patterns": [
             { "include": "source.ocaml#attributes" },
@@ -113,8 +129,12 @@
           "comment": "ocaml type annotation for token",
           "begin": "<",
           "end": ">",
-          "beginCaptures": [{ "name": "keyword.other.menhir" }],
-          "endCaptures": [{ "name": "keyword.other.menhir" }],
+          "beginCaptures": {
+            "1": { "name": "keyword.other.menhir" }
+          },
+          "endCaptures": {
+            "1": { "name": "keyword.other.menhir" }
+          },
           "patterns": [{ "include": "source.ocaml" }]
         }
       }
@@ -167,7 +187,9 @@
         {
           "comment": "production",
           "begin": "[:|]",
-          "beginCaptures": [{ "name": "keyword.other.menhir" }],
+          "beginCaptures": {
+            "1": { "name": "keyword.other.menhir" }
+          },
           "end": "(?=[{<|]|let\\b|[[:lower:]_][[:word:]]*[[:space:]]*(?:\\([^)]+\\)[[:space:]]*)?:|%(?!prec\\b))",
           "patterns": [
             { "include": "#comments" },
@@ -214,7 +236,9 @@
         {
           "comment": "production",
           "begin": "[:|]",
-          "beginCaptures": [{ "name": "keyword.other.menhir" }],
+          "beginCaptures": {
+            "1": { "name": "keyword.other.menhir" }
+          },
           "end": "(?=[{<|]|let\\b|[[:lower:]_][[:word:]]*[[:space:]]*(?:\\([^)]+\\)[[:space:]]*)?:|%(?!prec\\b))",
           "patterns": [
             { "include": "#comments" },
@@ -238,9 +262,13 @@
       "comment": "ocaml semantic action",
       "contentName": "source.embedded-action.menhir",
       "begin": "{",
-      "beginCaptures": [{ "name": "keyword.other.menhir" }],
+      "beginCaptures": {
+        "1": { "name": "keyword.other.menhir" }
+      },
       "end": "}",
-      "endCaptures": [{ "name": "keyword.other.menhir" }],
+      "endCaptures": {
+        "1": { "name": "keyword.other.menhir" }
+      },
       "patterns": [{ "include": "source.ocaml" }]
     },
     "new-actions": {
@@ -249,9 +277,13 @@
         {
           "comment": "point-free ocaml semantic action",
           "begin": "<",
-          "beginCaptures": [{ "name": "keyword.other.menhir" }],
+          "beginCaptures": {
+            "1": { "name": "keyword.other.menhir" }
+          },
           "end": ">",
-          "endCaptures": [{ "name": "keyword.other.menhir" }],
+          "endCaptures": {
+            "1": { "name": "keyword.other.menhir" }
+          },
           "patterns": [{ "include": "source.ocaml" }]
         }
       ]
@@ -279,7 +311,7 @@
         },
         {
           "comment": "destructured semantic value capture",
-          "begin": "(?<![[:word:]][[:space:]]*)\\(",
+          "begin": "(?<![[:word:]])[[:space:]]*\\(",
           "end": "\\)[[:space:]]*(=)",
           "endCaptures": {
             "1": { "name": "keyword.other.menhir" }

--- a/syntaxes/menhir.json
+++ b/syntaxes/menhir.json
@@ -14,11 +14,11 @@
       "comment": "sequence of rules",
       "begin": "%%",
       "beginCaptures": {
-        "1": { "name": "keyword.other.menhir" }
+        "0": { "name": "keyword.other.menhir" }
       },
       "end": "%%",
       "endCaptures": {
-        "1": { "name": "keyword.other.menhir" }
+        "0": { "name": "keyword.other.menhir" }
       },
       "patterns": [{ "include": "#comments" }, { "include": "#rules" }]
     },
@@ -49,11 +49,11 @@
           "comment": "ocaml header",
           "begin": "%{",
           "beginCaptures": {
-            "1": { "name": "keyword.other.menhir" }
+            "0": { "name": "keyword.other.menhir" }
           },
           "end": "%}",
           "endCaptures": {
-            "1": { "name": "keyword.other.menhir" }
+            "0": { "name": "keyword.other.menhir" }
           },
           "patterns": [{ "include": "source.ocaml" }]
         },
@@ -61,7 +61,7 @@
           "comment": "token declaration",
           "begin": "%token\\b",
           "beginCaptures": {
-            "1": { "name": "keyword.other.menhir" }
+            "0": { "name": "keyword.other.menhir" }
           },
           "end": "(?=%)",
           "patterns": [
@@ -76,7 +76,7 @@
           "comment": "associativity declaration",
           "begin": "%(?:nonassoc|left|right)\\b",
           "beginCaptures": {
-            "1": { "name": "keyword.other.menhir" }
+            "0": { "name": "keyword.other.menhir" }
           },
           "end": "(?=%)",
           "patterns": [
@@ -91,7 +91,7 @@
           "comment": "type/start/on_error_reduce declaration",
           "begin": "%(?:type|start|on_error_reduce)\\b",
           "beginCaptures": {
-            "1": { "name": "keyword.other.menhir" }
+            "0": { "name": "keyword.other.menhir" }
           },
           "end": "(?=%)",
           "patterns": [
@@ -111,7 +111,7 @@
           "comment": "attribute declaration",
           "begin": "%(?:attribute\\b|(?=\\[))",
           "beginCaptures": {
-            "1": { "name": "keyword.other.menhir" }
+            "0": { "name": "keyword.other.menhir" }
           },
           "end": "(?=%)",
           "patterns": [
@@ -130,10 +130,10 @@
           "begin": "<",
           "end": ">",
           "beginCaptures": {
-            "1": { "name": "keyword.other.menhir" }
+            "0": { "name": "keyword.other.menhir" }
           },
           "endCaptures": {
-            "1": { "name": "keyword.other.menhir" }
+            "0": { "name": "keyword.other.menhir" }
           },
           "patterns": [{ "include": "source.ocaml" }]
         }
@@ -188,7 +188,7 @@
           "comment": "production",
           "begin": "[:|]",
           "beginCaptures": {
-            "1": { "name": "keyword.other.menhir" }
+            "0": { "name": "keyword.other.menhir" }
           },
           "end": "(?=[{<|]|let\\b|[[:lower:]_][[:word:]]*[[:space:]]*(?:\\([^)]+\\)[[:space:]]*)?:|%(?!prec\\b))",
           "patterns": [
@@ -237,7 +237,7 @@
           "comment": "production",
           "begin": "[:|]",
           "beginCaptures": {
-            "1": { "name": "keyword.other.menhir" }
+            "0": { "name": "keyword.other.menhir" }
           },
           "end": "(?=[{<|]|let\\b|[[:lower:]_][[:word:]]*[[:space:]]*(?:\\([^)]+\\)[[:space:]]*)?:|%(?!prec\\b))",
           "patterns": [
@@ -263,11 +263,11 @@
       "contentName": "source.embedded-action.menhir",
       "begin": "{",
       "beginCaptures": {
-        "1": { "name": "keyword.other.menhir" }
+        "0": { "name": "keyword.other.menhir" }
       },
       "end": "}",
       "endCaptures": {
-        "1": { "name": "keyword.other.menhir" }
+        "0": { "name": "keyword.other.menhir" }
       },
       "patterns": [{ "include": "source.ocaml" }]
     },
@@ -278,11 +278,11 @@
           "comment": "point-free ocaml semantic action",
           "begin": "<",
           "beginCaptures": {
-            "1": { "name": "keyword.other.menhir" }
+            "0": { "name": "keyword.other.menhir" }
           },
           "end": ">",
           "endCaptures": {
-            "1": { "name": "keyword.other.menhir" }
+            "0": { "name": "keyword.other.menhir" }
           },
           "patterns": [{ "include": "source.ocaml" }]
         }

--- a/syntaxes/mlx.json
+++ b/syntaxes/mlx.json
@@ -290,16 +290,12 @@
           "comment": "Cinaps comment",
           "begin": "\\(\\*\\$",
           "end": "\\*\\)",
-          "beginCaptures": [
-            {
-              "name": "comment.cinaps.ocaml"
-            }
-          ],
-          "endCaptures": [
-            {
-              "name": "comment.cinaps.ocaml"
-            }
-          ],
+          "beginCaptures": {
+            "1": { "name": "comment.cinaps.ocaml" }
+          },
+          "endCaptures": {
+            "1": { "name": "comment.cinaps.ocaml" }
+          },
           "patterns": [{ "include": "$self" }]
         },
         {
@@ -517,31 +513,23 @@
         {
           "begin": "\\b(sig)\\b",
           "end": "\\b(end)\\b",
-          "beginCaptures": [
-            {
-              "name": "keyword.other.ocaml"
-            }
-          ],
-          "endCaptures": [
-            {
-              "name": "keyword.other.ocaml"
-            }
-          ],
+          "beginCaptures": {
+            "1": { "name": "keyword.other.ocaml" }
+          },
+          "endCaptures": {
+            "1": { "name": "keyword.other.ocaml" }
+          },
           "patterns": [{ "include": "source.ocaml.interface" }]
         },
         {
           "begin": "\\b(struct)\\b",
           "end": "\\b(end)\\b",
-          "beginCaptures": [
-            {
-              "name": "keyword.other.ocaml"
-            }
-          ],
-          "endCaptures": [
-            {
-              "name": "keyword.other.ocaml"
-            }
-          ],
+          "beginCaptures": {
+            "1": { "name": "keyword.other.ocaml" }
+          },
+          "endCaptures": {
+            "1": { "name": "keyword.other.ocaml" }
+          },
           "patterns": [{ "include": "$self" }]
         }
       ]

--- a/syntaxes/mlx.json
+++ b/syntaxes/mlx.json
@@ -291,10 +291,10 @@
           "begin": "\\(\\*\\$",
           "end": "\\*\\)",
           "beginCaptures": {
-            "1": { "name": "comment.cinaps.ocaml" }
+            "0": { "name": "comment.cinaps.ocaml" }
           },
           "endCaptures": {
-            "1": { "name": "comment.cinaps.ocaml" }
+            "0": { "name": "comment.cinaps.ocaml" }
           },
           "patterns": [{ "include": "$self" }]
         },
@@ -514,10 +514,10 @@
           "begin": "\\b(sig)\\b",
           "end": "\\b(end)\\b",
           "beginCaptures": {
-            "1": { "name": "keyword.other.ocaml" }
+            "0": { "name": "keyword.other.ocaml" }
           },
           "endCaptures": {
-            "1": { "name": "keyword.other.ocaml" }
+            "0": { "name": "keyword.other.ocaml" }
           },
           "patterns": [{ "include": "source.ocaml.interface" }]
         },
@@ -525,10 +525,10 @@
           "begin": "\\b(struct)\\b",
           "end": "\\b(end)\\b",
           "beginCaptures": {
-            "1": { "name": "keyword.other.ocaml" }
+            "0": { "name": "keyword.other.ocaml" }
           },
           "endCaptures": {
-            "1": { "name": "keyword.other.ocaml" }
+            "0": { "name": "keyword.other.ocaml" }
           },
           "patterns": [{ "include": "$self" }]
         }

--- a/syntaxes/ocaml.json
+++ b/syntaxes/ocaml.json
@@ -131,8 +131,12 @@
           "comment": "Cinaps comment",
           "begin": "\\(\\*\\$",
           "end": "\\*\\)",
-          "beginCaptures": [{ "name": "comment.cinaps.ocaml" }],
-          "endCaptures": [{ "name": "comment.cinaps.ocaml" }],
+          "beginCaptures": {
+            "1": { "name": "comment.cinaps.ocaml" }
+          },
+          "endCaptures": {
+            "1": { "name": "comment.cinaps.ocaml" }
+          },
           "patterns": [{ "include": "$self" }]
         },
         {
@@ -321,15 +325,23 @@
         {
           "begin": "\\b(sig)\\b",
           "end": "\\b(end)\\b",
-          "beginCaptures": [{ "name": "keyword.other.ocaml" }],
-          "endCaptures": [{ "name": "keyword.other.ocaml" }],
+          "beginCaptures": {
+            "1": { "name": "keyword.other.ocaml" }
+          },
+          "endCaptures": {
+            "1": { "name": "keyword.other.ocaml" }
+          },
           "patterns": [{ "include": "source.ocaml.interface" }]
         },
         {
           "begin": "\\b(struct)\\b",
           "end": "\\b(end)\\b",
-          "beginCaptures": [{ "name": "keyword.other.ocaml" }],
-          "endCaptures": [{ "name": "keyword.other.ocaml" }],
+          "beginCaptures": {
+            "1": {"name": "keyword.other.ocaml" }
+          },
+          "endCaptures": {
+            "1": { "name": "keyword.other.ocaml" }
+          },
           "patterns": [{ "include": "$self" }]
         }
       ]

--- a/syntaxes/ocaml.json
+++ b/syntaxes/ocaml.json
@@ -337,7 +337,7 @@
           "begin": "\\b(struct)\\b",
           "end": "\\b(end)\\b",
           "beginCaptures": {
-            "1": {"name": "keyword.other.ocaml" }
+            "1": { "name": "keyword.other.ocaml" }
           },
           "endCaptures": {
             "1": { "name": "keyword.other.ocaml" }

--- a/syntaxes/ocaml.json
+++ b/syntaxes/ocaml.json
@@ -132,10 +132,10 @@
           "begin": "\\(\\*\\$",
           "end": "\\*\\)",
           "beginCaptures": {
-            "1": { "name": "comment.cinaps.ocaml" }
+            "0": { "name": "comment.cinaps.ocaml" }
           },
           "endCaptures": {
-            "1": { "name": "comment.cinaps.ocaml" }
+            "0": { "name": "comment.cinaps.ocaml" }
           },
           "patterns": [{ "include": "$self" }]
         },
@@ -326,10 +326,10 @@
           "begin": "\\b(sig)\\b",
           "end": "\\b(end)\\b",
           "beginCaptures": {
-            "1": { "name": "keyword.other.ocaml" }
+            "0": { "name": "keyword.other.ocaml" }
           },
           "endCaptures": {
-            "1": { "name": "keyword.other.ocaml" }
+            "0": { "name": "keyword.other.ocaml" }
           },
           "patterns": [{ "include": "source.ocaml.interface" }]
         },
@@ -337,10 +337,10 @@
           "begin": "\\b(struct)\\b",
           "end": "\\b(end)\\b",
           "beginCaptures": {
-            "1": { "name": "keyword.other.ocaml" }
+            "0": { "name": "keyword.other.ocaml" }
           },
           "endCaptures": {
-            "1": { "name": "keyword.other.ocaml" }
+            "0": { "name": "keyword.other.ocaml" }
           },
           "patterns": [{ "include": "$self" }]
         }

--- a/syntaxes/ocamlbuild.json
+++ b/syntaxes/ocamlbuild.json
@@ -31,8 +31,12 @@
         {
           "begin": "<",
           "end": ">",
-          "beginCaptures": [{ "name": "keyword.operator.ocamlbuild" }],
-          "endCaptures": [{ "name": "keyword.operator.ocamlbuild" }],
+          "beginCaptures": {
+            "1": { "name": "keyword.operator.ocamlbuild" }
+          },
+          "endCaptures": {
+            "1": { "name": "keyword.operator.ocamlbuild" }
+          },
           "name": "string.quoted.double.ocamlbuild",
           "patterns": [{ "include": "#patterns" }]
         },
@@ -65,8 +69,12 @@
         {
           "begin": "{",
           "end": "}",
-          "beginCaptures": [{ "name": "keyword.operator.ocamlbuild" }],
-          "endCaptures": [{ "name": "keyword.operator.ocamlbuild" }],
+          "beginCaptures": {
+            "1": { "name": "keyword.operator.ocamlbuild" }
+          },
+          "endCaptures": {
+            "1": { "name": "keyword.operator.ocamlbuild" }
+          },
           "patterns": [
             { "name": "keyword.operator.ocamlbuild", "match": "," },
             { "include": "#patterns" }
@@ -75,8 +83,12 @@
         {
           "begin": "\\[\\^?",
           "end": "\\]",
-          "beginCaptures": [{ "name": "keyword.operator.ocamlbuild" }],
-          "endCaptures": [{ "name": "keyword.operator.ocamlbuild" }]
+          "beginCaptures": {
+            "1": { "name": "keyword.operator.ocamlbuild" }
+          },
+          "endCaptures": {
+            "1": { "name": "keyword.operator.ocamlbuild" }
+          }
         }
       ]
     },

--- a/syntaxes/ocamlbuild.json
+++ b/syntaxes/ocamlbuild.json
@@ -32,10 +32,10 @@
           "begin": "<",
           "end": ">",
           "beginCaptures": {
-            "1": { "name": "keyword.operator.ocamlbuild" }
+            "0": { "name": "keyword.operator.ocamlbuild" }
           },
           "endCaptures": {
-            "1": { "name": "keyword.operator.ocamlbuild" }
+            "0": { "name": "keyword.operator.ocamlbuild" }
           },
           "name": "string.quoted.double.ocamlbuild",
           "patterns": [{ "include": "#patterns" }]
@@ -70,10 +70,10 @@
           "begin": "{",
           "end": "}",
           "beginCaptures": {
-            "1": { "name": "keyword.operator.ocamlbuild" }
+            "0": { "name": "keyword.operator.ocamlbuild" }
           },
           "endCaptures": {
-            "1": { "name": "keyword.operator.ocamlbuild" }
+            "0": { "name": "keyword.operator.ocamlbuild" }
           },
           "patterns": [
             { "name": "keyword.operator.ocamlbuild", "match": "," },
@@ -84,10 +84,10 @@
           "begin": "\\[\\^?",
           "end": "\\]",
           "beginCaptures": {
-            "1": { "name": "keyword.operator.ocamlbuild" }
+            "0": { "name": "keyword.operator.ocamlbuild" }
           },
           "endCaptures": {
-            "1": { "name": "keyword.operator.ocamlbuild" }
+            "0": { "name": "keyword.operator.ocamlbuild" }
           }
         }
       ]

--- a/syntaxes/ocamllex.json
+++ b/syntaxes/ocamllex.json
@@ -67,9 +67,13 @@
         {
           "comment": "embedded ocaml source",
           "begin": "{",
-          "beginCaptures": [{ "name": "keyword.other.ocamllex" }],
+          "beginCaptures": {
+            "1": { "name": "keyword.other.ocamllex" }
+          },
           "end": "}",
-          "endCaptures": [{ "name": "keyword.other.ocamllex" }],
+          "endCaptures": {
+            "1": { "name": "keyword.other.ocamllex" }
+          },
           "patterns": [{ "include": "source.ocaml" }]
         }
       ]

--- a/syntaxes/ocamllex.json
+++ b/syntaxes/ocamllex.json
@@ -68,11 +68,11 @@
           "comment": "embedded ocaml source",
           "begin": "{",
           "beginCaptures": {
-            "1": { "name": "keyword.other.ocamllex" }
+            "0": { "name": "keyword.other.ocamllex" }
           },
           "end": "}",
           "endCaptures": {
-            "1": { "name": "keyword.other.ocamllex" }
+            "0": { "name": "keyword.other.ocamllex" }
           },
           "patterns": [{ "include": "source.ocaml" }]
         }


### PR DESCRIPTION
This pull-request fixes several structural issues with this extension's grammars that affect their portability to other TextMate-compatible highlighting engines… specifically, GitHub's [own](https://github.com/github-linguist/linguist/blob/main/CONTRIBUTING.md#fixing-syntax-highlighting) syntax highlighting.

The site currently uses [`textmate/ocaml.tmbundle`](https://github.com/textmate/ocaml.tmbundle) for highlighting OCaml syntax (and that repository hasn't been updated in 11 years), so I plan on replacing it with yours (which is clearly actively-maintained). However, some non-portable syntax needs to be fixed first (and don't worry, it won't have any user-facing changes).